### PR TITLE
Improve share list speed using lazy='subquery'

### DIFF
--- a/manila/db/sqlalchemy/models.py
+++ b/manila/db/sqlalchemy/models.py
@@ -318,7 +318,7 @@ class Share(BASE, ManilaBase):
     task_state = Column(String(255))
     instances = orm.relationship(
         "ShareInstance",
-        lazy='immediate',
+        lazy='subquery',
         primaryjoin=(
             'and_('
             'Share.id == ShareInstance.share_id, '
@@ -388,7 +388,7 @@ class ShareInstance(BASE, ManilaBase):
                                   nullable=True)
     _availability_zone = orm.relationship(
         "AvailabilityZone",
-        lazy='immediate',
+        lazy='subquery',
         foreign_keys=availability_zone_id,
         primaryjoin=(
             'and_('
@@ -400,7 +400,7 @@ class ShareInstance(BASE, ManilaBase):
 
     export_locations = orm.relationship(
         "ShareInstanceExportLocations",
-        lazy='immediate',
+        lazy='subquery',
         primaryjoin=(
             'and_('
             'ShareInstance.id == '
@@ -414,7 +414,7 @@ class ShareInstance(BASE, ManilaBase):
                              nullable=True)
     share_type = orm.relationship(
         "ShareTypes",
-        lazy='immediate',
+        lazy='subquery',
         foreign_keys=share_type_id,
         primaryjoin='and_('
                     'ShareInstance.share_type_id == ShareTypes.id, '


### PR DESCRIPTION
lazy='immediate' leads to each relationship being collected when
it is accessed. This results in at least three extra queries when
we query for all share details. lazy='subquery' collects all data
when the query is exected. In this commit we only changed code for
improving the share list with details ("manila list") speed.

This is joint work together with Johannes Kulik.