### PR TITLE
[stein] Make coverage non-voting and fix use of rpc_backend

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -29,6 +29,10 @@
         - manila-rally-multibackend-no-ss:
             voting: false
         - openstack-tox-lower-constraints
+        - openstack-tox-pylint:
+            voting: false
+        - openstack-tox-cover:
+            voting: false
     gate:
       jobs:
         - manila-tox-genconfig

--- a/manila/tests/api/v1/test_share_snapshots.py
+++ b/manila/tests/api/v1/test_share_snapshots.py
@@ -354,7 +354,7 @@ class ShareSnapshotAdminActionsAPITest(test.TestCase):
     def setUp(self):
         super(ShareSnapshotAdminActionsAPITest, self).setUp()
         self.controller = share_snapshots.ShareSnapshotsController()
-        self.flags(rpc_backend='manila.openstack.common.rpc.impl_fake')
+        self.flags(transport_url='rabbit://fake:fake@mqhost:5672')
         self.admin_context = context.RequestContext('admin', 'fake', True)
         self.member_context = context.RequestContext('fake', 'fake')
 

--- a/manila/tests/api/v1/test_shares.py
+++ b/manila/tests/api/v1/test_shares.py
@@ -1002,7 +1002,7 @@ class ShareAdminActionsAPITest(test.TestCase):
     def setUp(self):
         super(ShareAdminActionsAPITest, self).setUp()
         CONF.set_default("default_share_type", None)
-        self.flags(rpc_backend='manila.openstack.common.rpc.impl_fake')
+        self.flags(transport_url='rabbit://fake:fake@mqhost:5672')
         self.share_api = share_api.API()
         self.admin_context = context.RequestContext('admin', 'fake', True)
         self.member_context = context.RequestContext('fake', 'fake')

--- a/manila/tests/api/v2/test_share_group_snapshots.py
+++ b/manila/tests/api/v2/test_share_group_snapshots.py
@@ -53,7 +53,7 @@ class ShareGroupSnapshotAPITest(test.TestCase):
         self.context = self.request.environ['manila.context']
         self.admin_context = context.RequestContext('admin', 'fake', True)
         self.member_context = context.RequestContext('fake', 'fake')
-        self.flags(rpc_backend='manila.openstack.common.rpc.impl_fake')
+        self.flags(transport_url='rabbit://fake:fake@mqhost:5672')
 
     def _get_fake_share_group_snapshot(self, **values):
         snap = {

--- a/manila/tests/api/v2/test_share_groups.py
+++ b/manila/tests/api/v2/test_share_groups.py
@@ -56,7 +56,7 @@ class ShareGroupAPITest(test.TestCase):
         self.api_version = '2.34'
         self.request = fakes.HTTPRequest.blank(
             '/share-groups', version=self.api_version, experimental=True)
-        self.flags(rpc_backend='manila.openstack.common.rpc.impl_fake')
+        self.flags(transport_url='rabbit://fake:fake@mqhost:5672')
         self.admin_context = context.RequestContext('admin', 'fake', True)
         self.member_context = context.RequestContext('fake', 'fake')
         self.mock_policy_check = self.mock_object(

--- a/manila/tests/api/v2/test_share_snapshots.py
+++ b/manila/tests/api/v2/test_share_snapshots.py
@@ -581,7 +581,7 @@ class ShareSnapshotAdminActionsAPITest(test.TestCase):
     def setUp(self):
         super(ShareSnapshotAdminActionsAPITest, self).setUp()
         self.controller = share_snapshots.ShareSnapshotsController()
-        self.flags(rpc_backend='manila.openstack.common.rpc.impl_fake')
+        self.flags(transport_url='rabbit://fake:fake@mqhost:5672')
         self.admin_context = context.RequestContext('admin', 'fake', True)
         self.member_context = context.RequestContext('fake', 'fake')
 

--- a/manila/tests/api/v2/test_shares.py
+++ b/manila/tests/api/v2/test_shares.py
@@ -2341,7 +2341,7 @@ class ShareAdminActionsAPITest(test.TestCase):
     def setUp(self):
         super(ShareAdminActionsAPITest, self).setUp()
         CONF.set_default("default_share_type", None)
-        self.flags(rpc_backend='manila.openstack.common.rpc.impl_fake')
+        self.flags(transport_url='rabbit://fake:fake@mqhost:5672')
         self.share_api = share_api.API()
         self.admin_context = context.RequestContext('admin', 'fake', True)
         self.member_context = context.RequestContext('fake', 'fake')


### PR DESCRIPTION
rpc_backend was an old oslo_messaging option
that was deprecated in stable/newton and removed
in master/stein [2], so stop using it in our
unit tests.

The coverage job in manila was always non-voting,
however, a773e31420bfd141682c43d0823d2009078c2fec
added a common coverage job-template from the
openstack-zuul-jobs repository. This change
inadvertently made the non-voting cover job a
voting job.

Our coverage script isn't perfect, it is known
to fail erroneously on non-code changes, and
some genuine failures are just an indication
to developers and reviewers to make the best
effort to adhere to the script's strict
checks [3].

These changes are unrelated, but must be fixed
together to pass the gate, since we have a
chicken-and-egg problem with both failures
preventing separate fixes from merging
separately.

[1] https://review.openstack.org/#/c/317285/
[2] https://review.openstack.org/#/c/580910/
[3] http://git.openstack.org/cgit/openstack/manila/tree/tools/cover.sh

Closes-Bug: #1796759
Related-Bug: #1797512
Change-Id: Ie349c3866d51ea4e706369ad67bc1155f62f2651