### PR TITLE
Fix get instance parent

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -1473,18 +1473,19 @@ def _set_instances_share_data(context, instances, session):
 def share_instances_get_all_by_host(context, host, with_share_data=False,
                                     session=None):
     """Retrieves all share instances hosted on a host."""
-    session = session or get_session()
-    instances = (
-        model_query(context, models.ShareInstance).filter(
+    query = model_query(context, models.ShareInstance).filter(
             or_(
                 models.ShareInstance.host == host,
                 models.ShareInstance.host.like("{0}#%".format(host))
             )
-        ).all()
-    )
-
+        )
     if with_share_data:
-        instances = _set_instances_share_data(context, instances, session)
+        instances = query.options(joinedload('share')).all()
+        instances = [s for s in instances if s.share]
+        for s in instances:
+            s.set_share_data(s.share)
+    else:
+        instances = query.all()
     return instances
 
 

--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -1473,12 +1473,10 @@ def _set_instances_share_data(context, instances, session):
 def share_instances_get_all_by_host(context, host, with_share_data=False,
                                     session=None):
     """Retrieves all share instances hosted on a host."""
-    query = model_query(context, models.ShareInstance).filter(
-            or_(
-                models.ShareInstance.host == host,
-                models.ShareInstance.host.like("{0}#%".format(host))
-            )
-        )
+    query = model_query(context, models.ShareInstance).filter(or_(
+        models.ShareInstance.host == host,
+        models.ShareInstance.host.like("{0}#%".format(host))
+    ))
     if with_share_data:
         instances = query.options(joinedload('share')).all()
         instances = [s for s in instances if s.share]

--- a/manila/db/sqlalchemy/models.py
+++ b/manila/db/sqlalchemy/models.py
@@ -421,7 +421,6 @@ class ShareInstance(BASE, ManilaBase):
                     'ShareTypes.deleted == "False")')
     share = orm.relationship(
         'Share',
-        lazy='subquery',
         foreign_keys=share_id,
         primaryjoin='ShareInstance.share_id == Share.id'
     )

--- a/manila/db/sqlalchemy/models.py
+++ b/manila/db/sqlalchemy/models.py
@@ -419,6 +419,12 @@ class ShareInstance(BASE, ManilaBase):
         primaryjoin='and_('
                     'ShareInstance.share_type_id == ShareTypes.id, '
                     'ShareTypes.deleted == "False")')
+    share = orm.relationship(
+        'Share',
+        lazy='subquery',
+        foreign_keys=share_id,
+        primaryjoin='ShareInstance.share_id == Share.id'
+    )
 
 
 class ShareInstanceExportLocations(BASE, ManilaBase):


### PR DESCRIPTION
Improve performance of function `manila.db.sqlalchemy.api.share_instances_get_all_by_host` with argument `with_share_data=True`.

Old implementation loops over the instance list and fetch share for each. It leads to bad performance when instance list is long (>100). Instead, query `share_instances` table with join to `share` table is much more performant. 