### PR TITLE
Skip updating share size when revert-to-snapshot

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2812,7 +2812,10 @@ class ShareManager(manager.SchedulerDependentManager):
 
         self.db.share_update(
             context, share_id,
-            {'status': constants.STATUS_AVAILABLE, 'size': snapshot['size']})
+            {'status': constants.STATUS_AVAILABLE})
+        # Note:  backend driver does not necessarilly resize the share,
+        # therefore do not update share size to the snapshot size.
+
         self.db.share_snapshot_update(
             context, snapshot_id, {'status': constants.STATUS_AVAILABLE})
 

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -5902,7 +5902,7 @@ class ShareManagerTestCase(test.TestCase):
 
         mock_share_update.assert_called_once_with(
             mock.ANY, share_id,
-            {'status': constants.STATUS_AVAILABLE, 'size': snapshot['size']})
+            {'status': constants.STATUS_AVAILABLE})
         mock_share_snapshot_update.assert_called_once_with(
             mock.ANY, 'fake_snapshot_id',
             {'status': constants.STATUS_AVAILABLE})


### PR DESCRIPTION
Netapp driver does not resize share when reverting to snapshot.