### PR TITLE
If no sort keys were specified when shares are listed, the shares are

### DIFF
--- a/manila/tests/db/sqlalchemy/test_api.py
+++ b/manila/tests/db/sqlalchemy/test_api.py
@@ -459,7 +459,8 @@ class ShareDatabaseAPITestCase(test.TestCase):
             self.assertNotIn('share_proto', instance)
 
     def test_share_instance_get_all_by_host_not_found_exception(self):
-        self.skipTest("invalid test due to pull request https://github.com/sapcc/manila/pull/6")
+        self.skipTest("invalid test due to PR "
+                      "https://github.com/sapcc/manila/pull/6")
         db_utils.create_share()
         self.mock_object(db_api, 'share_get', mock.Mock(
                          side_effect=exception.NotFound))


### PR DESCRIPTION
listed by 'created_at' timestamp by default. On the edge-case when
shares are listed with --limit (and --offset) two shares with the
exactly same creation timestamp might switch their postition in the list
and with small limit this means lists can be inconsitent between the
same API calls. This fix is an attempt to use two sort keys be default,
the 'created_at' and 'id' to have consistent results.