### PR TITLE
Share Affinity and Anti-Affinity Scheduler filters.

### DIFF
--- a/manila/api/v1/shares.py
+++ b/manila/api/v1/shares.py
@@ -236,7 +236,8 @@ class ShareMixin(object):
     @wsgi.Controller.authorize('create')
     def _create(self, req, body,
                 check_create_share_from_snapshot_support=False,
-                check_availability_zones_extra_spec=False):
+                check_availability_zones_extra_spec=False,
+                scheduler_hints=None):
         """Creates a new share."""
         context = req.environ['manila.context']
 
@@ -407,7 +408,7 @@ class ShareMixin(object):
         if share_type:
             kwargs['share_type'] = share_type
 
-        kwargs['scheduler_hints'] = share.get('scheduler_hints')
+        kwargs['scheduler_hints'] = scheduler_hints
 
         new_share = self.share_api.create(context,
                                           share_proto,

--- a/manila/api/v2/shares.py
+++ b/manila/api/v2/shares.py
@@ -179,9 +179,15 @@ class ShareController(shares.ShareMixin,
 
     @wsgi.Controller.api_version("2.48")
     def create(self, req, body):
+        if not self.is_valid_body(body, 'share'):
+            raise exc.HTTPUnprocessableEntity()
+
+        share = body['share']
+        scheduler_hints = share.pop('scheduler_hints', None)
         return self._create(req, body,
                             check_create_share_from_snapshot_support=True,
-                            check_availability_zones_extra_spec=True)
+                            check_availability_zones_extra_spec=True,
+                            scheduler_hints=scheduler_hints)
 
     @wsgi.Controller.api_version("2.31", "2.47")  # noqa
     def create(self, req, body):  # pylint: disable=function-redefined  # noqa F811

--- a/manila/db/api.py
+++ b/manila/db/api.py
@@ -742,6 +742,11 @@ def share_metadata_get(context, share_id):
     return IMPL.share_metadata_get(context, share_id)
 
 
+def share_metadata_get_item(context, share_id, key):
+    """Get metatem for given key and for a given share.."""
+    return IMPL.share_metadata_get_item(context, share_id, key)
+
+
 def share_metadata_delete(context, share_id, key):
     """Delete the given metadata item."""
     IMPL.share_metadata_delete(context, share_id, key)
@@ -750,6 +755,11 @@ def share_metadata_delete(context, share_id, key):
 def share_metadata_update(context, share, metadata, delete):
     """Update metadata if it exists, otherwise create it."""
     IMPL.share_metadata_update(context, share, metadata, delete)
+
+
+def share_metadata_update_item(context, share_id, item):
+    """update meta item containing key and value for given share."""
+    IMPL.share_metadata_update_item(context, share_id, item)
 
 
 ###################

--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -61,6 +61,7 @@ LOG = log.getLogger(__name__)
 QUOTAS = quota.QUOTAS
 
 _DEFAULT_QUOTA_NAME = 'default'
+_DEFAULT_AFFINITY_METADATA = '__affinity_'
 PER_PROJECT_QUOTAS = []
 
 _FACADE = None
@@ -2047,10 +2048,15 @@ def _share_get_all_with_filters(context, project_id=None, share_server_id=None,
 
     if 'metadata' in filters:
         for k, v in filters['metadata'].items():
-            # pylint: disable=no-member
-            query = query.filter(
-                or_(models.Share.share_metadata.any(
-                    key=k, value=v)))
+            if v == "*":
+                # pylint: disable=no-member
+                query = query.filter(
+                    or_(models.Share.share_metadata.any(key=k)))
+            else:
+                # pylint: disable=no-member
+                query = query.filter(
+                    or_(models.Share.share_metadata.any(key=k, value=v)))
+
     if 'extra_specs' in filters:
         query = query.join(
             models.ShareTypeExtraSpecs,
@@ -3203,15 +3209,47 @@ def share_metadata_get(context, share_id):
 
 @require_context
 @require_share_exists
+def share_metadata_get_item(context, share_id, key, session=None):
+    session = session or get_session()
+    try:
+        row = _share_metadata_get_item(context, share_id, key,
+                                       session=session)
+    except exception.ShareMetadataNotFound:
+        raise exception.ShareMetadataNotFound()
+
+    result = {}
+    result[row['key']] = row['value']
+
+    return result
+
+
+@require_context
+@require_share_exists
 def share_metadata_delete(context, share_id, key):
-    (_share_metadata_get_query(context, share_id).
-        filter_by(key=key).soft_delete())
+    if (context.is_admin or
+            not key.startswith(_DEFAULT_AFFINITY_METADATA)):
+        # admins can delete any metadata, but users cannot delete private one
+        (_share_metadata_get_query(context, share_id).
+            filter_by(key=key).soft_delete())
+    else:
+        # normal user should not be able to delete private admin metadata
+        raise exception.ShareMetadataNotFound(metadata_key=key,
+                                              share_id=share_id)
 
 
 @require_context
 @require_share_exists
 def share_metadata_update(context, share_id, metadata, delete):
     return _share_metadata_update(context, share_id, metadata, delete)
+
+
+@require_context
+@require_share_exists
+def share_metadata_update_item(context, share_id, item, session=None):
+    #NOTE(galkindmitrii): we use force as an extra flag here because only
+    # admins can update affinity metadata values.
+    return _share_metadata_update(context, share_id, item, delete=False,
+                                  force=True)
 
 
 def _share_metadata_get_query(context, share_id, session=None):
@@ -3227,12 +3265,12 @@ def _share_metadata_get(context, share_id, session=None):
     result = {}
     for row in rows:
         result[row['key']] = row['value']
-
     return result
 
 
 @oslo_db_api.wrap_db_retry(max_retries=5, retry_on_deadlock=True)
-def _share_metadata_update(context, share_id, metadata, delete, session=None):
+def _share_metadata_update(context, share_id, metadata, delete, session=None,
+                           force=False):
     if not session:
         session = get_session()
 
@@ -3243,10 +3281,12 @@ def _share_metadata_update(context, share_id, metadata, delete, session=None):
                                                     session=session)
             for meta_key, meta_value in original_metadata.items():
                 if meta_key not in metadata:
-                    meta_ref = _share_metadata_get_item(context, share_id,
-                                                        meta_key,
-                                                        session=session)
-                    meta_ref.soft_delete(session=session)
+                    # But do not delete affinity metadata unless forced:
+                    if (force or not meta_key.startswith(_DEFAULT_AFFINITY_METADATA)):
+                        meta_ref = _share_metadata_get_item(context, share_id,
+                                                            meta_key,
+                                                            session=session)
+                        meta_ref.soft_delete(session=session)
 
         meta_ref = None
 
@@ -3254,19 +3294,24 @@ def _share_metadata_update(context, share_id, metadata, delete, session=None):
         # objects
         for meta_key, meta_value in metadata.items():
 
-            # update the value whether it exists or not
-            item = {"value": meta_value}
+            # Update any item if admin or forced
+            # otherwise filter out affinity metadata keys
+            if (force or context.is_admin or
+                    not meta_key.startswith(_DEFAULT_AFFINITY_METADATA)):
 
-            try:
-                meta_ref = _share_metadata_get_item(context, share_id,
-                                                    meta_key,
-                                                    session=session)
-            except exception.ShareMetadataNotFound:
-                meta_ref = models.ShareMetadata()
-                item.update({"key": meta_key, "share_id": share_id})
+                # update the value whether it exists or not
+                item = {"value": meta_value}
 
-            meta_ref.update(item)
-            meta_ref.save(session=session)
+                try:
+                    meta_ref = _share_metadata_get_item(context, share_id,
+                                                        meta_key,
+                                                        session=session)
+                except exception.ShareMetadataNotFound:
+                    meta_ref = models.ShareMetadata()
+                    item.update({"key": meta_key, "share_id": share_id})
+
+                meta_ref.update(item)
+                meta_ref.save(session=session)
 
         return metadata
 

--- a/manila/exception.py
+++ b/manila/exception.py
@@ -175,7 +175,7 @@ class InvalidParameterValue(Invalid):
 
 
 class InvalidUUID(Invalid):
-    message = _("Expected a uuid but received %(uuid)s.")
+    message = _("%(uuid)s is not a valid uuid.")
 
 
 class InvalidDriverMode(Invalid):
@@ -530,6 +530,10 @@ class ExportLocationNotFound(NotFound):
 
 class ShareNotFound(NotFound):
     message = _("Share %(share_id)s could not be found.")
+
+
+class ShareInstanceNotFound(NotFound):
+    message = _("Share instance %(share_instance_id)s could not be found.")
 
 
 class ShareSnapshotNotFound(NotFound):

--- a/manila/message/api.py
+++ b/manila/message/api.py
@@ -63,6 +63,7 @@ class API(base.Base):
             'message_level': level,
             'expires_at': expires_at,
         }
+
         try:
             self.db.message_create(context, message_record)
         except Exception:

--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -98,6 +98,8 @@ class Detail(object):
         '019',
         _("Share Driver does not support shrinking shares."
           " Shrinking share operation failed."))
+    FILTER_AFFINITY = ('020', FILTER_MSG % 'AffinityFilter')
+    FILTER_ANTI_AFFINITY = ('021', FILTER_MSG % 'AntiAffinityFilter')
 
     ALL = (UNKNOWN_ERROR,
            NO_VALID_HOST,
@@ -117,7 +119,9 @@ class Detail(object):
            FILTER_CREATE_FROM_SNAPSHOT,
            DRIVER_FAILED_CREATING_FROM_SNAP,
            DRIVER_REFUSED_SHRINK,
-           DRIVER_FAILED_SHRINK)
+           DRIVER_FAILED_SHRINK,
+           FILTER_AFFINITY,
+           FILTER_ANTI_AFFINITY)
 
     # Exception and detail mappings
     EXCEPTION_DETAIL_MAPPINGS = {
@@ -136,6 +140,8 @@ class Detail(object):
         'RetryFilter': FILTER_RETRY,
         'ShareReplicationFilter': FILTER_REPLICATION,
         'CreateFromSnapshotFilter': FILTER_CREATE_FROM_SNAPSHOT,
+        'AffinityFilter': FILTER_AFFINITY,
+        'AntiAffinityFilter': FILTER_ANTI_AFFINITY,
     }
 
 

--- a/manila/scheduler/drivers/filter.py
+++ b/manila/scheduler/drivers/filter.py
@@ -23,6 +23,7 @@ filters and weighing functions.
 from oslo_config import cfg
 from oslo_log import log
 
+from manila.db import api as db_api
 from manila import exception
 from manila.i18n import _
 from manila.scheduler.drivers import base
@@ -31,6 +32,11 @@ from manila.share import share_types
 
 CONF = cfg.CONF
 LOG = log.getLogger(__name__)
+
+AFFINITY_HINT = 'same_host'
+ANTI_AFFINITY_HINT = 'different_host'
+AFFINITY_KEY = "__affinity_same_host"
+ANTI_AFFINITY_KEY = "__affinity_different_host"
 
 
 class FilterScheduler(base.Scheduler):
@@ -198,7 +204,8 @@ class FilterScheduler(base.Scheduler):
                                   'replication_domain': replication_domain,
                                   })
 
-        self.populate_filter_properties_share(request_spec, filter_properties)
+        self.populate_filter_properties_share(context, request_spec,
+                                              filter_properties)
 
         return filter_properties, share_properties
 
@@ -299,7 +306,17 @@ class FilterScheduler(base.Scheduler):
                       "exc": "exc"
                       })
 
-    def populate_filter_properties_share(self, request_spec,
+    def populate_filter_properties_share_scheduler_hint(self, context,
+                                                        share_id, hints,
+                                                        key, hint):
+        try:
+            result = db_api.share_metadata_get_item(context, share_id, key)
+        except exception.ShareMetadataNotFound:
+            pass
+        else:
+            hints.update({hint: result.get(key)})
+
+    def populate_filter_properties_share(self, context, request_spec,
                                          filter_properties):
         """Stuff things into filter_properties.
 
@@ -313,6 +330,25 @@ class FilterScheduler(base.Scheduler):
         )
         filter_properties['user_id'] = shr.get('user_id')
         filter_properties['metadata'] = shr.get('metadata')
+
+        share_id = request_spec.get('share_id', None)
+        if not share_id:
+            filter_properties['scheduler_hints'] = {}
+            return
+
+        try:
+            db_api.share_get(context, share_id)
+        except exception.NotFound:
+            filter_properties['scheduler_hints'] = {}
+        else:
+            hints = {}
+            self.populate_filter_properties_share_scheduler_hint(
+                context, share_id, hints,
+                AFFINITY_KEY, AFFINITY_HINT)
+            self.populate_filter_properties_share_scheduler_hint(
+                context, share_id, hints,
+                ANTI_AFFINITY_KEY, ANTI_AFFINITY_HINT)
+            filter_properties['scheduler_hints'] = hints
 
     def schedule_create_share_group(self, context, share_group_id,
                                     request_spec, filter_properties):

--- a/manila/scheduler/filters/affinity.py
+++ b/manila/scheduler/filters/affinity.py
@@ -16,14 +16,13 @@
 from oslo_log import log
 from oslo_utils import uuidutils
 
+from manila.exception import ManilaException
 from manila.exception import NotFound as ManilaNotFound
+from manila.exception import PolicyNotAuthorized as ManilaNotAuthorized
 from manila.scheduler.filters import base_host
 from manila.share import api
 
 LOG = log.getLogger(__name__)
-
-AFFINITY_FILTER = 'affinity_filter'
-ANTI_AFFINITY_FILTER = 'anti_affinity_filter'
 
 
 class AffinityBaseFilter(base_host.BaseHostFilter):
@@ -46,6 +45,7 @@ class AffinityBaseFilter(base_host.BaseHostFilter):
             # filters are skipped.
             return filter_obj_list
         except (InvalidUUIDError,
+                InvalidUUIDListError,
                 ShareNotFoundError,
                 ShareInstanceNotFoundError) as e:
             # Stop scheduling share when above errors are caught
@@ -70,8 +70,10 @@ class AffinityBaseFilter(base_host.BaseHostFilter):
             if share_uuids is None:
                 raise SchedulerHintsNotSet
 
+        # (ccloud): do not allow string, should be list of strings?
         if not isinstance(share_uuids, (tuple, list)):
-            share_uuids = share_uuids,
+            share_uuids = share_uuids.split(",")
+            #raise InvalidUUIDListError(share_uuids)
 
         filter_properties['scheduler_hints'][self._filter_type] = []
 
@@ -79,8 +81,12 @@ class AffinityBaseFilter(base_host.BaseHostFilter):
             if not uuidutils.is_uuid_like(uuid):
                 raise InvalidUUIDError(uuid)
             try:
+                # NOTE(ccloud):
+                # if we want to allow to specify uuid from another project,
+                # we need to change the policy as context.elevated() right now
+                # still hard tied to the current project:
                 share = self.share_api.get(context, uuid)
-            except ManilaNotFound:
+            except (ManilaNotFound, ManilaNotAuthorized):
                 raise ShareNotFoundError(uuid)
             instances = share.get('instances')
             if len(instances) == 0:
@@ -90,46 +96,89 @@ class AffinityBaseFilter(base_host.BaseHostFilter):
 
         return filter_properties
 
+    def _get_host_name_from_state(self, host_state_host):
+        """Returns the actual host_name from the host_state"""
+        host_name = ""
+        if host_state_host:
+            full_name = host_state_host.split('@')
+            if len(full_name) == 2:
+                # we can relibly say that first is the hostname
+                host_name = full_name[0]
+            #TODO: missing error handling here...
+
+        return host_name
+
 
 class AffinityFilter(AffinityBaseFilter):
-    _filter_type = AFFINITY_FILTER
+    _filter_type = api.AFFINITY_HINT
 
     def host_passes(self, host_state, filter_properties):
         allowed_hosts = \
             filter_properties['scheduler_hints'][self._filter_type]
-        return host_state.host in allowed_hosts
+        host_name = self._get_host_name_from_state(host_state.host)
+
+        allowed_host_names = set()
+        for allowed_host in allowed_hosts:
+            allowed_host_name = self._get_host_name_from_state(allowed_host)
+            allowed_host_names.add(allowed_host_name)
+
+        if len(allowed_host_names) > 1:
+            # The given share uuids are located on different filers.
+            # Affinity with both at the same time is not possible.
+            return None
+
+        if host_name in allowed_host_names:
+            # Valid, pass the host:
+            return host_state.host
 
 
 class AntiAffinityFilter(AffinityBaseFilter):
-    _filter_type = ANTI_AFFINITY_FILTER
+    _filter_type = api.ANTI_AFFINITY_HINT
 
     def host_passes(self, host_state, filter_properties):
         forbidden_hosts = \
             filter_properties['scheduler_hints'][self._filter_type]
-        return host_state.host not in forbidden_hosts
+        host_name = self._get_host_name_from_state(host_state.host)
+
+        for forbidden_host in forbidden_hosts:
+            if host_name in self._get_host_name_from_state(forbidden_host):
+                # do not pass the host if there is a host_name match:
+                return None
+
+        return host_state.host
 
 
-class SchedulerHintsNotSet(Exception):
+class SchedulerHintsNotSet(ManilaException):
     pass
 
 
-class InvalidUUIDError(Exception):
+class InvalidUUIDError(ManilaException):
     def __init__(self, uuid):
         message = '%s is not a valid uuid' % uuid
-        super(InvalidUUIDError, self).__init__(message)
+        detail_data = {'detail_message': message}
+        super(InvalidUUIDError, self).__init__(message, detail_data)
 
 
-class ShareNotFoundError(Exception):
+class InvalidUUIDListError(ManilaException):
+    def __init__(self, uuid):
+        message = '%s is not a valid list of uuid-s' % uuid
+        detail_data = {'detail_message': message}
+        super(InvalidUUIDListError, self).__init__(message, detail_data)
+
+
+class ShareNotFoundError(ManilaException):
     def __init__(self, share_uuid):
         message = 'share %s not found' % share_uuid
-        super(ShareNotFoundError, self).__init__(message)
+        detail_data = {'detail_message': message}
+        super(ShareNotFoundError, self).__init__(message, detail_data)
 
 
-class ShareInstanceNotFoundError(Exception):
+class ShareInstanceNotFoundError(ManilaException):
     def __init__(self, share_uuid):
         message = 'share instance not found for share "%s"' % share_uuid
-        super(ShareInstanceNotFoundError, self).__init__(message)
+        detail_data = {'detail_message': message}
+        super(ShareInstanceNotFoundError, self).__init__(message, detail_data)
 
 
-class AffinityFilterTypeNotSetError(Exception):
+class AffinityFilterTypeNotSetError(ManilaException):
     pass

--- a/manila/scheduler/host_manager.py
+++ b/manila/scheduler/host_manager.py
@@ -49,6 +49,8 @@ host_manager_opts = [
                     'DriverFilter',
                     'ShareReplicationFilter',
                     'CreateFromSnapshotFilter',
+                    'AffinityFilter',
+                    'AntiAffinityFilter',
                 ],
                 help='Which filter class names to use for filtering hosts '
                      'when not specified in the request.'),

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -25,6 +25,7 @@ from oslo_log import log
 from oslo_utils import excutils
 from oslo_utils import strutils
 from oslo_utils import timeutils
+from oslo_utils import uuidutils
 import six
 
 from manila.common import constants
@@ -59,6 +60,11 @@ CONF.register_opts(share_api_opts)
 LOG = log.getLogger(__name__)
 GB = 1048576 * 1024
 QUOTAS = quota.QUOTAS
+
+AFFINITY_HINT = 'same_host'
+ANTI_AFFINITY_HINT = 'different_host'
+AFFINITY_KEY = "__affinity_same_host"
+ANTI_AFFINITY_KEY = "__affinity_different_host"
 
 
 class API(base.Base):
@@ -345,6 +351,8 @@ class API(base.Base):
                 finally:
                     QUOTAS.rollback(
                         context, reservations, share_type_id=share_type_id)
+
+        self.save_scheduler_hints(context, share, scheduler_hints)
 
         host = None
         snapshot_host = None
@@ -1135,6 +1143,8 @@ class API(base.Base):
             raise exception.InvalidShare(reason=msg)
 
         self._check_is_share_busy(share)
+        self.delete_scheduler_hints(context, share)
+
         for share_instance in share.instances:
             if share_instance['host']:
                 self.delete_instance(context, share_instance, force=force)
@@ -1252,6 +1262,7 @@ class API(base.Base):
         share_server = self.db.share_server_update(
             context, share_server['id'], update_data)
 
+        self.delete_scheduler_hints(context, share)
         self.share_rpcapi.unmanage_share_server(
             context, share_server, force=force)
 
@@ -1997,6 +2008,86 @@ class API(base.Base):
     def delete_share_metadata(self, context, share, key):
         """Delete the given metadata item from a share."""
         self.db.share_metadata_delete(context, share['id'], key)
+
+    def _validate_scheduler_hints(self, context, share, share_uuids):
+        for uuid in share_uuids:
+            if not uuidutils.is_uuid_like(uuid):
+                raise exception.InvalidUUID(uuid=uuid)
+            try:
+                self.get(context, uuid)
+            except (exception.NotFound, exception.PolicyNotAuthorized):
+                raise exception.ShareNotFound(share_id=uuid)
+
+    def _save_scheduler_hints(self, context, share, share_uuids, key):
+        if not isinstance(share_uuids, list):
+            share_uuids = share_uuids.split(",")
+
+        self._validate_scheduler_hints(context, share, share_uuids)
+        val_uuids = None
+        for uuid in share_uuids:
+            try:
+                result = self.db.share_metadata_get_item(context, uuid, key)
+            except exception.ShareMetadataNotFound:
+                item = {key: share['id']}
+            else:
+                existing_uuids = result.get(key, "")
+                item = {key:
+                        ','.join(existing_uuids.split(',') + [share['id']])}
+            self.db.share_metadata_update_item(context, uuid, item)
+            if not val_uuids:
+                val_uuids = uuid
+            else:
+                val_uuids = val_uuids + "," + uuid
+
+        if val_uuids:
+            item = {key: val_uuids}
+            self.db.share_metadata_update_item(context, share['id'], item)
+
+    def save_scheduler_hints(self, context, share, scheduler_hints=None):
+        if scheduler_hints is None:
+            return
+
+        same_host_uuids = scheduler_hints.get(AFFINITY_HINT, None)
+        different_host_uuids = scheduler_hints.get(ANTI_AFFINITY_HINT, None)
+
+        if same_host_uuids:
+            self._save_scheduler_hints(context, share, same_host_uuids,
+                                       AFFINITY_KEY)
+        if different_host_uuids:
+            self._save_scheduler_hints(context, share, different_host_uuids,
+                                       ANTI_AFFINITY_KEY)
+
+    def _delete_scheduler_hints(self, context, share, key):
+        try:
+            result = self.db.share_metadata_get_item(context, share['id'],
+                                                     key)
+        except exception.ShareMetadataNotFound:
+            return
+
+        # elevate context as default user context won't be enough
+        # to delete the scheduler hints.
+        context = context.elevated()
+
+        share_uuids = result.get(key, "").split(",")
+        for uuid in share_uuids:
+            try:
+                result = self.db.share_metadata_get_item(context, uuid, key)
+            except exception.ShareMetadataNotFound:
+                continue
+
+            new_val_uuids = [val_uuid for val_uuid
+                             in result.get(key, "").split(",")
+                             if val_uuid != share['id']]
+            if not new_val_uuids:
+                self.db.share_metadata_delete(context, uuid, key)
+            else:
+                item = {key: ','.join(new_val_uuids)}
+                self.db.share_metadata_update_item(context, uuid, item)
+        self.db.share_metadata_delete(context, share['id'], key)
+
+    def delete_scheduler_hints(self, context, share):
+        self._delete_scheduler_hints(context, share, AFFINITY_KEY)
+        self._delete_scheduler_hints(context, share, ANTI_AFFINITY_KEY)
 
     def _check_is_share_busy(self, share):
         """Raises an exception if share is busy with an active task."""

--- a/manila/tests/scheduler/drivers/test_filter.py
+++ b/manila/tests/scheduler/drivers/test_filter.py
@@ -98,7 +98,7 @@ class FilterSchedulerTestCase(test_base.SchedulerTestCase):
             'share_properties': {'project_id': 1, 'size': 1},
             'share_instance_properties': {},
             'share_type': {'name': 'NFS'},
-            'share_id': ['fake-id1'],
+            'share_id': 'fake-id1',
         }
         self.assertRaises(exception.NoValidHost, sched.schedule_create_share,
                           fake_context, request_spec, {})
@@ -123,7 +123,7 @@ class FilterSchedulerTestCase(test_base.SchedulerTestCase):
             'share_properties': {'project_id': 1, 'size': 1},
             'share_instance_properties': {},
             'share_type': {'name': 'NFS'},
-            'share_id': ['fake-id1'],
+            'share_id': 'fake-id1',
         }
         self.assertRaises(exception.NoValidHost, sched.schedule_create_share,
                           fake_context, request_spec, {})

--- a/manila/tests/scheduler/filters/test_affinity.py
+++ b/manila/tests/scheduler/filters/test_affinity.py
@@ -12,23 +12,18 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
 import ddt
 from unittest import mock
-
-from manila.exception import NotFound
+from manila import exception
 from manila.scheduler.filters import affinity
 from manila import test
 from manila.tests.scheduler import fakes
-
-
 fake_hosts = [
     fakes.FakeHostState('host1', {}),
     fakes.FakeHostState('host2', {}),
     fakes.FakeHostState('host3', {}),
     ]
-
-fake_shares = {
+fake_shares_1 = {
     'abb6e0ac-7c3e-4ce0-8a69-5a166d246882': {
         'instances': [
             {'host': fake_hosts[0].host}
@@ -36,56 +31,56 @@ fake_shares = {
         },
     '4de0cc74-450c-4468-8159-52128cf03407': {
         'instances': [
+            {'host': fake_hosts[0].host}
+            ]
+        },
+    }
+fake_shares_2 = {
+    'c920fb61-e250-4c3c-a25d-1fdd9ca7cbc3': {
+        'instances': [
             {'host': fake_hosts[1].host}
             ]
         },
     }
-
-
+fake_shares_3 = {
+    '3923bebf-9825-4a66-971e-6092a9fe2dbb': {
+        'instances': [
+            {'host': fake_hosts[2].host}
+            ]
+        },
+    }
 @ddt.ddt
 class AffinityFilterTestCase(test.TestCase):
     """Test case for AffinityFilter."""
-
     def setUp(self):
         super(AffinityFilterTestCase, self).setUp()
         self.filter = affinity.AffinityFilter()
         self.anti_filter = affinity.AntiAffinityFilter()
-
     def _make_filter_hints(self, *hints):
         return {
             'context': None,
-            'scheduler_hints': {'affinity_filter': list(hints)},
+            'scheduler_hints': {'same_host': ','.join(list(hints))},
         }
-
     def _make_anti_filter_hints(self, *hints):
         return {
             'context': None,
-            'scheduler_hints': {'anti_affinity_filter': list(hints)},
+            'scheduler_hints': {'different_host': ','.join(list(hints))},
         }
-
     def _fake_get(self, context, uuid):
-        if uuid in fake_shares.keys():
-            return fake_shares[uuid]
-        raise NotFound
-
-    @ddt.data(
-        {'affinity_filter': 'uuid1'},
-        {'affinity_filter': ('uuid1', 'uuid2')},
-        {'affinity_filter': ['uuid1', 'uuid2']},
-    )
-    def test_affinity_invalid_uuid(self, hints):
-        filter_properties = {'context': None, 'scheduler_hints': hints}
-        self.assertRaises(affinity.InvalidUUIDError,
-                          self.filter._validate, filter_properties)
-
+        if uuid in fake_shares_1.keys():
+            return fake_shares_1[uuid]
+        if uuid in fake_shares_2.keys():
+            return fake_shares_2[uuid]
+        if uuid in fake_shares_3.keys():
+            return fake_shares_3[uuid]
+        raise exception.ShareNotFound(uuid)
     @ddt.data('b5c207da-ac0b-43b0-8691-c6c9e860199d')
     @mock.patch('manila.share.api.API.get')
     def test_affinity_share_not_found(self, unknown_id, mock_share_get):
         mock_share_get.side_effect = self._fake_get
-        self.assertRaises(affinity.ShareNotFoundError,
+        self.assertRaises(exception.ShareNotFound,
                           self.filter._validate,
                           self._make_filter_hints(unknown_id))
-
     @ddt.data(
         {'context': None},
         {'context': None, 'scheduler_hints': None},
@@ -94,29 +89,23 @@ class AffinityFilterTestCase(test.TestCase):
     def test_affinity_scheduler_hint_not_set(self, hints):
         self.assertRaises(affinity.SchedulerHintsNotSet,
                           self.filter._validate, hints)
-
     @ mock.patch('manila.share.api.API.get')
     def test_affinity_filter(self, mock_share_get):
         mock_share_get.side_effect = self._fake_get
-
-        share_ids = fake_shares.keys()
+        share_ids = fake_shares_1.keys()
         hints = self._make_filter_hints(*share_ids)
         valid_hosts = self.filter.filter_all(fake_hosts, hints)
         valid_hosts = [h.host for h in valid_hosts]
-
         self.assertIn('host1', valid_hosts)
-        self.assertIn('host2', valid_hosts)
+        self.assertNotIn('host2', valid_hosts)
         self.assertNotIn('host3', valid_hosts)
-
     @ mock.patch('manila.share.api.API.get')
     def test_anti_affinity_filter(self, mock_share_get):
         mock_share_get.side_effect = self._fake_get
-
-        share_ids = fake_shares.keys()
+        share_ids = fake_shares_2.keys()
         hints = self._make_anti_filter_hints(*share_ids)
         valid_hosts = self.anti_filter.filter_all(fake_hosts, hints)
         valid_hosts = [h.host for h in valid_hosts]
-
-        self.assertNotIn('host1', valid_hosts)
-        self.assertNotIn('host2', valid_hosts)
+        self.assertIn('host1', valid_hosts)
         self.assertIn('host3', valid_hosts)
+        self.assertNotIn('host2', valid_hosts)


### PR DESCRIPTION
Based on https://review.opendev.org/c/openstack/manila/+/775201/
with the following changes:

- '__affinity_*' metadata can only be updated or deleted by admin.
- Affinity/Anti-Affinity filters work on actual hosts, not
aggregates level.
- Allow to query metadata by key with any value (by giving * wildcard).
- Extend error messages to point to Affinity/AntiAffinity when respective
filter returns no host and share cannot be scheduled.