### PR TITLE
Fix non-captured exception from listing snapshots

### DIFF
--- a/manila/db/sqlalchemy/models.py
+++ b/manila/db/sqlalchemy/models.py
@@ -695,9 +695,11 @@ class ShareSnapshot(BASE, ManilaBase):
                 lambda x: qualified_replica(x.share_instance), self.instances))
 
             migrating_snapshots = list(filter(
-                lambda x: x.share_instance['status'] in (
-                    constants.STATUS_MIGRATING,
-                    constants.STATUS_SERVER_MIGRATING), self.instances))
+                lambda x: (x.share_instance is not None and
+                           x.share_instance['status'] in (
+                               constants.STATUS_MIGRATING,
+                               constants.STATUS_SERVER_MIGRATING)
+                           ), self.instances))
 
             snapshot_instances = (replica_snapshots or migrating_snapshots
                                   or self.instances)


### PR DESCRIPTION
Non-captured exceptions are logged in Sentries while constructing the `migrating_snapshots` list during the API call to list the snapshots. The `share_instance` is `None`, and therefore is not subscriptable. This is a similar fix to 5cf087e1856e9225f204d09b40caeeda1340b785