### PR TITLE
OnlyHostFilter allows user to specify host during share create.

### DIFF
--- a/manila/scheduler/filters/host.py
+++ b/manila/scheduler/filters/host.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 SAP.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from manila.scheduler.filters import base_host
+
+
+class OnlyHostFilter(base_host.BaseHostFilter):
+    """Filters Hosts by 'only_host' scheduler_hint."""
+
+    def host_passes(self, host_state, filter_properties):
+        hints = filter_properties.get('scheduler_hints')
+        if hints is None:
+            return True
+        requested_host = hints.get('only_host', None)
+        if requested_host is None:
+            return True
+        # e.g. "only_host=hostname@generic2#GENERIC2"
+        return host_state.host == requested_host

--- a/manila/scheduler/host_manager.py
+++ b/manila/scheduler/host_manager.py
@@ -51,6 +51,7 @@ host_manager_opts = [
                     'CreateFromSnapshotFilter',
                     'AffinityFilter',
                     'AntiAffinityFilter',
+                    'OnlyHostFilter',
                 ],
                 help='Which filter class names to use for filtering hosts '
                      'when not specified in the request.'),

--- a/manila/tests/scheduler/filters/test_host.py
+++ b/manila/tests/scheduler/filters/test_host.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 SAP.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import ddt
+
+from manila.scheduler.filters import host
+from manila import test
+from manila.tests.scheduler import fakes
+
+
+fake_host1 = fakes.FakeHostState('host1', {})
+fake_host2 = fakes.FakeHostState('host2', {})
+fake_host3 = fakes.FakeHostState('host3', {})
+
+
+@ddt.ddt
+class OnlyHostFilterTestCase(test.TestCase):
+    """Test case for OnlyHostFilter."""
+
+    def setUp(self):
+        super(OnlyHostFilterTestCase, self).setUp()
+        self.filter = host.OnlyHostFilter()
+
+    def _make_filter_hints(self):
+        return {
+            'context': None,
+            'scheduler_hints': {'only_host': fake_host1.host},
+        }
+
+    @ddt.data((fake_host1, {'context': None}),
+              (fake_host1, {'context': None, 'scheduler_hints': None}),
+              (fake_host1, {'context': None, 'scheduler_hints': {}}))
+    @ddt.unpack
+    def test_only_host_scheduler_hint_not_set(self, host, hints):
+        self.assertTrue(self.filter.host_passes(host, hints))
+
+    @ddt.data((fake_host1, True),
+              (fake_host2, False),
+              (fake_host3, False))
+    @ddt.unpack
+    def test_only_host_filter(self, host, host_passes):
+        hints = self._make_filter_hints()
+        self.assertEqual(host_passes, self.filter.host_passes(host, hints))

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ manila.scheduler.filters =
     IgnoreAttemptedHostsFilter = manila.scheduler.filters.ignore_attempted_hosts:IgnoreAttemptedHostsFilter
     JsonFilter = manila.scheduler.filters.json:JsonFilter
     RetryFilter = manila.scheduler.filters.retry:RetryFilter
+    OnlyHostFilter = manila.scheduler.filters.host:OnlyHostFilter
     ShareReplicationFilter = manila.scheduler.filters.share_replication:ShareReplicationFilter
     CreateFromSnapshotFilter = manila.scheduler.filters.create_from_snapshot:CreateFromSnapshotFilter
     # Share Group filters


### PR DESCRIPTION
e.g. manila create NFS 1 --name Share2 --share-network net1 \
--scheduler_hint="only_host=c5332059-vm@generic1#GENERIC1"

Since there is no way to create SVM in manila, we can use a workaround of creating
first share on specific host (e.g. host@backend#pool). This will then create the
SVM/(Share server) automatically on that host.