### PR TITLE
Custom event processing for ec2_backup scenario.

### DIFF
--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -111,6 +111,12 @@ class Detail(object):
         _("Share Driver failed to create share because a security service "
           "has not been added to the share network used. Please add a "
           "security service to the share network."))
+    DRIVER_FAILED_DELETE_SHARE_SNAPMIRROR = (
+        '024',
+        _("Share Driver failed to delete the share. The EC2 backup SnapMirror "
+          "configuration exist in the backend that has to be removed first in "
+          "order to delete the share. Please contact Storage Team via SNOW "
+          "ticket."))
 
     ALL = (UNKNOWN_ERROR,
            NO_VALID_HOST,
@@ -134,7 +140,8 @@ class Detail(object):
            FILTER_AFFINITY,
            FILTER_ANTI_AFFINITY,
            SECURITY_SERVICE_FAILED_AUTH,
-           MISSING_SECURITY_SERVICE)
+           MISSING_SECURITY_SERVICE,
+           DRIVER_FAILED_DELETE_SHARE_SNAPMIRROR)
 
 
     # Exception and detail mappings

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -3449,13 +3449,26 @@ class ShareManager(manager.SchedulerDependentManager):
                         context,
                         share_instance_id,
                         {'status': constants.STATUS_ERROR_DELETING})
-                self.message_api.create(
-                    context,
-                    message_field.Action.DELETE,
-                    share_instance['project_id'],
-                    resource_type=message_field.Resource.SHARE,
-                    resource_id=share_instance_id,
-                    exception=excep)
+
+                # NOTE: workaround to filter NetApp snapmirror error:
+                exc_msg = getattr(excep, 'message', '')
+                exc_code = getattr(excep, 'code', '')
+                if ('18436' in exc_code and 'SnapMirror' in exc_msg):
+                    self.message_api.create(
+                        context,
+                        message_field.Action.DELETE,
+                        share_instance['project_id'],
+                        resource_type=message_field.Resource.SHARE,
+                        resource_id=share_id,
+                        detail=message_field.Detail.DRIVER_FAILED_DELETE_SHARE_SNAPMIRROR)
+                else:
+                    self.message_api.create(
+                        context,
+                        message_field.Action.DELETE,
+                        share_instance['project_id'],
+                        resource_type=message_field.Resource.SHARE,
+                        resource_id=share_instance_id,
+                        exception=excep)
 
         self.db.share_instance_delete(
             context, share_instance_id, need_to_update_usages=True)


### PR DESCRIPTION
In case user tries to delete a share that is in SnapMirror relation,
the error will be propagated to the share error log via Manila messaging.