### PR TITLE
Enable logical space reporting

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -164,14 +164,15 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     @na_utils.trace
     def create_vserver(self, vserver_name, root_volume_aggregate_name,
                        root_volume_name, aggregate_names, ipspace_name,
-                       delete_retention_hours):
+                       delete_retention_hours, logical_space_reporting):
         """Creates new vserver and assigns aggregates."""
         self._create_vserver(
             vserver_name, aggregate_names, ipspace_name,
             delete_retention_hours, root_volume_name=root_volume_name,
             root_volume_aggregate_name=root_volume_aggregate_name,
             root_volume_security_style='unix',
-            name_server_switch='file')
+            name_server_switch='file',
+            logical_space_reporting=logical_space_reporting)
 
     @na_utils.trace
     def create_vserver_dp_destination(self, vserver_name, aggregate_names,
@@ -186,7 +187,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                         delete_retention_hours, root_volume_name=None,
                         root_volume_aggregate_name=None,
                         root_volume_security_style=None,
-                        name_server_switch=None, subtype=None):
+                        name_server_switch=None, subtype=None,
+                        logical_space_reporting=False):
         """Creates new vserver and assigns aggregates."""
         create_args = {
             'vserver-name': vserver_name,
@@ -210,6 +212,10 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 raise exception.NetAppException(msg)
             else:
                 create_args['ipspace'] = ipspace_name
+
+        if logical_space_reporting:
+            create_args['is-space-reporting-logical'] = True
+            create_args['is-space-enforcement-logical'] = True
 
         self.send_request('vserver-create', create_args)
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -270,7 +270,8 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 self.configuration.netapp_root_volume,
                 self._find_matching_aggregates(),
                 ipspace_name,
-                self.configuration.netapp_delete_retention_hours)
+                self.configuration.netapp_delete_retention_hours,
+                self.configuration.netapp_enable_logical_space_reporting)
 
             vserver_client = self._get_api_client(vserver=vserver_name)
 
@@ -1401,6 +1402,13 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             msg = _("The extra spec 'adaptive_qos_policy_group' is not "
                     "supported by backends configured with "
                     "'driver_handles_share_server' == True mode.")
+            raise exception.NetAppException(msg)
+
+        if (self.configuration.netapp_enable_logical_space_reporting and
+                not provisioning_options.get('thin_provisioned')):
+            msg = _("Logical space reporting is only available if thin "
+                    "provisioning is enabled. Set 'thin_provisioning=True' "
+                    "in your provisioning options")
             raise exception.NetAppException(msg)
 
         (super(NetAppCmodeMultiSVMFileStorageLibrary, self)

--- a/manila/share/drivers/netapp/options.py
+++ b/manila/share/drivers/netapp/options.py
@@ -127,6 +127,11 @@ netapp_provisioning_opts = [
                      'snapshot reserve is then added on top of net capacity. '
                      'The total size is calculated as (size * 100) divided by '
                      '(100 - netapp_volume_snapshot_reserve_percent)',
+                default=False),
+    cfg.BoolOpt('netapp_enable_logical_space_reporting',
+                help='This option enables the logical space reporting on a '
+                     'newly created vserver and locical space accounting '
+                     'on newly created volumes on this vserver. ',
                 default=False), ]
 
 netapp_cluster_opts = [

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -439,7 +439,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                                    fake.ROOT_VOLUME_NAME,
                                    fake.SHARE_AGGREGATE_NAMES,
                                    None,
-                                   16)
+                                   16,
+                                   False)
 
         self.client.send_request.assert_has_calls([
             mock.call('vserver-create', vserver_create_args),
@@ -470,7 +471,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                                    fake.ROOT_VOLUME_NAME,
                                    fake.SHARE_AGGREGATE_NAMES,
                                    fake.IPSPACE_NAME,
-                                   24)
+                                   24,
+                                   False)
 
         self.client.send_request.assert_has_calls([
             mock.call('vserver-create', vserver_create_args),
@@ -512,7 +514,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                           fake.ROOT_VOLUME_NAME,
                           fake.SHARE_AGGREGATE_NAMES,
                           fake.IPSPACE_NAME,
-                          17)
+                          17,
+                          False)
 
     def test_get_vserver_root_volume_name(self):
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -547,7 +547,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                 fake.NETWORK_INFO)
         self.library._client.create_vserver.assert_called_once_with(
             vserver_name, fake.ROOT_VOLUME_AGGREGATE, fake.ROOT_VOLUME,
-            fake.AGGREGATES, fake.IPSPACE, 12)
+            fake.AGGREGATES, fake.IPSPACE, 12, False)
         self.library._get_api_client.assert_called_once_with(
             vserver=vserver_name)
         self.library._create_vserver_lifs.assert_called_once_with(


### PR DESCRIPTION
The backend config option "netapp_enable_logical_space_reporting=True"
allows to create share server with logical space reporting. This only
works in combination with thin_provisioned volumes.