### PR TITLE
ccloud: add security service association for multi

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/drv_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/drv_multi_svm.py
@@ -40,7 +40,8 @@ class NetAppCmodeMultiSvmShareDriver(driver.ShareDriver):
         self.security_service_update_support = True
         self.dhss_mandatory_security_service_association = {
             'nfs': None,
-            'cifs': ['active_directory', ]
+            'cifs': ['active_directory', ],
+            'multi': ['active_directory', 'ldap'],
         }
 
     def do_setup(self, context):


### PR DESCRIPTION
fail early if ad and ldap security services are missing
to create a multi protocol share