### PR TITLE
ccloud: add extra spec 'netapp:max_files_multiplier'

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -94,6 +94,7 @@ class NetAppCmodeFileStorageLibrary(object):
         'netapp:snapshot_policy': 'snapshot_policy',
         'netapp:language': 'language',
         'netapp:max_files': 'max_files',
+        'netapp:max_files_multiplier': 'max_files_multiplier',
         'netapp:adaptive_qos_policy_group': 'adaptive_qos_policy_group',
         'netapp:fpolicy_extensions_to_include':
             'fpolicy_extensions_to_include',
@@ -1174,6 +1175,13 @@ class NetAppCmodeFileStorageLibrary(object):
         vserver_client.update_volume_efficiency_attributes(
             share_name, dedup_enabled, compression_enabled, is_flexgroup=True)
 
+        if provisioning_options.get('max_files_multiplier') is not None:
+            max_files_multiplier = provisioning_options.pop(
+                'max_files_multiplier')
+            max_files = na_utils.calculate_max_files(size,
+                                                     max_files_multiplier,
+                                                     max_files)
+
         if max_files is not None:
             vserver_client.set_volume_max_files(share_name, max_files)
 
@@ -1290,6 +1298,9 @@ class NetAppCmodeFileStorageLibrary(object):
         if 'netapp:max_files' in extra_specs:
             self._check_if_max_files_is_valid(share,
                                               extra_specs['netapp:max_files'])
+        if 'netapp:max_files_multiplier' in extra_specs:
+            self._check_if_max_files_multiplier_is_valid(
+                share, extra_specs['netapp:max_files_multiplier'])
         if 'netapp:fpolicy_file_operations' in extra_specs:
             self._check_fpolicy_file_operations(
                 share, extra_specs['netapp:fpolicy_file_operations'])
@@ -1303,6 +1314,22 @@ class NetAppCmodeFileStorageLibrary(object):
             msg = _('Invalid value "%(value)s" for extra_spec "%(key)s" '
                     'in share_type %(type_id)s for share %(share_id)s.')
             raise exception.NetAppException(msg % args)
+
+    @na_utils.trace
+    def _check_if_max_files_multiplier_is_valid(self, share, value):
+        """Check if max_files_multiplier has a valid value."""
+        try:
+            if float(value) <= 0 or float(value) > 8:
+                args = {'value': value,
+                        'key': 'netapp:max_files_multiplier',
+                        'type_id': share['share_type_id'],
+                        'share_id': share['id']}
+                msg = _('Invalid value "%(value)s" for extra_spec "%(key)s" '
+                        'in share_type %(type_id)s for share %(share_id)s. '
+                        'Must be between "0" and "8".')
+                raise exception.NetAppException(msg % args)
+        except ValueError as e:
+            raise exception.InvalidInput(e)
 
     @na_utils.trace
     def _check_fpolicy_file_operations(self, share, value):
@@ -1502,6 +1529,8 @@ class NetAppCmodeFileStorageLibrary(object):
                                                 qos_specs=None):
         """Checks if provided provisioning options are valid."""
         adaptive_qos = provisioning_options.get('adaptive_qos_policy_group')
+        max_files = provisioning_options.get('max_files')
+        max_files_multiplier = provisioning_options.get('max_files_multiplier')
         replication_type = (extra_specs.get('replication_type')
                             if extra_specs else None)
         if adaptive_qos and qos_specs:
@@ -1521,6 +1550,11 @@ class NetAppCmodeFileStorageLibrary(object):
         if adaptive_qos and replication_type:
             msg = _("The extra spec 'adaptive_qos_policy_group' is not "
                     "supported by share replication feature.")
+            raise exception.NetAppException(msg)
+
+        if max_files and max_files_multiplier:
+            msg = _("Share cannot be provisioned with both 'max_files' and "
+                    "'max_files_multiplier' extra specs.")
             raise exception.NetAppException(msg)
 
         # NOTE(dviroel): This validation will need to be updated if newer
@@ -1609,6 +1643,12 @@ class NetAppCmodeFileStorageLibrary(object):
         if share['size'] > snapshot['size']:
             vserver_client.set_volume_size(share_name, share['size'],
                                            **self._volume_size_options)
+            if provisioning_options.get('max_files_multiplier') is not None:
+                max_files_multiplier = provisioning_options.pop(
+                    'max_files_multiplier')
+                max_files = na_utils.calculate_max_files(share['size'],
+                                                         max_files_multiplier)
+                vserver_client.set_volume_max_files(share_name, max_files)
 
         if hide_snapdir:
             self._apply_snapdir_visibility(
@@ -2073,6 +2113,14 @@ class NetAppCmodeFileStorageLibrary(object):
             vserver_client.modify_fpolicy_scope(
                 policy_name, shares_to_include=shares_to_include)
 
+        if provisioning_options.get('max_files_multiplier') is not None:
+            max_files_multiplier = provisioning_options.pop(
+                'max_files_multiplier')
+            max_files = na_utils.calculate_max_files(volume_size,
+                                                     max_files_multiplier)
+            vserver_client.set_volume_max_files(share_name, max_files,
+                                                retry_allocated=True)
+
         # Save original volume info to private storage.
         original_data = {
             'original_name': volume['name'],
@@ -2364,6 +2412,9 @@ class NetAppCmodeFileStorageLibrary(object):
         """Extends size of existing share."""
         vserver, vserver_client = self._get_vserver(share_server=share_server)
         share_name = self._get_backend_share_name(share['id'])
+        extra_specs = share_types.get_extra_specs_from_share(share)
+        provisioning_options = self._get_provisioning_options(extra_specs)
+
         vserver_client.set_volume_filesys_size_fixed(share_name,
                                                      filesys_size_fixed=False)
 
@@ -2371,6 +2422,13 @@ class NetAppCmodeFileStorageLibrary(object):
                   {'name': share_name, 'size': new_size})
         vserver_client.set_volume_size(share_name, new_size,
                                        **self._volume_size_options)
+
+        if provisioning_options.get('max_files_multiplier') is not None:
+            max_files_multiplier = provisioning_options.pop(
+                'max_files_multiplier')
+            max_files = na_utils.calculate_max_files(new_size,
+                                                     max_files_multiplier)
+            vserver_client.set_volume_max_files(share_name, max_files)
 
         self._adjust_qos_policy_with_volume_resize(share, new_size,
                                                    vserver_client)
@@ -2380,6 +2438,9 @@ class NetAppCmodeFileStorageLibrary(object):
         """Shrinks size of existing share."""
         vserver, vserver_client = self._get_vserver(share_server=share_server)
         share_name = self._get_backend_share_name(share['id'])
+        extra_specs = share_types.get_extra_specs_from_share(share)
+        provisioning_options = self._get_provisioning_options(extra_specs)
+
         vserver_client.set_volume_filesys_size_fixed(share_name,
                                                      filesys_size_fixed=False)
 
@@ -2401,6 +2462,14 @@ class NetAppCmodeFileStorageLibrary(object):
 
         self._adjust_qos_policy_with_volume_resize(
             share, new_size, vserver_client)
+
+        if provisioning_options.get('max_files_multiplier') is not None:
+            max_files_multiplier = provisioning_options.pop(
+                'max_files_multiplier')
+            max_files = na_utils.calculate_max_files(new_size,
+                                                     max_files_multiplier)
+            vserver_client.set_volume_max_files(share_name, max_files,
+                                                retry_allocated=True)
 
     @na_utils.trace
     def _update_access(self, helper, share, share_name, access_rules):
@@ -2496,6 +2565,13 @@ class NetAppCmodeFileStorageLibrary(object):
         except netapp_api.NaApiError:
             LOG.warning('update share %(share)s on aggregate %(aggr)s with '
                         'provisioning options %(options)s failed', modify_args)
+
+        if provisioning_options.get('max_files_multiplier') is not None:
+            max_files_multiplier = provisioning_options.pop(
+                'max_files_multiplier')
+            max_files = na_utils.calculate_max_files(share['size'],
+                                                     max_files_multiplier)
+            vserver_client.set_volume_max_files(share_name, max_files)
 
         # non-active replicas do not have export locations
         replica_state = share.get('replica_state')
@@ -2912,6 +2988,22 @@ class NetAppCmodeFileStorageLibrary(object):
                                                orig_active_replica,
                                                is_dr,
                                                share_server=share_server)
+
+        extra_specs = share_types.get_extra_specs_from_share(
+            new_active_replica)
+        provisioning_options = self._get_provisioning_options(extra_specs)
+
+        if provisioning_options.get('max_files_multiplier') is not None:
+            max_files_multiplier = provisioning_options.pop(
+                'max_files_multiplier')
+            max_files = na_utils.calculate_max_files(
+                new_active_replica['size'], max_files_multiplier)
+            new_active_replica_share_name = self._get_backend_share_name(
+                new_active_replica['id'])
+            __, vserver_client = self._get_vserver(
+                share_server=share_server)
+            vserver_client.set_volume_max_files(new_active_replica_share_name,
+                                                max_files)
 
         return new_replica_list
 

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -3485,7 +3485,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
     def test_set_volume_max_files(self):
 
-        self.mock_object(self.client, 'send_request')
+        api_response = netapp_api.NaElement(fake.VOLUME_MODIFY_ITER_RESPONSE)
+        self.mock_object(self.client,
+                         'send_request',
+                         mock.Mock(return_value=api_response))
 
         self.client.set_volume_max_files(fake.SHARE_NAME, fake.MAX_FILES)
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -1812,6 +1812,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             'adaptive_qos_policy_group': None,
             'language': None,
             'max_files': None,
+            'max_files_multiplier': None,
             'snapshot_policy': None,
             'thin_provisioned': False,
             'compression_enabled': False,
@@ -3460,6 +3461,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          '_get_vserver',
                          mock.Mock(return_value=(fake.VSERVER1,
                                                  vserver_client)))
+        self.mock_object(
+            share_types, 'get_extra_specs_from_share',
+            mock.Mock(return_value=fake.EXTRA_SPEC))
         mock_adjust_qos_policy = self.mock_object(
             self.library, '_adjust_qos_policy_with_volume_resize')
 
@@ -3486,6 +3490,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.library, '_adjust_qos_policy_with_volume_resize')
         mock_set_volume_size = self.mock_object(vserver_client,
                                                 'set_volume_size')
+        self.mock_object(share_types, 'get_extra_specs_from_share')
+        self.mock_object(self.library, '_get_provisioning_options',
+                         mock.Mock(return_value={}))
         new_size = fake.SHARE['size'] - 1
 
         self.library.shrink_share(fake.SHARE, new_size)
@@ -3509,6 +3516,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         mock_set_volume_size = self.mock_object(
             vserver_client, 'set_volume_size', naapi_error)
+        self.mock_object(share_types, 'get_extra_specs_from_share')
+        self.mock_object(self.library, '_get_provisioning_options',
+                         mock.Mock(return_value={}))
 
         new_size = fake.SHARE['size'] - 1
 
@@ -4413,6 +4423,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_is_flexgroup_pool',
                          mock.Mock(return_value=False))
+        self.mock_object(share_types, 'get_extra_specs_from_share')
+        self.mock_object(self.library, '_get_provisioning_options',
+                         mock.Mock(return_value={}))
 
         mock_dm_session = mock.Mock()
         self.mock_object(data_motion, "DataMotionSession",
@@ -4496,6 +4509,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(
             protocol_helper, 'cleanup_demoted_replica',
             mock.Mock(side_effect=exception.StorageCommunicationException))
+        self.mock_object(share_types, 'get_extra_specs_from_share')
+        self.mock_object(self.library, '_get_provisioning_options',
+                         mock.Mock(return_value={}))
         mock_log = self.mock_object(lib_base.LOG, 'exception')
 
         self.library.promote_replica(
@@ -4526,6 +4542,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(
             self.library, '_convert_destination_replica_to_independent',
             mock.Mock(side_effect=exception.StorageCommunicationException))
+        self.mock_object(share_types, 'get_extra_specs_from_share')
+        self.mock_object(self.library, '_get_provisioning_options',
+                         mock.Mock(return_value={}))
 
         replicas = self.library.promote_replica(
             None, [self.fake_replica, self.fake_replica_2],
@@ -4569,6 +4588,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))
+        self.mock_object(share_types, 'get_extra_specs_from_share')
+        self.mock_object(self.library, '_get_provisioning_options',
+                         mock.Mock(return_value={}))
 
         replicas = self.library.promote_replica(
             None, [self.fake_replica, self.fake_replica_2, fake_replica_3],
@@ -4625,6 +4647,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))
+        self.mock_object(share_types, 'get_extra_specs_from_share')
+        self.mock_object(self.library, '_get_provisioning_options',
+                         mock.Mock(return_value={}))
 
         replicas = self.library.promote_replica(
             None, [self.fake_replica, self.fake_replica_2],
@@ -4852,6 +4877,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))
+        self.mock_object(share_types, 'get_extra_specs_from_share')
+        self.mock_object(self.library, '_get_provisioning_options',
+                         mock.Mock(return_value={}))
         replicas = self.library.promote_replica(
             None, [self.fake_replica, self.fake_replica_2],
             self.fake_replica_2, fake_access_rules, share_server=None)
@@ -6654,6 +6682,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             id='src-snapshot', provider_location='test-src-provider-location')
         dest_snap = fake_share.fake_snapshot_instance(id='dest-snapshot',
                                                       as_primitive=True)
+        extra_specs = copy.deepcopy(fake.EXTRA_SPEC)
         source_snapshots = [snap]
         snapshot_mappings = {snap['id']: dest_snap}
         self.library.configuration.netapp_volume_move_cutover_timeout = 15
@@ -6680,7 +6709,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.library, '_get_volume_move_status',
             mock.Mock(side_effect=vol_move_side_effects))
         self.mock_object(share_types, 'get_extra_specs_from_share',
-                         mock.Mock(return_value=fake.EXTRA_SPEC))
+                         mock.Mock(return_value=extra_specs))
         self.mock_object(self.library, '_check_fpolicy_file_operations')
         self.mock_object(
             self.library, '_get_provisioning_options',

--- a/manila/tests/share/drivers/netapp/dataontap/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/fakes.py
@@ -361,6 +361,7 @@ PROVISIONING_OPTIONS_STRING = {
     'snapshot_policy': 'default',
     'language': 'en-US',
     'max_files': 5000,
+    'max_files_multiplier': 4.2,
     'adaptive_qos_policy_group': None,
     'fpolicy_extensions_to_exclude': None,
     'fpolicy_extensions_to_include': None,
@@ -371,6 +372,7 @@ PROVISIONING_OPTIONS_STRING_MISSING_SPECS = {
     'snapshot_policy': 'default',
     'language': 'en-US',
     'max_files': None,
+    'max_files_multiplier': None,
     'adaptive_qos_policy_group': None,
     'fpolicy_extensions_to_exclude': None,
     'fpolicy_extensions_to_include': None,
@@ -381,6 +383,7 @@ PROVISIONING_OPTIONS_STRING_DEFAULT = {
     'snapshot_policy': None,
     'language': None,
     'max_files': None,
+    'max_files_multiplier': None,
     'adaptive_qos_policy_group': None,
     'fpolicy_extensions_to_exclude': None,
     'fpolicy_extensions_to_include': None,
@@ -395,6 +398,7 @@ STRING_EXTRA_SPEC = {
     'netapp:snapshot_policy': 'default',
     'netapp:language': 'en-US',
     'netapp:max_files': 5000,
+    'netapp:max_files_multiplier': 4.2,
     'netapp:adaptive_qos_policy_group': None,
 }
 


### PR DESCRIPTION
NetApp Driver: Specify how much inodes (files) should be possible at
maximum depending on volume (share) size.

Possible multipliers are between (0,8].
The default is somewhere around 1 -  meaning, you get 1 inode for each
32 KiB inside a volume - e.g. a 32 GiB share would be allowed to hold
1024*1024 files.
The maximum multiplier 8 is derived from the example table in TR-4617.

Increasing this value, means increasing the max inode count.
E.g. setting max_files_multiplier to 4 would mean you get 1 inode
already for each 8 KiB inside a volume - a 32 GiB share would then
hold 4*1024*1024 files.

Extending volume size will directly proportional increase the inode
count up to the NetApp absolute maximum of around 2 billion files
in a volumes. TR-4617:
"An inode in ONTAP is a pointer to any file or folder within the
file system, including Snapshot copies. Each FlexVol volume has a
finite number of inodes and has an absolute maximum of 2,040,109,451
inodes."

Shrinking volume size will decrease the inode count. TR-4617:
"Inodes can be increased after a FlexVol volume has been created and
can be decreased only to a number that has not already been allocated."
If the allocated inode count is higher than the calculated number
depending on the new size it will only be decreased to that count.


Just coded away

- [x] qa tests with check `files` on netapp
  - [x] create a NFS share
  - [x] create a CIFS share
  - [x] extend share
  - [x] shrink share
  - [x] create a snapshot + share from snapshot
  - [x] create a replica 
  - [x] migrate share
  - [x] run tempest with changed default type
- [x] improve to also work for update_share to modify existing volumes

Out of scope: flexgroup volumes + share groups, manila manage (i.e. import share), edge cases: setting to 7.599999 may result in errors, because the calculation is not documented exactly (i.e. calculation here does not exactly reflect tables in TR-4617)