### PR TITLE
ccloud: fix missing share type name in share_instance dict

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -4932,6 +4932,12 @@ class ShareManager(manager.SchedulerDependentManager):
         if share_instance_ref.get('share_type'):
             share_instance_ref['share_type_name'] = share_instance_ref.get(
                 'share_type').get('name')
+        else:
+            if share_instance.get('share_type_id'):
+                share_type = share_types.get_share_type(
+                    context, share_instance.get('share_type_id'))
+                share_instance_ref['share_type_name'] = share_type.get('name')
+
         if share_instance_ref['share_server']:
             share_instance_ref['share_server'] = self._get_share_server_dict(
                 context, share_instance_ref['share_server']

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -7427,6 +7427,7 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(
             self.share_manager, '_get_share_server',
             mock.Mock(return_value=None))
+        self.mock_object(share_types, 'get_share_type', mock.Mock())
         self.mock_object(
             db, 'share_replicas_get_all_by_share',
             mock.Mock(return_value=replicas))


### PR DESCRIPTION
is required to get it into volume comment

Change-Id: I657c19a74eb561f441dc6749210bfa906687a002