### PR TITLE
ccloud: ensure max_files but allow backend overwrite

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2337,8 +2337,28 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
     @na_utils.trace
     def set_volume_max_files(self, volume_name, max_files,
-                             retry_allocated=False):
+                             retry_allocated=True, allow_decrease=False):
         """Set flexvol file limit."""
+        if not allow_decrease:
+            alloc_files = self.get_volume_allocated_files(volume_name)
+            current_max_files = alloc_files['max']
+            """
+            '13', because netapp is setting less than you request:
+            vol modify -vserver ma_1 -volume share_1 -files 149771
+
+            vol show share_1 -fields files
+            vserver volume  files
+            ------- ------- ------
+            ma_1    share_1 149758
+            """
+            if (int(current_max_files) + 13) >= max_files:
+                """
+                Do nothing in case max files is already set to a value
+                that is higher or the same like the one requested.
+                Higher can happen due to manual overwrite on the backend
+                """
+                return
+
         api_args = {
             'query': {
                 'volume-attributes': {
@@ -2373,13 +2393,20 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                         if new_max_files == alloc_files['max']:
                             return
 
-                        msg = _('Set higher max files %(new_max_files)s '
-                                'on %(vol)s. The current allocated inodes '
-                                'are larger than requested %(max_files)s.')
+                        msg = _('Set current allocated inodes to max files '
+                                '%(new_max_files)s on %(vol)s. Requested was '
+                                '%(max_files)s.')
                         msg_args = {'vol': volume_name,
                                     'max_files': max_files,
                                     'new_max_files': new_max_files}
-                        LOG.info(msg, msg_args)
+
+                        if int(new_max_files) <= max_files:
+                            raise netapp_api.NaApiError(
+                                error_code,
+                                errors[0].get_child_content('error-message'))
+                        else:
+                            LOG.info(msg, msg_args)
+
                         self.set_volume_max_files(volume_name, new_max_files,
                                                   retry_allocated=False)
                 else:

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -2116,8 +2116,7 @@ class NetAppCmodeFileStorageLibrary(object):
                 'max_files_multiplier')
             max_files = na_utils.calculate_max_files(volume_size,
                                                      max_files_multiplier)
-            vserver_client.set_volume_max_files(share_name, max_files,
-                                                retry_allocated=True)
+            vserver_client.set_volume_max_files(share_name, max_files)
 
         # Save original volume info to private storage.
         original_data = {
@@ -2467,7 +2466,7 @@ class NetAppCmodeFileStorageLibrary(object):
             max_files = na_utils.calculate_max_files(new_size,
                                                      max_files_multiplier)
             vserver_client.set_volume_max_files(share_name, max_files,
-                                                retry_allocated=True)
+                                                allow_decrease=True)
 
     @na_utils.trace
     def _update_access(self, helper, share, share_name, access_rules):

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -3492,7 +3492,9 @@ class NetAppClientCmodeTestCase(test.TestCase):
                          'send_request',
                          mock.Mock(return_value=api_response))
 
-        self.client.set_volume_max_files(fake.SHARE_NAME, fake.MAX_FILES)
+        self.client.set_volume_max_files(fake.SHARE_NAME, fake.MAX_FILES,
+                                         retry_allocated=False,
+                                         allow_decrease=True)
 
         volume_modify_iter_api_args = {
             'query': {


### PR DESCRIPTION
only shrink share is expected to decrease max_files.
This is flawed in a way: setting max_files_multiplier to < 1
may not work as intended in this case.

Change-Id: I94215b212ceccdba151e64cb38db9f26f7fbc1d2