### PR TITLE
ccloud: do not touch nfs v4.0 if it has not been enabled

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1520,12 +1520,10 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def _enable_nfs_protocols(self, versions):
         """Set the enabled NFS protocol versions."""
         nfs3 = 'true' if 'nfs3' in versions else 'false'
-        nfs40 = 'true' if 'nfs4.0' in versions else 'false'
         nfs41 = 'true' if 'nfs4.1' in versions else 'false'
 
         nfs_service_modify_args = {
             'is-nfsv3-enabled': nfs3,
-            'is-nfsv40-enabled': nfs40,
             'is-nfsv41-enabled': nfs41,
             'showmount': 'true',
             'is-v3-ms-dos-client-enabled': 'true',
@@ -1533,6 +1531,10 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'enable-ejukebox': 'false',
             'is-vstorage-enabled': 'true',
         }
+
+        if 'nfs4.0' in versions:
+            nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
+
         self.send_request('nfs-service-modify', nfs_service_modify_args)
 
     @na_utils.trace

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -2505,7 +2505,6 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
         nfs_service_modify_args = {
             'is-nfsv3-enabled': 'true' if v3 else 'false',
-            'is-nfsv40-enabled': 'true' if v40 else 'false',
             'is-nfsv41-enabled': 'true' if v41 else 'false',
             'showmount': 'true',
             'is-v3-ms-dos-client-enabled': 'true',
@@ -2513,6 +2512,9 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'enable-ejukebox': 'false',
             'is-vstorage-enabled': 'true',
         }
+        if v40:
+            nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
+
         self.client.send_request.assert_called_once_with(
             'nfs-service-modify', nfs_service_modify_args)
 


### PR DESCRIPTION
keeps existing setting on update, uses default on new vservers

Change-Id: I43cbe288fd72af40d630abba0c351c7317667065