### PR TITLE
create replica: allow to specify uuid

### DIFF
--- a/manila/db/api.py
+++ b/manila/db/api.py
@@ -375,6 +375,11 @@ def share_instances_get_all_by_share_group_id(context, share_group_id):
     return IMPL.share_instances_get_all_by_share_group_id(
         context, share_group_id)
 
+
+def share_instance_purge(context, instance_id):
+    """Removes share instance from database."""
+    return IMPL.share_instance_purge(context, instance_id)
+
 ###################
 
 

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -527,7 +527,8 @@ class API(base.Base):
             self, context, share, availability_zone=None,
             share_group=None, host=None, share_network_id=None,
             share_type_id=None, cast_rules_to_readonly=False,
-            availability_zones=None, snapshot_host=None):
+            availability_zones=None, snapshot_host=None,
+            share_instance_id=None):
 
         availability_zone_id = None
         if availability_zone:
@@ -540,6 +541,7 @@ class API(base.Base):
         share_instance = self.db.share_instance_create(
             context, share['id'],
             {
+                'id': share_instance_id if context.is_admin else None,
                 'share_network_id': share_network_id,
                 'status': constants.STATUS_CREATING,
                 'scheduled_at': timeutils.utcnow(),
@@ -604,7 +606,7 @@ class API(base.Base):
 
     def create_share_replica(self, context, share, availability_zone=None,
                              share_network_id=None,
-                             scheduler_hints=None):
+                             scheduler_hints=None, replica_id=None):
 
         if not share.get('replication_type'):
             msg = _("Replication not supported for share %s.")
@@ -694,7 +696,7 @@ class API(base.Base):
                     share_network_id=share_network_id,
                     share_type_id=share['instance']['share_type_id'],
                     cast_rules_to_readonly=cast_rules_to_readonly,
-                    availability_zones=type_azs)
+                    availability_zones=type_azs, share_instance_id=replica_id)
             )
             QUOTAS.commit(
                 context, reservations, project_id=share['project_id'],

--- a/manila/tests/share/test_api.py
+++ b/manila/tests/share/test_api.py
@@ -966,6 +966,7 @@ class ShareAPITestCase(test.TestCase):
         db_api.share_instance_create.assert_called_once_with(
             self.context, share['id'],
             {
+                'id': None,
                 'share_network_id': None,
                 'status': constants.STATUS_CREATING,
                 'scheduled_at': self.dt_utc,
@@ -3839,7 +3840,8 @@ class ShareAPITestCase(test.TestCase):
              self.context, share, availability_zone=None,
              share_network_id=share_network_id, share_type_id=share_type['id'],
              availability_zones=expected_azs,
-             cast_rules_to_readonly=cast_rules_to_readonly))
+             cast_rules_to_readonly=cast_rules_to_readonly,
+             share_instance_id=None))
         db_api.share_replica_update.assert_called_once()
         mock_snapshot_get_all_call.assert_called_once()
         mock_sched_rpcapi_call.assert_called_once()
@@ -3966,7 +3968,8 @@ class ShareAPITestCase(test.TestCase):
              self.context, share, availability_zone='FAKE_AZ',
              share_network_id=share_network_id, share_type_id=share_type['id'],
              availability_zones=expected_azs,
-             cast_rules_to_readonly=cast_rules_to_readonly))
+             cast_rules_to_readonly=cast_rules_to_readonly,
+             share_instance_id=None))
 
     def test_delete_last_active_replica(self):
         fake_replica = fakes.fake_replica(
@@ -4203,7 +4206,8 @@ class ShareAPITestCase(test.TestCase):
                                  share_network_id=share_network_id,
                                  share_type_id=share_type['id'],
                                  availability_zones=expected_azs,
-                                 cast_rules_to_readonly=False))
+                                 cast_rules_to_readonly=False,
+                                 share_instance_id=None))
 
     def test_migration_complete(self):
 


### PR DESCRIPTION
If soft-deleted share instance with that uuid is still existing,
purge it.

Allows to re-create replicas, that were in unrecoverable error state.
Only for context.is_admin.