### PR TITLE
Dedupe and logical space reporting

### DIFF
--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -484,6 +484,9 @@ class API(base.Base):
                 availability_zones=availability_zones,
                 snapshot_host=snapshot_host))
 
+        # SAPCC add project_domain_name in request_spec and pass to driver
+        request_spec['project_domain_name'] = context.project_domain_name
+
         if share_group_snapshot_member:
             # Inherit properties from the share_group_snapshot_member
             member_share_instance = share_group_snapshot_member[

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2188,7 +2188,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                       compression_enabled=False, max_files=None,
                       snapshot_reserve=None, volume_type='rw', comment='',
                       qos_policy_group=None, adaptive_qos_policy_group=None,
-                      encrypt=None, **options):
+                      encrypt=None, logical_space_reporting=None, **options):
         """Creates a volume."""
         if adaptive_qos_policy_group and not self.features.ADAPTIVE_QOS:
             msg = 'Adaptive QoS not supported on this backend ONTAP version.'
@@ -2198,10 +2198,11 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'containing-aggr-name': aggregate_name,
             'volume': volume_name,
         }
-        api_args.update(self._get_create_volume_api_args(
-            volume_name, thin_provisioned, snapshot_policy, language,
-            snapshot_reserve, volume_type, comment, qos_policy_group, encrypt,
-            adaptive_qos_policy_group))
+        api_args.update(
+            self._get_create_volume_api_args(
+                volume_name, thin_provisioned, snapshot_policy, language,
+                snapshot_reserve, volume_type, comment, qos_policy_group,
+                encrypt, adaptive_qos_policy_group, logical_space_reporting))
 
         if (options.get('provision_net_capacity') and
                 snapshot_reserve is not None):
@@ -2238,7 +2239,9 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                             volume_type='rw', comment=None,
                             qos_policy_group=None, encrypt=False,
                             adaptive_qos_policy_group=None,
-                            auto_provisioned=False, **options):
+                            auto_provisioned=False,
+                            logical_space_reporting=None,
+                            **options):
         """Creates a volume asynchronously."""
 
         if adaptive_qos_policy_group and not self.features.ADAPTIVE_QOS:
@@ -2256,7 +2259,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         api_args.update(self._get_create_volume_api_args(
             volume_name, thin_provisioned, snapshot_policy, language,
             snapshot_reserve, volume_type, comment, qos_policy_group, encrypt,
-            adaptive_qos_policy_group))
+            adaptive_qos_policy_group, logical_space_reporting))
 
         if (options.get('provision_net_capacity') and
                 snapshot_reserve is not None):
@@ -2284,7 +2287,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                                     snapshot_policy, language,
                                     snapshot_reserve, volume_type, comment,
                                     qos_policy_group, encrypt,
-                                    adaptive_qos_policy_group):
+                                    adaptive_qos_policy_group,
+                                    logical_space_reporting):
         api_args = {
             'volume-type': volume_type,
             'volume-comment': comment,
@@ -2315,6 +2319,12 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 api_args['encrypt'] = 'true'
             else:
                 api_args['encrypt'] = 'false'
+
+        # SAPCC If logical_space_reporting is not set, the settings are
+        # contrlled by parent share server
+        if logical_space_reporting in (True, False):
+            api_args['is-space-reporting-logical'] = logical_space_reporting
+            api_args['is-space-enforcement-logical'] = logical_space_reporting
 
         return api_args
 
@@ -2653,7 +2663,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                       compression_enabled=False, max_files=None,
                       qos_policy_group=None, hide_snapdir=None,
                       autosize_attributes=None, comment=None, replica=False,
-                      adaptive_qos_policy_group=None, **options):
+                      adaptive_qos_policy_group=None,
+                      logical_space_reporting=None, **options):
         """Update backend volume for a share as necessary.
 
         :param aggregate_name: either a list or a string. List for aggregate
@@ -2740,6 +2751,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             api_args['attributes']['volume-attributes'][
                 'volume-id-attributes'][
                     'comment'] = comment
+
+        # SAPCC If logical_space_reporting not set, the settings is controlled
+        # by the parent vserver.
+        if logical_space_reporting in (True, False):
+            api_args['attributes']['volume-attributes'][
+                'volume-space-attributes'][
+                'is-space-reporting-logical'] = logical_space_reporting
+            api_args['attributes']['volume-attributes'][
+                'volume-space-attributes'][
+                'is-space-enforcement-logical'] = logical_space_reporting
 
         self.send_request('volume-modify-iter', api_args)
 
@@ -3065,6 +3086,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                     },
                     'volume-space-attributes': {
                         'size': None,
+                        'is-space-enforcement-logical': None,
+                        'is-space-reporting-logical': None,
                     },
                 },
             },
@@ -3115,7 +3138,13 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'qos-policy-group-name': volume_qos_attributes.get_child_content(
                 'policy-group-name'),
             'style-extended': volume_id_attributes.get_child_content(
-                'style-extended')
+                'style-extended'),
+            'is-space-reporting-logical': (
+                volume_space_attributes.get_child_content(
+                    'is-space-reporting-logical')),
+            'is-space-enforcement-logical': (
+                volume_space_attributes.get_child_content(
+                    'is-space-enforcement-logical'))
         }
         return volume
 

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2158,6 +2158,12 @@ class ShareManager(manager.SchedulerDependentManager):
                             "mandatory for protocol %s.") %
                             share_instance.get('share_proto'))
 
+        # SAPCC If project_domain_name is not in the context, get it from
+        # request_spec
+        if context.project_domain_name is None and request_spec:
+            context.project_domain_name = request_spec.get(
+                'project_domain_name')
+
         status = constants.STATUS_AVAILABLE
         try:
             if snapshot_ref:

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -3143,7 +3143,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
         self.client._get_create_volume_api_args.assert_called_once_with(
             fake.SHARE_NAME, False, None, None, None,
-            'rw', '', None, None, None)
+            'rw', '', None, None, None, None)
         self.client.send_request.assert_called_with('volume-create',
                                                     volume_create_args)
         (self.client.update_volume_efficiency_attributes.
@@ -3198,7 +3198,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
         self.client._get_create_volume_api_args.assert_called_once_with(
             fake.SHARE_NAME, False, None, None, None, 'rw', None, None,
-            False, None)
+            False, None, None)
         self.client.send_request.assert_called_with('volume-create-async',
                                                     volume_create_args)
         self.assertEqual(expected_result, result)
@@ -3226,11 +3226,12 @@ class NetAppClientCmodeTestCase(test.TestCase):
         qos_name = 'fake_qos'
         encrypt = True
         qos_adaptive_name = 'fake_adaptive_qos'
+        logical_space_reporting = False
 
         result_api_args = self.client._get_create_volume_api_args(
             fake.SHARE_NAME, thin_provisioned, snapshot_policy, language,
             reserve, volume_type, fake.VOLUME_COMMENT, qos_name, encrypt,
-            qos_adaptive_name)
+            qos_adaptive_name, logical_space_reporting)
 
         expected_api_args = {
             'volume-type': volume_type,
@@ -3243,6 +3244,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'qos-policy-group-name': qos_name,
             'qos-adaptive-policy-group-name': qos_adaptive_name,
             'encrypt': 'true',
+            'is-space-enforcement-logical': False,
+            'is-space-reporting-logical': False,
         }
         self.assertEqual(expected_api_args, result_api_args)
 
@@ -3258,16 +3261,19 @@ class NetAppClientCmodeTestCase(test.TestCase):
         encrypt = False
         qos_adaptive_name = None
         volume_comment = None
+        logical_space_reporting = False
 
         result_api_args = self.client._get_create_volume_api_args(
             fake.SHARE_NAME, thin_provisioned, snapshot_policy, language,
             reserve, volume_type, volume_comment, qos_name, encrypt,
-            qos_adaptive_name)
+            qos_adaptive_name, logical_space_reporting)
 
         expected_api_args = {
             'encrypt': 'false',
             'volume-type': volume_type,
             'volume-comment': volume_comment,
+            'is-space-enforcement-logical': False,
+            'is-space-reporting-logical': False,
         }
         self.assertEqual(expected_api_args, result_api_args)
 
@@ -3278,7 +3284,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
                           self.client._get_create_volume_api_args,
                           fake.SHARE_NAME, True, 'default', 'en-US',
                           15, 'rw', 'fake_comment', 'fake_qos',
-                          encrypt, 'fake_qos_adaptive')
+                          encrypt, 'fake_qos_adaptive', False)
 
     def test_is_flexvol_encrypted_unsupported(self):
 
@@ -4222,6 +4228,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                     },
                     'volume-space-attributes': {
                         'size': None,
+                        'is-space-enforcement-logical': None,
+                        'is-space-reporting-logical': None
                     },
                     'volume-qos-attributes': {
                         'policy-group-name': None,
@@ -4237,6 +4245,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'name': fake.SHARE_NAME,
             'type': 'rw',
             'style': 'flex',
+            'is-space-enforcement-logical': None,
+            'is-space-reporting-logical': None,
             'size': fake.SHARE_SIZE,
             'owning-vserver-name': fake.VSERVER_NAME,
             'qos-policy-group-name': fake.QOS_POLICY_GROUP_NAME,
@@ -4281,6 +4291,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                     },
                     'volume-space-attributes': {
                         'size': None,
+                        'is-space-enforcement-logical': None,
+                        'is-space-reporting-logical': None
                     },
                     'volume-qos-attributes': {
                         'policy-group-name': None,
@@ -4292,6 +4304,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
         expected = {
             'aggregate': fake.SHARE_AGGREGATE_NAME,
             'aggr-list': [],
+            'is-space-enforcement-logical': None,
+            'is-space-reporting-logical': None,
             'junction-path': '/%s' % fake.SHARE_NAME,
             'name': fake.SHARE_NAME,
             'type': 'rw',

--- a/manila/tests/share/drivers/netapp/dataontap/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/fakes.py
@@ -318,6 +318,7 @@ PROVISIONING_OPTIONS = {
     'encrypt': False,
     'hide_snapdir': False,
     'adaptive_qos_policy_group': None,
+    'logical_space_reporting': False,
 }
 
 PROVISIONING_OPTIONS_WITH_QOS = copy.deepcopy(PROVISIONING_OPTIONS)


### PR DESCRIPTION
- For all projects enable logical space reporting
- For neo set efficiency policy to 'inline-only' and disable cross-volume-dedupe
- For share replica, share from snapshot, share modify(extend/shrink) retain behaviour parent share.