### PR TITLE
Adds support max share extend size limited by share_type

### DIFF
--- a/doc/source/admin/capabilities_and_extra_specs.rst
+++ b/doc/source/admin/capabilities_and_extra_specs.rst
@@ -267,3 +267,8 @@ Share type common capability extra-specs that are not visible to end users:
   must be an integer and greater than 0. If administrators set this capability
   as an extra-spec in a share type, the size of share created with the share
   type can not be less than the specified value.
+
+* **provisioning:max_share_extend_size** can set the max size of share extend,
+  the value must be an integer and greater than 0. If administrators set this
+  capability as an extra-spec in a share type, the size of share extended with
+  the share type can not be greater than the specified value.

--- a/manila/api/openstack/api_version_request.py
+++ b/manila/api/openstack/api_version_request.py
@@ -172,6 +172,7 @@ REST_API_VERSION_HISTORY = """
              'update_security_service', 'update_security_service_check' and
              'add_security_service_check'.
     * 2.65 - Added ability to set scheduler hints via the share create API.
+             Added optional provisioning:max_share_extend_size
 """
 
 # The minimum and maximum versions of the API supported

--- a/manila/common/constants.py
+++ b/manila/common/constants.py
@@ -253,6 +253,7 @@ class ExtraSpecs(object):
     AVAILABILITY_ZONES = "availability_zones"
     PROVISIONING_MAX_SHARE_SIZE = "provisioning:max_share_size"
     PROVISIONING_MIN_SHARE_SIZE = "provisioning:min_share_size"
+    PROVISIONING_MAX_SHARE_EXTEND_SIZE = "provisioning:max_share_extend_size"
 
     # Extra specs containers
     REQUIRED = (
@@ -267,7 +268,8 @@ class ExtraSpecs(object):
         MOUNT_SNAPSHOT_SUPPORT,
         AVAILABILITY_ZONES,
         PROVISIONING_MAX_SHARE_SIZE,
-        PROVISIONING_MIN_SHARE_SIZE
+        PROVISIONING_MIN_SHARE_SIZE,
+        PROVISIONING_MAX_SHARE_EXTEND_SIZE,
     )
 
     # NOTE(cknight): Some extra specs are necessary parts of the Manila API and

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -2265,7 +2265,8 @@ class API(base.Base):
                 context, share['instance']['share_type_id'])
         except (exception.InvalidShareType, exception.ShareTypeNotFound):
             share_type = None
-        share_types.provision_filter_on_size(context, share_type, new_size)
+        if not context.is_admin:
+            share_types.provision_filter_on_size(context, share_type, new_size)
 
         replicas = self.db.share_replicas_get_all_by_share(
             context, share['id'])

--- a/manila/share/share_types.py
+++ b/manila/share/share_types.py
@@ -36,6 +36,7 @@ LOG = log.getLogger(__name__)
 
 MIN_SIZE_KEY = "provisioning:min_share_size"
 MAX_SIZE_KEY = "provisioning:max_share_size"
+MAX_EXTEND_SIZE_KEY = "provisioning:max_share_extend_size"
 
 
 def create(context, name, extra_specs=None, is_public=True,
@@ -355,7 +356,8 @@ def is_valid_optional_extra_spec(key, value):
     elif key == constants.ExtraSpecs.AVAILABILITY_ZONES:
         return is_valid_csv(value)
     elif key in [constants.ExtraSpecs.PROVISIONING_MAX_SHARE_SIZE,
-                 constants.ExtraSpecs.PROVISIONING_MIN_SHARE_SIZE]:
+                 constants.ExtraSpecs.PROVISIONING_MIN_SHARE_SIZE,
+                 constants.ExtraSpecs.PROVISIONING_MAX_SHARE_EXTEND_SIZE]:
         try:
             common.validate_integer(value, 'share_size', min_value=1)
             return True
@@ -458,5 +460,14 @@ def provision_filter_on_size(context, share_type, size):
                     "greater than the maximum allowable size of "
                     "'%(max_size)s' for share type '%(sha_type)s'."
                     ) % {'req_size': size_int, 'max_size': max_size,
+                         'sha_type': share_type['name']}
+            raise exception.InvalidInput(reason=msg)
+        max_extend_size = extra_specs.get(MAX_EXTEND_SIZE_KEY)
+        if max_extend_size and size_int > int(max_extend_size):
+            msg = _("Specified share size of '%(req_size)d' is "
+                    "greater than the maximum allowable extend size of "
+                    "'%(max_extend_size)s' for share type '%(sha_type)s'."
+                    ) % {'req_size': size_int,
+                         'max_extend_size': max_extend_size,
                          'sha_type': share_type['name']}
             raise exception.InvalidInput(reason=msg)

--- a/manila/tests/share/test_api.py
+++ b/manila/tests/share/test_api.py
@@ -127,7 +127,8 @@ class ShareAPITestCase(test.TestCase):
     def _setup_sized_share_types(self):
         """create a share type with size limit"""
         spec_dict = {share_types.MIN_SIZE_KEY: 2,
-                     share_types.MAX_SIZE_KEY: 4}
+                     share_types.MAX_SIZE_KEY: 4,
+                     share_types.MAX_EXTEND_SIZE_KEY: 6}
         db_utils.create_share_type(name='limit', extra_specs=spec_dict)
         self.sized_sha_type = db_api.share_type_get_by_name(self.context,
                                                             'limit')
@@ -2888,14 +2889,15 @@ class ShareAPITestCase(test.TestCase):
                           self.api.extend, self.context, share, new_size)
 
     def test_extend_with_share_type_size_limit(self):
+        ctx = context.RequestContext('fake_uid', 'fake_pid_1', is_admin=False)
         share = db_utils.create_share(status=constants.STATUS_AVAILABLE,
                                       size=3)
         self.mock_object(share_types, 'get_share_type',
                          mock.Mock(return_value=self.sized_sha_type))
-        new_size = 5
+        new_size = 7
 
         self.assertRaises(exception.InvalidInput,
-                          self.api.extend, self.context,
+                          self.api.extend, ctx,
                           share, new_size)
 
     def _setup_extend_mocks(self, supports_replication):

--- a/manila/tests/share/test_share_types.py
+++ b/manila/tests/share/test_share_types.py
@@ -549,6 +549,11 @@ class ShareTypesTestCase(test.TestCase):
                                share_types.MAX_SIZE_KEY: "99",
                                "key4": "val4",
                                "driver_handles_share_servers": False})
+        share_types.create(self.context, "type5",
+                           extra_specs={
+                               share_types.MAX_EXTEND_SIZE_KEY: "99",
+                               "key4": "val4",
+                               "driver_handles_share_servers": False})
 
         # Make sure we don't raise if there are no min/max set
         type1 = share_types.get_share_type_by_name(self.context, 'type1')
@@ -581,3 +586,11 @@ class ShareTypesTestCase(test.TestCase):
         share_types.provision_filter_on_size(self.context, type4, "24")
         share_types.provision_filter_on_size(self.context, type4, "99")
         share_types.provision_filter_on_size(self.context, type4, "30")
+
+        # verify max extend size requirements
+        type5 = share_types.get_share_type_by_name(self.context, 'type5')
+        self.assertRaises(exception.InvalidInput,
+                          share_types.provision_filter_on_size,
+                          self.context, type5, "100")
+        share_types.provision_filter_on_size(self.context, type5, "99")
+        share_types.provision_filter_on_size(self.context, type5, "1")


### PR DESCRIPTION
Allows set max share extend size that can be created in
extra_specs for each share_type.the share size will
be checked at API level as part of share extend. New
extra_specs keys are supported for set max extend size
of share. 'provisioning:max_share_extend_size'