### PR TITLE
ccloud: Enable logical space reporting for new shares

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2800,7 +2800,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             else:
                 self.disable_compression(volume_name)
 
-    def update_volume_space_attributes(self, volume_name, logical_space_reporting):
+    def update_volume_space_attributes(self, volume_name,
+                                       logical_space_reporting):
         api_args = {
             'query': {
                 'volume-attributes': {
@@ -2812,8 +2813,10 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'attributes': {
                 'volume-attributes': {
                     'volume-space-attributes': {
-                        'is-space-reporting-logical': logical_space_reporting,
-                        'is-space-enforcement-logical': logical_space_reporting,
+                        'is-space-reporting-logical':
+                            logical_space_reporting,
+                        'is-space-enforcement-logical':
+                            logical_space_reporting,
                     },
                 },
             },

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2188,7 +2188,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                       compression_enabled=False, max_files=None,
                       snapshot_reserve=None, volume_type='rw', comment='',
                       qos_policy_group=None, adaptive_qos_policy_group=None,
-                      encrypt=None, **options):
+                      encrypt=None, logical_space_reporting=None, **options):
         """Creates a volume."""
         if adaptive_qos_policy_group and not self.features.ADAPTIVE_QOS:
             msg = 'Adaptive QoS not supported on this backend ONTAP version.'
@@ -2201,7 +2201,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         api_args.update(self._get_create_volume_api_args(
             volume_name, thin_provisioned, snapshot_policy, language,
             snapshot_reserve, volume_type, comment, qos_policy_group, encrypt,
-            adaptive_qos_policy_group))
+            adaptive_qos_policy_group, logical_space_reporting))
 
         if (options.get('provision_net_capacity') and
                 snapshot_reserve is not None):
@@ -2238,7 +2238,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                             volume_type='rw', comment=None,
                             qos_policy_group=None, encrypt=False,
                             adaptive_qos_policy_group=None,
-                            auto_provisioned=False, **options):
+                            auto_provisioned=False,
+                            logical_space_reporting=None, **options):
         """Creates a volume asynchronously."""
 
         if adaptive_qos_policy_group and not self.features.ADAPTIVE_QOS:
@@ -2256,7 +2257,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         api_args.update(self._get_create_volume_api_args(
             volume_name, thin_provisioned, snapshot_policy, language,
             snapshot_reserve, volume_type, comment, qos_policy_group, encrypt,
-            adaptive_qos_policy_group))
+            adaptive_qos_policy_group, logical_space_reporting))
 
         if (options.get('provision_net_capacity') and
                 snapshot_reserve is not None):
@@ -2284,7 +2285,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                                     snapshot_policy, language,
                                     snapshot_reserve, volume_type, comment,
                                     qos_policy_group, encrypt,
-                                    adaptive_qos_policy_group):
+                                    adaptive_qos_policy_group,
+                                    logical_space_reporting):
         api_args = {
             'volume-type': volume_type,
             'volume-comment': comment,
@@ -2315,6 +2317,12 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 api_args['encrypt'] = 'true'
             else:
                 api_args['encrypt'] = 'false'
+
+        # SAPCC Ignore when logical_space_reporting is None. The attribue
+        # will be the same of its parent vserver.
+        if logical_space_reporting in (True, False):
+            api_args['is-space-reporting-logical'] = logical_space_reporting
+            api_args['is-space-enforcement-logical'] = logical_space_reporting
 
         return api_args
 
@@ -2653,7 +2661,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                       compression_enabled=False, max_files=None,
                       qos_policy_group=None, hide_snapdir=None,
                       autosize_attributes=None, comment=None, replica=False,
-                      adaptive_qos_policy_group=None, **options):
+                      adaptive_qos_policy_group=None,
+                      logical_space_reporting=None, **options):
         """Update backend volume for a share as necessary.
 
         :param aggregate_name: either a list or a string. List for aggregate
@@ -2740,6 +2749,13 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             api_args['attributes']['volume-attributes'][
                 'volume-id-attributes'][
                     'comment'] = comment
+        if logical_space_reporting in (True, False):
+            api_args['attributes']['volume-attributes'][
+                'volume-space-attributes'][
+                    'is-space-reporting-logical'] = logical_space_reporting
+            api_args['attributes']['volume-attributes'][
+                'volume-space-attributes'][
+                    'is-space-enforcement-logical'] = logical_space_reporting
 
         self.send_request('volume-modify-iter', api_args)
 
@@ -2783,6 +2799,26 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 self.disable_compression_async(volume_name)
             else:
                 self.disable_compression(volume_name)
+
+    def update_volume_space_attributes(self, volume_name, logical_space_reporting):
+        api_args = {
+            'query': {
+                'volume-attributes': {
+                    'volume-id-attributes': {
+                        'name': volume_name,
+                    },
+                },
+            },
+            'attributes': {
+                'volume-attributes': {
+                    'volume-space-attributes': {
+                        'is-space-reporting-logical': logical_space_reporting,
+                        'is-space-enforcement-logical': logical_space_reporting,
+                    },
+                },
+            },
+        }
+        self.send_request('volume-modify-iter', api_args)
 
     @na_utils.trace
     def volume_exists(self, volume_name):
@@ -3065,6 +3101,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                     },
                     'volume-space-attributes': {
                         'size': None,
+                        'is-space-enforcement-logical': None,
+                        'is-space-reporting-logical': None,
                     },
                 },
             },
@@ -3117,6 +3155,14 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'style-extended': volume_id_attributes.get_child_content(
                 'style-extended')
         }
+        volume.update({
+            'is-space-reporting-logical':
+                volume_space_attributes.get_child_content(
+                    'is-space-reporting-logical'),
+            'is-space-enforcement-logical':
+                volume_space_attributes.get_child_content(
+                    'is-space-enforcement-logical')
+        })
         return volume
 
     @na_utils.trace

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -195,7 +195,6 @@ class NetAppCmodeFileStorageLibrary(object):
         # Performance monitoring library
         self._perf_library = performance.PerformanceLibrary(self._client)
 
-
         if self._client.features.CIFS_CHANNEL_BINDING:
             self._channel_binding_support = True
 
@@ -412,7 +411,8 @@ class NetAppCmodeFileStorageLibrary(object):
             'share_backend_name': self._backend_name,
             'driver_name': self.driver_name,
             'vendor_name': 'NetApp',
-            'driver_version': self._client.get_system_version()['version-tuple'],
+            'driver_version': self._client.get_system_version(
+                )['version-tuple'],
             'netapp_storage_family': 'ontap_cluster',
             'storage_protocol': 'NFS_CIFS_MULTI',
             'pools': self._get_pools(get_filter_function=get_filter_function,
@@ -782,7 +782,8 @@ class NetAppCmodeFileStorageLibrary(object):
             logical_opts = self._get_logical_space_options(
                 src_vserver_client, src_share_name)
             self._allocate_container_from_snapshot(
-                share, snapshot, src_vserver, src_vserver_client, **logical_opts)
+                share, snapshot, src_vserver, src_vserver_client,
+                **logical_opts)
             return self._create_export(share, share_server, src_vserver,
                                        src_vserver_client)
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -746,7 +746,7 @@ class NetAppCmodeFileStorageLibrary(object):
     def _get_logical_space_options(self, vserver_client, share_name):
         src_volume = vserver_client.get_volume(share_name)
         return {
-            'logical-space-reporting':
+            'logical_space_reporting':
                 src_volume.get('is-space-reporting-logical')
         }
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -743,11 +743,23 @@ class NetAppCmodeFileStorageLibrary(object):
 
         return pool
 
+    def _get_logical_space_options(self, vserver_client, share_name):
+        src_volume = vserver_client.get_volume(share_name)
+        return {
+            'logical-space-reporting':
+                src_volume.get('is-space-reporting-logical')
+        }
+
     @na_utils.trace
     def create_share(self, context, share, share_server):
         """Creates new share."""
         vserver, vserver_client = self._get_vserver(share_server=share_server)
-        self._allocate_container(share, vserver, vserver_client)
+        # SAPCC
+        # Force enabling logical-space-reporting on new Volumes.
+        # Disable cross volume dedupe in neo projects.
+        provisioning_options = {'logical_space_reporting': True}
+        self._allocate_container(share, vserver, vserver_client,
+                                 **provisioning_options)
         return self._create_export(share, share_server, vserver,
                                    vserver_client)
 
@@ -765,8 +777,12 @@ class NetAppCmodeFileStorageLibrary(object):
             src_vserver, src_vserver_client = self._get_vserver(
                 share_server=share_server)
             # Creating a new share from snapshot in the source share's pool
+            # SAPCC Get attribuets from parent Share and apply.
+            src_share_name = self._get_backend_share_name(snapshot['share_id'])
+            logical_opts = self._get_logical_space_options(
+                src_vserver_client, src_share_name)
             self._allocate_container_from_snapshot(
-                share, snapshot, src_vserver, src_vserver_client)
+                share, snapshot, src_vserver, src_vserver_client, **logical_opts)
             return self._create_export(share, share_server, src_vserver,
                                        src_vserver_client)
 
@@ -845,6 +861,10 @@ class NetAppCmodeFileStorageLibrary(object):
             parent_aggr = share_utils.extract_host(parent_share['host'],
                                                    level='pool')
 
+        # SAPCC Get attributes from parent share
+        logical_opts = self._get_logical_space_options(src_vserver_client,
+                                                       parent_share_name)
+
         try:
             # NOTE(felipe_rodrigues): no support to move volumes that are
             # FlexGroup or without the cluster credential. So, performs the
@@ -860,7 +880,7 @@ class NetAppCmodeFileStorageLibrary(object):
                 # 2. Create a replica in destination host.
                 self._allocate_container(
                     dest_share, dest_vserver, dest_vserver_client,
-                    replica=True, set_qos=False)
+                    replica=True, set_qos=False, **logical_opts)
                 # 3. Initialize snapmirror relationship with cloned share.
                 src_share_instance['replica_state'] = (
                     constants.REPLICA_STATE_ACTIVE)
@@ -878,8 +898,8 @@ class NetAppCmodeFileStorageLibrary(object):
                 # its parent in order to move it to a different aggregate or
                 # vserver.
                 self._allocate_container_from_snapshot(
-                    dest_share, snapshot, src_vserver,
-                    src_vserver_client, split=True)
+                    dest_share, snapshot, src_vserver, src_vserver_client,
+                    split=True, **logical_opts)
                 # The split volume clone operation can take some time to be
                 # concluded and we'll answer the call asynchronously.
                 state = self.STATE_SPLITTING_VOLUME_CLONE
@@ -1069,15 +1089,18 @@ class NetAppCmodeFileStorageLibrary(object):
         if return_values['status'] == constants.STATUS_AVAILABLE:
             if apply_qos_on_dest:
                 extra_specs = share_types.get_extra_specs_from_share(share)
+                share_name = self._get_backend_share_name(share['id'])
                 provisioning_options = self._get_provisioning_options(
                     extra_specs)
+                provisioning_options.update(
+                    self._get_logical_space_options(src_vserver_client,
+                                                    share_name))
                 qos_policy_group_name = (
                     self._modify_or_create_qos_for_existing_share(
                         share, extra_specs, dest_vserver, dest_vserver_client))
                 if qos_policy_group_name:
                     provisioning_options['qos_policy_group'] = (
                         qos_policy_group_name)
-                share_name = self._get_backend_share_name(share['id'])
                 # Modify volume to match extra specs
                 dest_vserver_client.modify_volume(
                     dest_aggr, share_name, **provisioning_options)
@@ -1096,8 +1119,8 @@ class NetAppCmodeFileStorageLibrary(object):
 
     @na_utils.trace
     def _allocate_container(self, share, vserver, vserver_client,
-                            replica=False, create_fpolicy=True,
-                            set_qos=True):
+                            replica=False, create_fpolicy=True, set_qos=True,
+                            **force_provisioning_options):
         """Create new share on aggregate."""
         share_name = self._get_backend_share_name(share['id'])
         share_comment = self._get_backend_share_comment(share)
@@ -1109,7 +1132,8 @@ class NetAppCmodeFileStorageLibrary(object):
             raise exception.InvalidHost(reason=msg)
 
         provisioning_options = self._get_provisioning_options_for_share(
-            share, vserver, vserver_client=vserver_client, set_qos=set_qos)
+            share, vserver, vserver_client=vserver_client, set_qos=set_qos,
+            **force_provisioning_options)
 
         if replica:
             # If this volume is intended to be a replication destination,
@@ -1134,8 +1158,7 @@ class NetAppCmodeFileStorageLibrary(object):
                 **provisioning_options)
         else:
             vserver_client.create_volume(
-                pool_name, share_name, share['size'],
-                comment=share_comment,
+                pool_name, share_name, share['size'], comment=share_comment,
                 snapshot_reserve=self.configuration.
                 netapp_volume_snapshot_reserve_percent, **provisioning_options)
 
@@ -1490,8 +1513,9 @@ class NetAppCmodeFileStorageLibrary(object):
         return qos_policy_group_name
 
     @na_utils.trace
-    def _get_provisioning_options_for_share(
-            self, share, vserver, vserver_client=None, set_qos=True):
+    def _get_provisioning_options_for_share(self, share, vserver,
+                                            vserver_client=None, set_qos=True,
+                                            **force_provisioning_options):
         """Return provisioning options from a share.
 
         Starting with a share, this method gets the extra specs, rationalizes
@@ -1516,6 +1540,10 @@ class NetAppCmodeFileStorageLibrary(object):
         # CIFS-only shares come with 0777, NFS-only with 0755 by default.
         if self._is_multi_protocol_share(share):
             provisioning_options['unix-permissions'] = '0777'
+
+        # SAPCC override share type specs by force_provisioning_options
+        for k, v in force_provisioning_options.items():
+            provisioning_options[k] = v
 
         return provisioning_options
 
@@ -1625,7 +1653,7 @@ class NetAppCmodeFileStorageLibrary(object):
     def _allocate_container_from_snapshot(
             self, share, snapshot, vserver, vserver_client,
             snapshot_name_func=_get_backend_snapshot_name, split=None,
-            create_fpolicy=True):
+            create_fpolicy=True, **force_provisioning_options):
         """Clones existing share."""
         share_name = self._get_backend_share_name(share['id'])
         parent_share_name = self._get_backend_share_name(snapshot['share_id'])
@@ -1637,7 +1665,8 @@ class NetAppCmodeFileStorageLibrary(object):
             parent_snapshot_name = snapshot['provider_location']
 
         provisioning_options = self._get_provisioning_options_for_share(
-            share, vserver, vserver_client=vserver_client)
+            share, vserver, vserver_client=vserver_client,
+            **force_provisioning_options)
 
         hide_snapdir = provisioning_options.pop('hide_snapdir')
         if split is not None:
@@ -2547,6 +2576,10 @@ class NetAppCmodeFileStorageLibrary(object):
         provisioning_options = self._get_provisioning_options_for_share(
             share, vserver, vserver_client=vserver_client)
 
+        # SAPCC Keep logical space reporting attributes while update share
+        provisioning_options.update(
+            self._get_logical_space_options(vserver_client, share_name))
+
         qos_policy_group_name = self._modify_or_create_qos_for_existing_share(
             share, extra_specs, vserver, vserver_client)
         if qos_policy_group_name:
@@ -2932,6 +2965,19 @@ class NetAppCmodeFileStorageLibrary(object):
 
         dm_session = data_motion.DataMotionSession()
 
+        # SAPCC Get space logical reporting settings from original replica.
+        orig_active_vserver = dm_session.get_vserver_from_share(
+            orig_active_replica)
+        orig_active_replica_backend = share_utils.extract_host(
+            orig_active_replica['host'], level='backend_name')
+        orig_active_replica_name = self._get_backend_share_name(
+            orig_active_replica['id'])
+        orig_active_vserver_client = data_motion.get_client_for_backend(
+            orig_active_replica_backend, vserver_name=orig_active_vserver)
+        logical_opts = self._get_logical_space_options(
+            orig_active_vserver_client, orig_active_replica_name)
+        is_logical_space_reporting = logical_opts['logical-space-reporting']
+
         new_replica_list = []
 
         # Setup the new active replica
@@ -3014,6 +3060,14 @@ class NetAppCmodeFileStorageLibrary(object):
                 share_server=share_server)
             vserver_client.set_volume_max_files(new_active_replica_share_name,
                                                 max_files)
+
+        # SAPCC update new replica
+        _, new_active_vserver_client = self._get_vserver(
+            share_server=share_server)
+        new_active_replica_name = self._get_backend_share_name(
+            new_active_replica['id'])
+        new_active_vserver_client.update_volume_space_attributes(
+            new_active_replica_name, is_logical_space_reporting)
 
         return new_replica_list
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -2977,7 +2977,7 @@ class NetAppCmodeFileStorageLibrary(object):
             orig_active_replica_backend, vserver_name=orig_active_vserver)
         logical_opts = self._get_logical_space_options(
             orig_active_vserver_client, orig_active_replica_name)
-        is_logical_space_reporting = logical_opts['logical-space-reporting']
+        is_logical_space_reporting = logical_opts['logical_space_reporting']
 
         new_replica_list = []
 

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -3143,7 +3143,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
         self.client._get_create_volume_api_args.assert_called_once_with(
             fake.SHARE_NAME, False, None, None, None,
-            'rw', '', None, None, None)
+            'rw', '', None, None, None, None)
         self.client.send_request.assert_called_with('volume-create',
                                                     volume_create_args)
         (self.client.update_volume_efficiency_attributes.
@@ -3198,7 +3198,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
         self.client._get_create_volume_api_args.assert_called_once_with(
             fake.SHARE_NAME, False, None, None, None, 'rw', None, None,
-            False, None)
+            False, None, None)
         self.client.send_request.assert_called_with('volume-create-async',
                                                     volume_create_args)
         self.assertEqual(expected_result, result)
@@ -3226,11 +3226,12 @@ class NetAppClientCmodeTestCase(test.TestCase):
         qos_name = 'fake_qos'
         encrypt = True
         qos_adaptive_name = 'fake_adaptive_qos'
+        logical_space_reporting = False
 
         result_api_args = self.client._get_create_volume_api_args(
             fake.SHARE_NAME, thin_provisioned, snapshot_policy, language,
             reserve, volume_type, fake.VOLUME_COMMENT, qos_name, encrypt,
-            qos_adaptive_name)
+            qos_adaptive_name, logical_space_reporting)
 
         expected_api_args = {
             'volume-type': volume_type,
@@ -3243,6 +3244,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'qos-policy-group-name': qos_name,
             'qos-adaptive-policy-group-name': qos_adaptive_name,
             'encrypt': 'true',
+            'is-space-enforcement-logical': logical_space_reporting,
+            'is-space-reporting-logical': logical_space_reporting,
         }
         self.assertEqual(expected_api_args, result_api_args)
 
@@ -3258,16 +3261,19 @@ class NetAppClientCmodeTestCase(test.TestCase):
         encrypt = False
         qos_adaptive_name = None
         volume_comment = None
+        logical_space_reporting = False
 
         result_api_args = self.client._get_create_volume_api_args(
             fake.SHARE_NAME, thin_provisioned, snapshot_policy, language,
             reserve, volume_type, volume_comment, qos_name, encrypt,
-            qos_adaptive_name)
+            qos_adaptive_name, logical_space_reporting)
 
         expected_api_args = {
             'encrypt': 'false',
             'volume-type': volume_type,
             'volume-comment': volume_comment,
+            'is-space-enforcement-logical': logical_space_reporting,
+            'is-space-reporting-logical': logical_space_reporting,
         }
         self.assertEqual(expected_api_args, result_api_args)
 
@@ -3278,7 +3284,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
                           self.client._get_create_volume_api_args,
                           fake.SHARE_NAME, True, 'default', 'en-US',
                           15, 'rw', 'fake_comment', 'fake_qos',
-                          encrypt, 'fake_qos_adaptive')
+                          encrypt, 'fake_qos_adaptive', False)
 
     def test_is_flexvol_encrypted_unsupported(self):
 
@@ -4222,6 +4228,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                     },
                     'volume-space-attributes': {
                         'size': None,
+                        'is-space-enforcement-logical': None,
+                        'is-space-reporting-logical': None,
                     },
                     'volume-qos-attributes': {
                         'policy-group-name': None,
@@ -4243,6 +4251,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'style-extended': (fake.FLEXGROUP_STYLE_EXTENDED
                                if is_flexgroup
                                else fake.FLEXVOL_STYLE_EXTENDED),
+            'is-space-enforcement-logical': None,
+            'is-space-reporting-logical': None,
         }
         self.client.send_request.assert_has_calls([
             mock.call('volume-get-iter', volume_get_iter_args)])
@@ -4281,6 +4291,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                     },
                     'volume-space-attributes': {
                         'size': None,
+                        'is-space-enforcement-logical': None,
+                        'is-space-reporting-logical': None,
                     },
                     'volume-qos-attributes': {
                         'policy-group-name': None,
@@ -4300,6 +4312,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'owning-vserver-name': fake.VSERVER_NAME,
             'qos-policy-group-name': None,
             'style-extended': fake.FLEXVOL_STYLE_EXTENDED,
+            'is-space-reporting-logical': None,
+            'is-space-enforcement-logical': None,
         }
         self.client.send_request.assert_has_calls([
             mock.call('volume-get-iter', volume_get_iter_args)])

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -817,9 +817,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                                            fake.SHARE,
                                            share_server=fake.SHARE_SERVER)
 
-        mock_allocate_container.assert_called_once_with(fake.SHARE,
-                                                        fake.VSERVER1,
-                                                        vserver_client)
+        mock_allocate_container.assert_called_once_with(
+            fake.SHARE, fake.VSERVER1, vserver_client,
+            logical_space_reporting=True)
         mock_create_export.assert_called_once_with(fake.SHARE,
                                                    fake.SHARE_SERVER,
                                                    fake.VSERVER1,
@@ -836,6 +836,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          '_get_vserver',
                          mock.Mock(return_value=(fake.VSERVER1,
                                                  vserver_client)))
+        self.mock_object(
+            vserver_client, 'get_volume',
+            mock.Mock(return_value={'is-space-reporting-logical': False}))
         mock_allocate_container_from_snapshot = self.mock_object(
             self.library,
             '_allocate_container_from_snapshot')
@@ -855,7 +858,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             share,
             fake.SNAPSHOT,
             fake.VSERVER1,
-            vserver_client)
+            vserver_client,
+            logical_space_reporting=False)
         mock_create_export.assert_called_once_with(share,
                                                    fake.SHARE_SERVER,
                                                    fake.VSERVER1,
@@ -928,6 +932,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.library.private_storage, 'update')
         self.mock_object(self.library, '_have_cluster_creds',
                          mock.Mock(return_value=True))
+        self.mock_object(
+            self.src_vserver_client, 'get_volume',
+            mock.Mock(return_value={'is-space-reporting-logical': False}))
 
         # Parent share on MANILA_HOST_2
         self.parent_share = copy.copy(fake.SHARE)
@@ -986,7 +993,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                 self.src_vserver_client, split=False, create_fpolicy=False)
             self.mock_allocate_container.assert_called_once_with(
                 self.fake_share, fake.VSERVER2,
-                self.dest_vserver_client, replica=True, set_qos=False)
+                self.dest_vserver_client, replica=True, set_qos=False,
+                logical_space_reporting=False)
             self.mock_dm_create_snapmirror.assert_called_once()
             self.temp_src_share['replica_state'] = (
                 constants.REPLICA_STATE_ACTIVE)
@@ -994,7 +1002,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         else:
             self.mock_allocate_container_from_snapshot.assert_called_once_with(
                 self.fake_share, fake.SNAPSHOT, fake.VSERVER1,
-                self.src_vserver_client, split=True)
+                self.src_vserver_client, split=True,
+                logical_space_reporting=False)
             state = self.library.STATE_SPLITTING_VOLUME_CLONE
 
         self.temp_src_share['aggregate'] = ([fake.POOL_NAME] if is_flexgroup
@@ -1037,7 +1046,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_get_dest_cluster.assert_called_once()
         self.mock_allocate_container_from_snapshot.assert_called_once_with(
             self.fake_share, fake.SNAPSHOT, fake.VSERVER1,
-            self.src_vserver_client, split=True)
+            self.src_vserver_client, split=True, logical_space_reporting=False)
         mock_delete_snapmirror.assert_called_once_with(self.temp_src_share,
                                                        self.fake_share)
         mock_delete_share.assert_called_once_with(

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -1271,6 +1271,11 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             mock.Mock(return_value=fake.QOS_POLICY_GROUP_NAME))
         self.mock_mark_qos_deletion = self.mock_object(
             self.src_vserver_client, 'mark_qos_policy_group_for_deletion')
+        self.mock_get_volume = self.mock_object(
+            self.src_vserver_client, 'get_volume',
+            mock.Mock(return_value={
+                'is-space-reporting-logical': True,
+            }))
 
     @ddt.data(fake.MANILA_HOST_NAME, fake.MANILA_HOST_NAME_2)
     def test__create_from_snapshot_continue_state_splitting(self, src_host):
@@ -1322,7 +1327,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                 fake.SHARE_ID)
             self.mock_modify_vol.assert_called_once_with(
                 fake.POOL_NAME, fake.SHARE_NAME,
-                **fake.PROVISIONING_OPTIONS_WITH_QOS)
+                **fake.PROVISIONING_OPTIONS_WITH_QOS,
+                logical_space_reporting=True)
             self.mock_pvt_storage_delete.assert_called_once_with(
                 fake.SHARE['id'])
             self.mock_create_export.assert_called_once_with(
@@ -1429,7 +1435,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                 self.dest_vserver_client)
             self.mock_modify_vol.assert_called_once_with(
                 fake.POOL_NAME, fake.SHARE_NAME,
-                **fake.PROVISIONING_OPTIONS_WITH_QOS)
+                **fake.PROVISIONING_OPTIONS_WITH_QOS,
+                logical_space_reporting=True)
             expect_result['status'] = constants.STATUS_AVAILABLE
             self.mock_pvt_storage_delete.assert_called_once_with(
                 fake.SHARE['id'])


### PR DESCRIPTION
This pr patches NetApp driver to set the Volume's space attributes `is_space_reporting_logical` and `is_space_enforcement_logical`. When a new Share is created, the attributes are set to True values. When a Volume is created based on an existing Volume, for example when creating a Share from Snapshot, or when creating a Share replica, the attributes are set to the same values as the source Volume.