### PR TITLE
[NetApp] Consider last transfer size and error for replica state

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -164,7 +164,9 @@ class DataMotionSession(object):
                                 'mirror-state',
                                 'source-vserver',
                                 'source-volume',
-                                'last-transfer-end-timestamp'])
+                                'last-transfer-end-timestamp',
+                                'last-transfer-size',
+                                'last-transfer-error'])
         return snapmirrors
 
     def create_snapmirror(self, source_share_obj, dest_share_obj,

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -750,7 +750,6 @@ class NetAppCmodeFileStorageLibrary(object):
                 src_volume.get('is-space-reporting-logical')
         }
 
-
     def _get_efficiency_options(self, vserver_client, share_name):
         status = vserver_client.get_volume_efficiency_status(share_name)
         cross_dedup_disabled = (status.get('policy') == 'inline-only'
@@ -2954,6 +2953,22 @@ class NetAppCmodeFileStorageLibrary(object):
             (timeutils.is_older_than(
                 datetime.datetime.utcfromtimestamp(last_update_timestamp)
                 .isoformat(), 3600))):
+            return constants.REPLICA_STATE_OUT_OF_SYNC
+
+        replica_backend = share_utils.extract_host(replica['host'],
+                                                   level='backend_name')
+        config = data_motion.get_backend_configuration(replica_backend)
+        config_size = (int(config.safe_get(
+            'netapp_snapmirror_last_transfer_size_limit')) * units.Ki)
+        last_transfer_size = int(snapmirror.get('last-transfer-size', 0))
+        if last_transfer_size > config_size:
+            return constants.REPLICA_STATE_OUT_OF_SYNC
+
+        last_transfer_error = snapmirror.get('last-transfer-error', None)
+        if last_transfer_error:
+            LOG.debug('Found last-transfer-error: %(error)s for replica: '
+                      '%(replica)s.', {'replica': replica['id'],
+                                       'error': last_transfer_error})
             return constants.REPLICA_STATE_OUT_OF_SYNC
 
         # Check all snapshots exist

--- a/manila/share/drivers/netapp/options.py
+++ b/manila/share/drivers/netapp/options.py
@@ -232,6 +232,12 @@ netapp_data_motion_opts = [
                default=3600,  # One Hour
                help='The maximum time in seconds to wait for a snapmirror '
                     'release when breaking snapmirror relationships.'),
+    cfg.IntOpt('netapp_snapmirror_last_transfer_size_limit',
+               min=512,
+               default=1024,  # One MB
+               help='This option set the last transfer size limit (in KB) '
+                    'of snapmirror to decide whether replica is in sync or '
+                    'out of sync.'),
     cfg.IntOpt('netapp_volume_move_cutover_timeout',
                min=0,
                default=3600,  # One Hour,

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
@@ -765,7 +765,9 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
                                 'mirror-state',
                                 'source-vserver',
                                 'source-volume',
-                                'last-transfer-end-timestamp']
+                                'last-transfer-end-timestamp',
+                                'last-transfer-size',
+                                'last-transfer-error']
         )
         self.assertEqual(1, self.mock_dest_client.get_snapmirrors.call_count)
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -4371,6 +4371,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))
+        mock_backend_config = fake.get_config_cmode()
+        self.mock_object(data_motion, 'get_backend_configuration',
+                         mock.Mock(return_value=mock_backend_config))
 
         result = self.library.update_replica_state(None, [fake.SHARE],
                                                    fake.SHARE, None, [],
@@ -4414,6 +4417,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))
+        mock_backend_config = fake.get_config_cmode()
+        self.mock_object(data_motion, 'get_backend_configuration',
+                         mock.Mock(return_value=mock_backend_config))
 
         result = self.library.update_replica_state(None, [fake.SHARE],
                                                    fake.SHARE, None, snapshots,
@@ -4442,6 +4448,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))
+        mock_backend_config = fake.get_config_cmode()
+        self.mock_object(data_motion, 'get_backend_configuration',
+                         mock.Mock(return_value=mock_backend_config))
 
         result = self.library.update_replica_state(None, [fake.SHARE],
                                                    fake.SHARE, None, snapshots,

--- a/releasenotes/notes/netapp-consider-last-transfer-size-error-for-replica-state-7ef49186a1b8a5a0.yaml
+++ b/releasenotes/notes/netapp-consider-last-transfer-size-error-for-replica-state-7ef49186a1b8a5a0.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    NetApp driver now considers ``last-transfer-size`` and
+    ``last-transfer-error`` fields of the snapmirror in addition to existing
+    ``last-transfer-end-timestamp`` to decide whether replica is in_sync or
+    out_of_sync. Added new config option
+    `netapp_snapmirror_last_transfer_size_limit` (default 1MB). If value of
+    `last-transfer-size` field is greater than config value or if
+    `last-transfer-error` field is present, then replica is out_of_sync.


### PR DESCRIPTION
In order to determine replica state from snapmirror, in addition to existing check of last-transfer-end-timestamp', also add new checks of `last-transfer-size` and `last-transfer-error`. New config option `netapp_snapmirror_last_transfer_size_limit` added with default value of 1MB. The last-transfer-size above this value or presence of any last-transfer-error is considered as replica is out_of_sync.

Closes-bug: #1989175