### PR TITLE
Allow resync if replica is out_of_sync

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -2928,7 +2928,8 @@ class NetAppCmodeFileStorageLibrary(object):
                 snapmirror.get('relationship-status') in in_progress_status):
             return constants.REPLICA_STATE_OUT_OF_SYNC
 
-        if snapmirror.get('mirror-state') != 'snapmirrored':
+        if (replica['replica_state'] == constants.REPLICA_STATE_OUT_OF_SYNC or
+                snapmirror.get('mirror-state') != 'snapmirrored'):
             try:
                 vserver_client.resume_snapmirror_vol(
                     snapmirror['source-vserver'],


### PR DESCRIPTION
The 'snapmirrored' mirror-state indicates source and target volumes are in snapmirror relation, but this does not mean that they are in sync, as it is ASYNC mirror, there is always delta present which we have to take care by doing updates/resyncs. So allow resync when replica is out_of_sync take care of delta.