### PR TITLE
keep nfs v4.0 setting on existing vservers

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1549,12 +1549,17 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def _enable_nfs_protocols(self, versions):
         """Set the enabled NFS protocol versions."""
         nfs3 = 'true' if 'nfs3' in versions else 'false'
-        nfs40 = 'true' if 'nfs4.0' in versions else 'false'
+        # SAPCC absence of 'nfs4.0' should not equal 'false'
+        # instead it should mean:
+        #   don't touch existing value for existing vservers
+        #   and set the default value ('false' for ONTAP 9.7 and newer)
+        #   for new vservers
+        # Change back to upstream once all vservers have nfs4.0 disabled!
+        # nfs40 = 'true' if 'nfs4.0' in versions else 'false'
         nfs41 = 'true' if 'nfs4.1' in versions else 'false'
 
         nfs_service_modify_args = {
             'is-nfsv3-enabled': nfs3,
-            'is-nfsv40-enabled': nfs40,
             'is-nfsv41-enabled': nfs41,
             'showmount': 'true',
             'is-v3-ms-dos-client-enabled': 'true',
@@ -1563,6 +1568,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'is-vstorage-enabled': 'true',
         }
 
+        if 'nfs4.0' in versions:
+            nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
         if 'nfs4.1' in versions:
             nfs41_opts = {
                 'is-nfsv41-pnfs-enabled': 'true',

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -2505,7 +2505,6 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
         nfs_service_modify_args = {
             'is-nfsv3-enabled': 'true' if v3 else 'false',
-            'is-nfsv40-enabled': 'true' if v40 else 'false',
             'is-nfsv41-enabled': 'true' if v41 else 'false',
             'showmount': 'true',
             'is-v3-ms-dos-client-enabled': 'true',
@@ -2514,6 +2513,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'is-vstorage-enabled': 'true',
         }
 
+        if v40:
+            nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
         if v41:
             nfs41_opts = {
                 'is-nfsv41-pnfs-enabled': 'true',


### PR DESCRIPTION
SAPCC: re-introduce 77b4e2d47b892e6b369790161257d3bd3c4027f4

not sending the optional 'is-nfsv40-enabled' parameter to 'nfs-service-modify' means it will not be changed, which is relevant for update_vserver in the ensure loop.

I.e. we don't want to disable nfs v4.0 for existing vservers.

Change-Id: I1e2aa559cceede6505578bef38c1a5b2edf2d991