### PR TITLE
WIP svm migration

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -4665,7 +4665,7 @@ def network_allocations_get_for_share_server(context, share_server_id,
         share_server_id=share_server_id,
     )
     if label:
-        if label != 'admin':
+        if label == 'user':
             query = query.filter(or_(
                 # NOTE(vponomaryov): we treat None as alias for 'user'.
                 models.NetworkAllocation.label == None,  # noqa

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -55,18 +55,15 @@ CONF = cfg.CONF
 LOG = log.getLogger(__name__)
 
 
-# We need to monkey-patch neutron_client_exc to make neutron client to raise
-# exception for specific type of error. When neutron API returns a error of
-# type NeutronError, the exception NeutronErrorClient is raised, if it is
-# defined in the neutronclient.common.exceptions module. Monkey-patching the
-# module with PortBindingAlreadyExistsClient means the API error
-# PortBindingAlreadyExists can be handled as a python exception.
-
-
 class PortBindingAlreadyExistsClient(neutron_client_exc.Conflict):
     pass
 
 
+# We need to monkey-patch neutronclient.common.exceptions module, to make
+# neutron client to raise error specific exceptions. E.g., exception
+# PortBindingAlreadyExistsClient is raised for Neutron API error
+# PortBindingAlreadyExists. If not defined, a general exception Conflict will
+# be raised.
 neutron_client_exc.PortBindingAlreadyExistsClient = \
     PortBindingAlreadyExistsClient
 

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -296,7 +296,7 @@ class API(object):
                                              message=e.message)
 
     def bind_port_to_host(self, port_id, host, vnic_type):
-        """Add an inactive binding to exsiting port."""
+        """Add an inactive binding to exisiting port."""
 
         try:
             data = {"binding": {"host": host, "vnic_type": vnic_type}}

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -60,10 +60,10 @@ class PortBindingAlreadyExistsClient(neutron_client_exc.Conflict):
 
 
 # We need to monkey-patch neutronclient.common.exceptions module, to make
-# neutron client to raise error specific exceptions. E.g., exception
+# neutron client to raise error specific exceptions. E.g. exception
 # PortBindingAlreadyExistsClient is raised for Neutron API error
-# PortBindingAlreadyExists. If not defined, a general exception Conflict will
-# be raised.
+# PortBindingAlreadyExists. If not defined, a general exception of type
+# Conflict will be raised.
 neutron_client_exc.PortBindingAlreadyExistsClient = \
     PortBindingAlreadyExistsClient
 

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -296,8 +296,8 @@ class API(object):
                                              message=e.message)
 
     def bind_port_to_host(self, port_id, host, vnic_type):
-        """Add an extra binding to an already bound port. The newly added
-       binding is in INACTIVE state."""
+        """Add an inactive binding to exsiting port."""
+
         try:
             data = {"binding": {"host": host, "vnic_type": vnic_type}}
             return self.client.create_port_binding(port_id, data)['binding']

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -301,7 +301,7 @@ class API(object):
                                              message=e.message)
 
     def bind_port_to_host(self, port_id, host, vnic_type):
-        """Add an inactive binding to exisiting port."""
+        """Add an inactive binding to existing port."""
 
         try:
             data = {"binding": {"host": host, "vnic_type": vnic_type}}

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -55,6 +55,14 @@ CONF = cfg.CONF
 LOG = log.getLogger(__name__)
 
 
+# We need to monkey-patch neutron_client_exc to make neutron client to raise
+# exception for specific type of error. When neutron API returns a error of
+# type NeutronError, the exception NeutronErrorClient is raised, if it is
+# defined in the neutronclient.common.exceptions module. Monkey-patching the
+# module with PortBindingAlreadyExistsClient means the API error
+# PortBindingAlreadyExists can be handled as a python exception.
+
+
 class PortBindingAlreadyExistsClient(neutron_client_exc.Conflict):
     pass
 

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -315,8 +315,11 @@ class API(object):
                 code=e.status_code, message=e.message)
 
     def activate_port_binding(self, port_id, host):
-        pass
-
+        try:
+            return self.client.activate_port_binding(port_id, host)
+        except neutron_client_exc.NeutronClientException as e:
+            raise exception.NetworkException(
+                code=e.status_code, message=e.message)
 
     def show_router(self, router_id):
         try:

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -302,13 +302,17 @@ class API(object):
             data = {"binding": {"host": host, "vnic_type": vnic_type}}
             return self.client.create_port_binding(port_id, data)['binding']
         except neutron_client_exc.PortBindingAlreadyExistsClient as e:
-            LOG.warning('Port binding already exists')
+            LOG.warning('Port binding already exists: %s', e)
         except neutron_client_exc.NeutronClientException as e:
             raise exception.NetworkException(
                 code=e.status_code, message=e.message)
 
-    def delete_inactive_port_binding(self, port_id, host=''):
-        pass
+    def delete_port_binding(self, port_id, host):
+        try:
+            return self.client.delete_port_binding(port_id, host)
+        except neutron_client_exc.NeutronClientException as e:
+            raise exception.NetworkException(
+                code=e.status_code, message=e.message)
 
     def activate_port_binding(self, port_id, host):
         pass

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -686,15 +686,14 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
                 raise exception.NetworkException(msg)
 
             # Label the new port bindings with physical network name.
+            dest_port_bindings = []
             for port in active_port_bindings:
                 port_data = self.db.network_allocation_get(context, port.id)
                 port_data['label'] = phys_net
                 port_data['segmentation_id'] = vlan
                 port_data['id'] = None
-                self.db.network_allocation_create(context, port_data)
-            dest_port_bindings = (
-                self.db.network_allocations_get_for_share_server(
-                    context, share_server.id, label=phys_net))
+                dest_port_bindings.append(
+                    self.db.network_allocation_create(context, port_data))
 
         return dest_port_bindings
 

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -704,8 +704,8 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
             self.db.network_allocations_get_for_share_server(
                 context, share_server.id, label='user'))
         if len(ports) == 0:
-            msg = 'No ports found for Share server %s'
-            LOG.warning(msg % share_server.id)
+            msg = 'No ports found for Share server %{share_server}s'
+            LOG.warning(msg, {'share_server': share_server.id})
         dest_port_bindings = (
             self.db.network_allocations_get_for_share_server(
                 context, share_server.id, label=phys_net))

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -413,7 +413,7 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
         """Extend network to target host.
 
         Create extra (inactive) port bindings on given host. Network
-        is streched to the host with new segementation id.
+        is bound to the host with new segementation id.
         """
         phys_net = self.configuration.neutron_physical_net_name
         vnic_type = self.configuration.neutron_vnic_type

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -727,7 +727,7 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
             except exception.NetworkException as e:
                 msg = _(
                     'Failed to delete port binding on port %{port}s: %{err}s')
-                LOG.warn(msg, {'port': port.id, 'err': e})
+                LOG.warning(msg, {'port': port.id, 'err': e})
         for binding in dest_port_bindings:
             self.db.network_allocation_delete(context, binding.id)
 

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -409,6 +409,129 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
             self.db.share_network_subnet_update(
                 context, share_network_subnet['id'], subnet_values)
 
+    def extend_network_allocations(self, context, share_server, host):
+        """Extend network to target host.
+
+        Create extra (inactive) port bindings on given host. Network
+        is streched to the host with new segementation id.
+        """
+        phys_net = self.configuration.neutron_physical_net_name
+        vnic_type = self.configuration.neutron_vnic_type
+        vlan = None
+
+        # Active port bindings are labeled as 'user'. Destination port bindings
+        # are labeled with physical network name.
+        active_port_bindings = (
+            self.db.network_allocations_get_for_share_server(
+                context, share_server.id, label='user'))
+        dest_port_bindings = (
+            self.db.network_allocations_get_for_share_server(
+                context, share_server.id, label=phys_net))
+
+        if len(active_port_bindings) == 0:
+            raise exception.NetworkException(
+                'Can not extend network with no active bindings')
+
+        if len(dest_port_bindings) == 0:
+            # Create port binding on destination backend. Exception is ignored
+            # in the neutron api call, if the port is already bound to
+            # destination host.
+            for port in active_port_bindings:
+                self.neutron_api.bind_port_to_host(port.id, host, vnic_type)
+
+            # Get the segmentation id on destination host
+            neutron_network_id = share_server['share_network_subnet'].get(
+                'neutron_net_id')
+            neutron_network = self.neutron_api.get_network(neutron_network_id)
+            for segment in neutron_network['segments']:
+                if (segment['provider:physical_network'] == phys_net):
+                    vlan = segment['provider:segmentation_id']
+                    break
+            if vlan is None:
+                msg = _('Network segment not found on host %s') % host
+                raise exception.NetworkException(msg)
+
+            # Label the new port bindings with physical network name.
+            dest_port_bindings = []
+            for port in active_port_bindings:
+                port_data = self.db.network_allocation_get(context, port.id)
+                port_data['label'] = phys_net
+                port_data['segmentation_id'] = vlan
+                port_data['id'] = None
+                dest_port_bindings.append(
+                    self.db.network_allocation_create(context, port_data))
+
+        return dest_port_bindings
+
+    def delete_port_bindings(self, context, share_server, host):
+        phys_net = self.configuration.neutron_physical_net_name
+
+        ports = (
+            self.db.network_allocations_get_for_share_server(
+                context, share_server.id, label='user'))
+        if len(ports) == 0:
+            msg = 'No ports found for Share server %{share_server}s'
+            LOG.warning(msg, {'share_server': share_server.id})
+        dest_port_bindings = (
+            self.db.network_allocations_get_for_share_server(
+                context, share_server.id, label=phys_net))
+        if len(dest_port_bindings) == 0:
+            msg = (
+                'No port bindings found on %{host}s for '
+                'share server %{share_server}s')
+            LOG.warning(msg, {'host': host, 'share_server': share_server.id})
+        # Parent port are not tracked in network allocations; so we have to use
+        # the port id's extracted from source share server
+        for port in ports:
+            try:
+                self.neutron_api.delete_port_binding(port.id, host)
+            except exception.NetworkException as e:
+                msg = _(
+                    'Failed to delete port binding on port %{port}s: %{err}s')
+                LOG.warning(msg, {'port': port.id, 'err': e})
+        for binding in dest_port_bindings:
+            self.db.network_allocation_delete(context, binding.id)
+
+    def cutover_network_allocations(self, context, src_share_server,
+                                    dest_share_server):
+        physnet = self.configuration.neutron_physical_net_name
+        src_host = share_utils.extract_host(src_share_server['host'], 'host')
+        dest_host = share_utils.extract_host(dest_share_server['host'], 'host')
+
+        active_allocations = (
+            self.db.network_allocations_get_for_share_server(
+                context, src_share_server.id, label='user'))
+        inactive_allocations = (
+            self.db.network_allocations_get_for_share_server(
+                context, src_share_server.id, label=physnet))
+
+        if len(inactive_allocations) == 0:
+            msg = _(
+                'No target network allocations for cutover from '
+                '%{src_ss}s to %{dest_ss}s')
+            raise exception.NetworkException(
+                msg % {
+                    'src_ss': src_share_server.id,
+                    'dest_ss': dest_share_server.id
+                })
+        vlan_to_activate = inactive_allocations[0]['segmentation_id']
+
+        # Cutting over network allocations
+        alloc_data = {
+            'share_server_id': dest_share_server.id,
+            'segmentation_id': vlan_to_activate
+        }
+        for alloc in active_allocations:
+            self.neutron_api.activate_port_binding(alloc.id, dest_host)
+            self.neutron_api.delete_port_binding(alloc.id, src_host)
+            self.db.network_allocation_update(context, alloc.id, alloc_data)
+        for alloc in inactive_allocations:
+            self.db.network_allocation_delete(context, alloc.id)
+        # Update segmentation id of the share network subnet after cutting over
+        subnet_data = {'segmentation_id': vlan_to_activate}
+        sns_id = src_share_server['share_network_subnet']['id']
+        self.db.share_network_subnet_update(context, sns_id, subnet_data)
+
 
 class NeutronSingleNetworkPlugin(NeutronNetworkPlugin):
 
@@ -642,129 +765,6 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
                     ports[num] = self.db.network_allocation_update(
                         context, port['id'], port_info)
         return ports
-
-    def extend_network_allocations(self, context, share_server, host):
-        """Extend network to target host.
-
-        Create extra (inactive) port bindings on given host. Network
-        is streched to the host with new segementation id.
-        """
-        phys_net = self.configuration.neutron_physical_net_name
-        vnic_type = self.configuration.neutron_vnic_type
-        vlan = None
-
-        # Active port bindings are labeled as 'user'. Destination port bindings
-        # are labeled with physical network name.
-        active_port_bindings = (
-            self.db.network_allocations_get_for_share_server(
-                context, share_server.id, label='user'))
-        dest_port_bindings = (
-            self.db.network_allocations_get_for_share_server(
-                context, share_server.id, label=phys_net))
-
-        if len(active_port_bindings) == 0:
-            raise exception.NetworkException(
-                'Can not extend network with no active bindings')
-
-        if len(dest_port_bindings) == 0:
-            # Create port binding on destination backend. Exception is ignored
-            # in the neutron api call, if the port is already bound to
-            # destination host.
-            for port in active_port_bindings:
-                self.neutron_api.bind_port_to_host(port.id, host, vnic_type)
-
-            # Get the segmentation id on destination host
-            neutron_network_id = share_server['share_network_subnet'].get(
-                'neutron_net_id')
-            neutron_network = self.neutron_api.get_network(neutron_network_id)
-            for segment in neutron_network['segments']:
-                if (segment['provider:physical_network'] == phys_net):
-                    vlan = segment['provider:segmentation_id']
-                    break
-            if vlan is None:
-                msg = _('Network segment not found on host %s') % host
-                raise exception.NetworkException(msg)
-
-            # Label the new port bindings with physical network name.
-            dest_port_bindings = []
-            for port in active_port_bindings:
-                port_data = self.db.network_allocation_get(context, port.id)
-                port_data['label'] = phys_net
-                port_data['segmentation_id'] = vlan
-                port_data['id'] = None
-                dest_port_bindings.append(
-                    self.db.network_allocation_create(context, port_data))
-
-        return dest_port_bindings
-
-    def delete_port_bindings(self, context, share_server, host):
-        phys_net = self.configuration.neutron_physical_net_name
-
-        ports = (
-            self.db.network_allocations_get_for_share_server(
-                context, share_server.id, label='user'))
-        if len(ports) == 0:
-            msg = 'No ports found for Share server %{share_server}s'
-            LOG.warning(msg, {'share_server': share_server.id})
-        dest_port_bindings = (
-            self.db.network_allocations_get_for_share_server(
-                context, share_server.id, label=phys_net))
-        if len(dest_port_bindings) == 0:
-            msg = (
-                'No port bindings found on %{host}s for '
-                'share server %{share_server}s')
-            LOG.warning(msg, {'host': host, 'share_server': share_server.id})
-        # Parent port are not tracked in network allocations; so we have to use
-        # the port id's extracted from source share server
-        for port in ports:
-            try:
-                self.neutron_api.delete_port_binding(port.id, host)
-            except exception.NetworkException as e:
-                msg = _(
-                    'Failed to delete port binding on port %{port}s: %{err}s')
-                LOG.warning(msg, {'port': port.id, 'err': e})
-        for binding in dest_port_bindings:
-            self.db.network_allocation_delete(context, binding.id)
-
-    def cutover_network_allocations(self, context, src_share_server,
-                                    dest_share_server):
-        physnet = self.configuration.neutron_physical_net_name
-        src_host = share_utils.extract_host(src_share_server['host'], 'host')
-        dest_host = share_utils.extract_host(dest_share_server['host'], 'host')
-
-        active_allocations = (
-            self.db.network_allocations_get_for_share_server(
-                context, src_share_server.id, label='user'))
-        inactive_allocations = (
-            self.db.network_allocations_get_for_share_server(
-                context, src_share_server.id, label=physnet))
-
-        if len(inactive_allocations) == 0:
-            msg = _(
-                'No target network allocations for cutover from '
-                '%{src_ss}s to %{dest_ss}s')
-            raise exception.NetworkException(
-                msg % {
-                    'src_ss': src_share_server.id,
-                    'dest_ss': dest_share_server.id
-                })
-        vlan_to_activate = inactive_allocations[0]['segmentation_id']
-
-        # Cutting over network allocations
-        alloc_data = {
-            'share_server_id': dest_share_server.id,
-            'segmentation_id': vlan_to_activate
-        }
-        for alloc in active_allocations:
-            self.neutron_api.activate_port_binding(alloc.id, dest_host)
-            self.neutron_api.delete_port_binding(alloc.id, src_host)
-            self.db.network_allocation_update(context, alloc.id, alloc_data)
-        for alloc in inactive_allocations:
-            self.db.network_allocation_delete(context, alloc.id)
-        # Update segmentation id of the share network subnet after cutting over
-        subnet_data = {'segmentation_id': vlan_to_activate}
-        sns_id = src_share_server['share_network_subnet']['id']
-        self.db.share_network_subnet_update(context, sns_id, subnet_data)
 
 
 class NeutronBindSingleNetworkPlugin(NeutronSingleNetworkPlugin,

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -6332,6 +6332,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 raise exception.NetAppException(message=e.message)
             msg = (_('Failed to check migration support. Reason: '
                      '%s' % e.message))
+            LOG.error(msg)
             raise exception.NetAppException(msg)
 
     @na_utils.trace

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5417,6 +5417,8 @@ class ShareManager(manager.SchedulerDependentManager):
             # the validations.
             driver_result['compatible'] = False
 
+        self.driver.network_api.delete_port_bindings(
+            context, share_server, neutron_host)
         result.update(driver_result)
 
         return result

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5401,10 +5401,10 @@ class ShareManager(manager.SchedulerDependentManager):
             try:
                 neutron_host = share_utils.extract_host(
                     dest_host, level='host')
-                dest_ports = (
+                new_allocations = (
                     self.driver.network_api.extend_network_allocations(
                         context, share_server, neutron_host))
-                share_server['network_allocations'] = dest_ports
+                share_server['network_allocations'] = new_allocations
             except Exception:
                 self.driver.network_api.delete_port_bindings(
                     context, share_server, neutron_host)

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5220,6 +5220,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 availability_zone_id=service['availability_zone_id'],
                 share_network_id=new_share_network_id))
 
+        new_allocations = None
         dest_share_server = None
         try:
             # SAPCC: Extend network allocations to destination host, i.e.,
@@ -5323,6 +5324,12 @@ class ShareManager(manager.SchedulerDependentManager):
                 context, constants.STATUS_AVAILABLE,
                 share_instance_ids=share_instance_ids,
                 snapshot_instance_ids=snapshot_instance_ids)
+            # Rollback port bindings on destination host
+            if new_allocations:
+                neutron_host = share_utils.extract_host(
+                    dest_host, level='host')
+                self.driver.network_api.delete_port_bindings(
+                    context, source_share_server, neutron_host)
             # Rollback read only access rules
             self._reset_read_only_access_rules_for_server(
                 context, share_instances, source_share_server,

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5674,6 +5674,20 @@ class ShareManager(manager.SchedulerDependentManager):
         dest_sn = self.db.share_network_get(context, dest_sn_id)
         dest_sns = self.db.share_network_subnet_get(context, dest_sns_id)
 
+        # SAPCC: Network are extended to the destination host on previous
+        # (migration_start) step, i.e. port bindings are created on destination
+        # host using the old ports. The network allocations will be cut over on
+        # this (migration_complete) step, i.e. port bindings on destination
+        # host will be activated and bindings on source host will be deleted.
+        # Since network allocations has been taken care of in the cutover,
+        # driver should not touch them. Therefore source_share_server and
+        # dest_share_server are not refreshed with the new network allocations,
+        # so that driver does not know about them.
+        if True:
+            self.driver.network_api.cutover_network_allocations(
+                context, source_share_server, dest_share_server)
+            dest_sns = self.db.share_network_subnet_get(context, dest_sns_id)
+
         migration_reused_network_allocations = (len(
             self.db.network_allocations_get_for_share_server(
                 context, dest_share_server['id'])) == 0)

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5222,6 +5222,19 @@ class ShareManager(manager.SchedulerDependentManager):
 
         dest_share_server = None
         try:
+            # SAPCC: Extend network allocations to destination host, i.e.,
+            # create inactive port bindings on the destination host. Refresh
+            # network_allocations field in source_share_server with the new
+            # bindings, so that correct segmentation id is used during
+            # compatibility check and migration.
+            if True:
+                neutron_host = share_utils.extract_host(
+                    dest_host, level='host')
+                new_allocations = (
+                    self.driver.network_api.extend_network_allocations(
+                        context, source_share_server, neutron_host))
+                source_share_server['network_allocations'] = new_allocations
+
             compatibility = (
                 self.driver.share_server_migration_check_compatibility(
                     context, source_share_server, dest_host, old_share_network,

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -121,7 +121,9 @@ share_manager_opts = [
     cfg.BoolOpt('server_migration_extend_neutron_network',
                 default=False,
                 help='If set to True, neutron network are extended to '
-                     'destination host during share server migration'),
+                     'destination host during share server migration. This '
+                     'option should only be enabled when multiple bindings of '
+                     'Manila ports are supported by Neutron ML2 plugin.'),
     cfg.IntOpt('share_usage_size_update_interval',
                default=300,
                help='This value, specified in seconds, determines how often '

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5373,6 +5373,14 @@ class ShareManager(manager.SchedulerDependentManager):
         service = self.db.service_get_by_args(
             context, service_host, 'manila-share')
 
+        # Bind port to destination host
+        try:
+            neutron_host = share_utils.extract_host(dest_host, level='host')
+            self.driver.network_api.extend_network_allocations(
+                context, neutron_host, share_server)
+        except Exception:
+            return result
+
         # NOTE(dviroel): We'll build a list of request specs and send it to
         # the driver so vendors have a chance to validate if the destination
         # host meets the requirements before starting the migration.

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -118,6 +118,10 @@ share_manager_opts = [
                     'the share manager will poll the driver to perform the '
                     'next step of migration in the storage backend, for a '
                     'migrating share server.'),
+    cfg.BoolOpt('server_migration_extend_neutron_network',
+                default=False,
+                help='If set to True, neutron network are extended to '
+                     'destination host during share server migration'),
     cfg.IntOpt('share_usage_size_update_interval',
                default=300,
                help='This value, specified in seconds, determines how often '
@@ -5228,7 +5232,7 @@ class ShareManager(manager.SchedulerDependentManager):
             # network_allocations field in source_share_server with the new
             # bindings, so that correct segmentation id is used during
             # compatibility check and migration.
-            if True:
+            if CONF.server_migration_extend_neutron_network:
                 neutron_host = share_utils.extract_host(
                     dest_host, level='host')
                 new_allocations = (
@@ -5397,7 +5401,7 @@ class ShareManager(manager.SchedulerDependentManager):
         # bindings on destination host with the same ports in the share network
         # subnet. Refresh share_server with new network allocations, so that
         # correct segmentation id is used in the compatibility check.
-        if True:
+        if CONF.server_migration_extend_neutron_network:
             try:
                 neutron_host = share_utils.extract_host(
                     dest_host, level='host')
@@ -5690,7 +5694,7 @@ class ShareManager(manager.SchedulerDependentManager):
         # driver should not touch them. Therefore source_share_server and
         # dest_share_server are not refreshed with the new network allocations,
         # so that driver does not know about them.
-        if True:
+        if CONF.server_migration_extend_neutron_network:
             self.driver.network_api.cutover_network_allocations(
                 context, source_share_server, dest_share_server)
             dest_sns = self.db.share_network_subnet_get(context, dest_sns_id)

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5227,7 +5227,7 @@ class ShareManager(manager.SchedulerDependentManager):
         new_allocations = None
         dest_share_server = None
         try:
-            # NOTE(sapcc): Extend network allocations to destination host, i.e.,
+            # NOTE(sapcc): Extend network allocations to destination host, i.e.
             # create inactive port bindings on the destination host. Refresh
             # network_allocations field in source_share_server with the new
             # bindings, so that correct segmentation id is used during

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5695,10 +5695,11 @@ class ShareManager(manager.SchedulerDependentManager):
         # destination host with existing ports. The network allocations will be
         # cut over on this (migration_complete) step, i.e. port bindings on
         # destination host will be activated and bindings on source host will
-        # be deleted. Since network allocations has been taken care of in the
-        # cutover, driver should not touch them. Therefore source_share_server
-        # and dest_share_server are not updated with the new network
-        # allocations.
+        # be deleted. Since manager takes care of the cutover of network
+        # allocations, driver should not touch them. Therefore the cached
+        # source_share_server and dest_share_server are not updated with the
+        # new network allocations after the cutover_network_allocations call.
+        # Only dest_sns is updated to have the correct segmentation id.
         if CONF.server_migration_extend_neutron_network:
             self.driver.network_api.cutover_network_allocations(
                 context, source_share_server, dest_share_server)


### PR DESCRIPTION
A few notes on the implementations:
* network.neutron.api and network.neutron.neutron_network_plugin is extended to leverage the Neutron API, creating/activating new port bindings.
* Port bindings are tracked in DB table 'network_allocations', to distinguish from the active bindings, the physical network name is used as label of the inactive bindings.
* I try to make the implementation generic. Logic changes only in manila.share.manager. Objects are refreshed when needed, so no logic needs to be changed in driver.