### PR TITLE
Add manila in requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ alembic>=1.4.2 # MIT
 eventlet>=0.26.1 # MIT
 greenlet>=0.4.16 # MIT
 lxml>=4.5.2 # BSD
+manila>=13.0.0 # Apache-2.0
 netaddr>=0.8.0 # BSD
 oslo.config>=8.3.2 # Apache-2.0
 oslo.context>=3.1.1 # Apache-2.0


### PR DESCRIPTION
With new ubuntu image, tox updated from 3.x to 4.x which executes the tests in virtual env and fails to find manila.scheduler.filters and manila.scheduler.weighers. To overcome, install manila in tox env before executing the tests.