### PR TITLE
sapcc: Add warning on failures during replica promotion

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -352,14 +352,16 @@ class DataMotionSession(object):
         try:
             wait_for_quiesced()
         except exception.ReplicationException:
-            msg = ('failed to quiesce snapmirror in %(timeout)s seconds: '
-                   'abort snapmirror from %(src_volume)s to %(dest_volume)s')
-            values = {
+            msg_args = {
                 'timeout': config.netapp_snapmirror_quiesce_timeout,
                 'src_volume': src_volume,
                 'dest_volume': dest_volume,
             }
-            LOG.warning(msg % values)
+            msg = (
+                'failed to quiesce snapmirror in %(timeout)s seconds: '
+                'abort snapmirror from %(src_volume)s to %(dest_volume)s'
+            ) % msg_args
+            LOG.warning(msg)
             dest_client.abort_snapmirror_vol(src_vserver,
                                              src_volume,
                                              dest_vserver,

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -352,6 +352,14 @@ class DataMotionSession(object):
         try:
             wait_for_quiesced()
         except exception.ReplicationException:
+            msg = ('failed to quiesce snapmirror in %(timeout)s seconds: '
+                   'abort snapmirror from %(src_volume)s to %(dest_volume)s')
+            values = {
+                'timeout': config.netapp_snapmirror_quiesce_timeout,
+                'src_volume': src_volume,
+                'dest_volume': dest_volume,
+            }
+            LOG.warning(msg % values)
             dest_client.abort_snapmirror_vol(src_vserver,
                                              src_volume,
                                              dest_vserver,

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -3210,9 +3210,17 @@ class NetAppCmodeFileStorageLibrary(object):
             # 1. Start an update to try to get a last minute transfer before we
             # quiesce and break
             dm_session.update_snapmirror(orig_active_replica, replica)
-        except exception.StorageCommunicationException:
+        except exception.StorageCommunicationException as e:
             # Ignore any errors since the current source replica may be
             # unreachable
+            msg = ('failed to update snapmirror from %(source)s to '
+                   '%(target)s: %(error)s')
+            values = {
+                'source': orig_active_replica['id'],
+                'target': replica['id'],
+                'error': e
+            }
+            LOG.warning(msg % values)
             pass
         # 2. Break SnapMirror
         dm_session.break_snapmirror(orig_active_replica, replica)

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -3213,14 +3213,14 @@ class NetAppCmodeFileStorageLibrary(object):
         except exception.StorageCommunicationException as e:
             # Ignore any errors since the current source replica may be
             # unreachable
-            msg = ('failed to update snapmirror from %(source)s to '
-                   '%(target)s: %(error)s')
-            values = {
+            msg_args = {
                 'source': orig_active_replica['id'],
                 'target': replica['id'],
                 'error': e
             }
-            LOG.warning(msg % values)
+            msg = ('failed to update snapmirror from %(source)s to '
+                   '%(target)s: %(error)s') % msg_args
+            LOG.warning(msg)
             pass
         # 2. Break SnapMirror
         dm_session.break_snapmirror(orig_active_replica, replica)


### PR DESCRIPTION
During replica promotion, Manila tries to first update and then break snapmirror before promoting. Data will be synced from old source to target to prevent data lost. However both update and break steps can fail and therefore it can indeed happen. Update snapmirror can fail because of the client is inaccessible for some reason. Break snapmirror can fail because snapmirror quiesce timeout is reached.

We have tried to update snapmirror volumes more frequently by lowering replica update period from 1h to 10mins, which should allevate the data lost issue. But it's not guaranteed. Adding the warning messages in logs will enable us to monitor and debug the such issues.