### PR TITLE
sapcc: update schedule of existing snapmirrors

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -162,6 +162,7 @@ class DataMotionSession(object):
             source_volume=src_volume_name, dest_volume=dest_volume_name,
             desired_attributes=['relationship-status',
                                 'mirror-state',
+                                'schedule',
                                 'source-vserver',
                                 'source-volume',
                                 'last-transfer-end-timestamp',
@@ -411,6 +412,27 @@ class DataMotionSession(object):
                                           src_volume_name,
                                           dest_vserver,
                                           dest_volume_name)
+
+    def modify_snapmirror(self, source_share_obj, dest_share_obj,
+                          schedule=None):
+        """Modify SnapMirror relationship: set schedule"""
+        dest_volume_name, dest_vserver, dest_backend = (
+            self.get_backend_info_for_share(dest_share_obj))
+        dest_client = get_client_for_backend(dest_backend,
+                                             vserver_name=dest_vserver)
+
+        src_volume_name, src_vserver, __ = self.get_backend_info_for_share(
+            source_share_obj)
+
+        if schedule is None:
+            config = get_backend_configuration(dest_backend)
+            schedule = config.netapp_snapmirror_schedule
+
+        dest_client.modify_snapmirror_vol(src_vserver,
+                                          src_volume_name,
+                                          dest_vserver,
+                                          dest_volume_name,
+                                          schedule=schedule)
 
     def resume_snapmirror(self, source_share_obj, dest_share_obj):
         """Resume SnapMirror relationship from a quiesced state."""

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -2953,7 +2953,18 @@ class NetAppCmodeFileStorageLibrary(object):
             (timeutils.is_older_than(
                 datetime.datetime.utcfromtimestamp(last_update_timestamp)
                 .isoformat(), 1200))):
-            return constants.REPLICA_STATE_OUT_OF_SYNC
+            current_schedule = snapmirror.get('schedule')
+            new_schedule = self.configuration.netapp_snapmirror_schedule
+            if current_schedule == new_schedule:
+                return constants.REPLICA_STATE_OUT_OF_SYNC
+            else:
+                LOG.debug('Modify snapmirror schedule for replica:'
+                          '%(replica)s from %(from)s to %(to)s',
+                          {'replica': replica['id'],
+                           'from': current_schedule,
+                           'to': new_schedule})
+                dm_session.modify_snapmirror(active_replica, replica,
+                                             schedule=new_schedule)
 
         replica_backend = share_utils.extract_host(replica['host'],
                                                    level='backend_name')

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
@@ -763,6 +763,7 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
             dest_volume=self.fake_dest_vol_name,
             desired_attributes=['relationship-status',
                                 'mirror-state',
+                                'schedule',
                                 'source-vserver',
                                 'source-volume',
                                 'last-transfer-end-timestamp',

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -4331,6 +4331,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
     def test_update_replica_state_stale_snapmirror(self):
         fake_snapmirror = {
             'mirror-state': 'snapmirrored',
+            'schedule': self.library.configuration.netapp_snapmirror_schedule,
             'last-transfer-end-timestamp': '%s' % float(
                 timeutils.utcnow_ts() - 10000)
         }


### PR DESCRIPTION
We want to have conformity. not only new snapmirrors, but also old ones should have a schedule according to the current 'netapp_snapmirror_schedule' config.

Follows ee5d9917c786a8f2011e5a24ae1e56343e02349a and c53cd6105d55c7401b7cbc035791c680768347a2
Change-Id: I1f8f0d1f58d7f4dc540bf7949c32114b4599912c