### PR TITLE
introduce replica_snapshot_state_update_interval

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -106,6 +106,14 @@ share_manager_opts = [
                help='This value, specified in seconds, determines how often '
                     'the share manager will poll for the health '
                     '(replica_state) of each replica instance.'),
+    cfg.IntOpt('replica_snapshot_state_update_interval',
+               default=59,
+               help="This value, specified in seconds, determines how often "
+                    "the share manager will poll for the transition statuses "
+                    "of each replica's snapshot instances. It is most likely "
+                    "a good idea to choose an interval different from "
+                    "'replica_state_update_interval' with a big least common "
+                    "multiple."),
     cfg.IntOpt('migration_driver_continue_update_interval',
                default=60,
                help='This value, specified in seconds, determines how often '
@@ -3986,7 +3994,8 @@ class ShareManager(manager.SchedulerDependentManager):
             self.db.share_snapshot_instance_update(
                 context, instance['id'], instance)
 
-    @periodic_task.periodic_task(spacing=CONF.replica_state_update_interval)
+    @periodic_task.periodic_task(
+        spacing=CONF.replica_snapshot_state_update_interval)
     @utils.require_driver_initialized
     def periodic_share_replica_snapshot_update(self, context):
         LOG.debug("Updating status of share replica snapshots.")


### PR DESCRIPTION
New config option to control periodic task
periodic_share_replica_snapshot_update.
Defaults to 59 to not have many collision with
replica_state_update_interval default setting of 300: least common multiple is 59 * 300 = 17700 (about every 5 hours).

Change-Id: I261e4f54c872fb78ae3c15ca81d54c7a2faa8405