### PR TITLE
SAPCC: use default for NFS4.1 pNFS

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1592,7 +1592,6 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
         if 'nfs4.1' in versions:
             nfs41_opts = {
-                'is-nfsv41-pnfs-enabled': 'true',
                 'is-nfsv41-acl-enabled': 'true',
                 'is-nfsv41-read-delegation-enabled': 'true',
                 'is-nfsv41-write-delegation-enabled': 'true',

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -2521,7 +2521,6 @@ class NetAppClientCmodeTestCase(test.TestCase):
             nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
         if v41:
             nfs41_opts = {
-                'is-nfsv41-pnfs-enabled': 'true',
                 'is-nfsv41-acl-enabled': 'true',
                 'is-nfsv41-read-delegation-enabled': 'true',
                 'is-nfsv41-write-delegation-enabled': 'true',


### PR DESCRIPTION
that means it will be disabled since ONTAP 9.8
see https://docs.netapp.com/us-en/ontap/nfs-admin/enable-disable-pnfs-task.html

Only applies to new vservers, existing ones will not be modified.

This is how upstream is working at the time of writing, too.

Change-Id: Ibf9484643a55628a290c79b569bb01baa8b16f84