### PR TITLE
Recreate security cert during vserver create.

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -289,7 +289,8 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 aggr_set,
                 ipspace_name,
                 self.configuration.netapp_delete_retention_hours,
-                self.configuration.netapp_enable_logical_space_reporting)
+                self.configuration.netapp_enable_logical_space_reporting,
+                self.configuration.netapp_security_cert_expire_days)
 
             vserver_client = self._get_api_client(vserver=vserver_name)
 

--- a/manila/share/drivers/netapp/options.py
+++ b/manila/share/drivers/netapp/options.py
@@ -193,7 +193,15 @@ netapp_provisioning_opts = [
                 help='This option enables the logical space reporting on a '
                      'newly created vserver and locical space accounting '
                      'on newly created volumes on this vserver. ',
-                default=False), ]
+                default=False),
+    cfg.IntOpt('netapp_security_cert_expire_days',
+               min=1,
+               max=3652,
+               default=2190,
+               help='Create security certificate while creating vserver with '
+                    'specified expire days.'),
+
+]
 
 netapp_cluster_opts = [
     cfg.StrOpt('netapp_vserver',

--- a/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
@@ -45,6 +45,7 @@ VSERVER_PEER_NAME = 'fake_vserver_peer'
 ADMIN_VSERVER_NAME = 'fake_admin_vserver'
 NODE_VSERVER_NAME = 'fake_node_vserver'
 NFS_VERSIONS = ['nfs3', 'nfs4.0']
+SECURITY_CERT_EXPIRE_DAYS = 2190
 ROOT_AGGREGATE_NAMES = ('root_aggr1', 'root_aggr2')
 ROOT_VOLUME_AGGREGATE_NAME = 'fake_root_aggr'
 ROOT_VOLUME_NAME = 'fake_root_volume'
@@ -303,6 +304,18 @@ VSERVER_GET_RESPONSE = etree.XML("""
     'aggr1': SHARE_AGGREGATE_NAMES[0],
     'aggr2': SHARE_AGGREGATE_NAMES[1],
 })
+
+SECURITY_CERT_GET_RESPONSE = etree.XML("""
+  <results status="passed">
+    <attributes-list>
+      <certificate-info>
+        <vserver>%(vserver)s</vserver>
+        <serial-number>12345</serial-number>
+      </certificate-info>
+    </attributes-list>
+    <num-records>1</num-records>
+  </results>
+""" % {'vserver': VSERVER_NAME})
 
 VSERVER_DATA_LIST_RESPONSE = etree.XML("""
   <results status="passed">

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -436,17 +436,60 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'vserver-name': fake.VSERVER_NAME
         }
 
+        certificate_create_args = {
+            'vserver': fake.VSERVER_NAME,
+            'common-name': fake.VSERVER_NAME,
+            'type': 'server',
+            'expire-days': fake.SECURITY_CERT_EXPIRE_DAYS,
+        }
+
+        api_response = netapp_api.NaElement(fake.SECURITY_CERT_GET_RESPONSE)
+        self.mock_object(self.client,
+                         'send_iter_request',
+                         mock.Mock(return_value=api_response))
+        certificate_get_args = {
+            'query': {
+                'certificate-info': {
+                    'vserver': fake.VSERVER_NAME,
+                    'common-name': fake.VSERVER_NAME,
+                    'certificate-authority': fake.VSERVER_NAME,
+                    'type': 'server',
+                },
+            },
+            'desired-attributes': {
+                'certificate-info': {
+                    'serial-number': None,
+                },
+            },
+        }
+
+        certificate_delete_args = {
+            'certificate-authority': fake.VSERVER_NAME,
+            'common-name': fake.VSERVER_NAME,
+            'serial-number': '12345',
+            'type': 'server',
+            'vserver': fake.VSERVER_NAME,
+        }
+
         self.client.create_vserver(fake.VSERVER_NAME,
                                    fake.ROOT_VOLUME_AGGREGATE_NAME,
                                    fake.ROOT_VOLUME_NAME,
                                    fake.SHARE_AGGREGATE_NAMES,
                                    None,
                                    16,
-                                   False)
+                                   False,
+                                   fake.SECURITY_CERT_EXPIRE_DAYS)
 
         self.client.send_request.assert_has_calls([
             mock.call('vserver-create', vserver_create_args),
-            mock.call('vserver-modify', vserver_modify_args)])
+            mock.call('vserver-modify', vserver_modify_args),
+            mock.call(
+                'security-certificate-create', certificate_create_args),
+            mock.call(
+                'security-certificate-delete', certificate_delete_args)])
+
+        self.client.send_iter_request.assert_has_calls([
+            mock.call('security-certificate-get-iter', certificate_get_args)])
 
     def test_create_vserver_with_ipspace(self):
 
@@ -468,17 +511,60 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'vserver-name': fake.VSERVER_NAME
         }
 
+        certificate_create_args = {
+            'vserver': fake.VSERVER_NAME,
+            'common-name': fake.VSERVER_NAME,
+            'type': 'server',
+            'expire-days': fake.SECURITY_CERT_EXPIRE_DAYS,
+        }
+
+        api_response = netapp_api.NaElement(fake.SECURITY_CERT_GET_RESPONSE)
+        self.mock_object(self.client,
+                         'send_iter_request',
+                         mock.Mock(return_value=api_response))
+        certificate_get_args = {
+            'query': {
+                'certificate-info': {
+                    'vserver': fake.VSERVER_NAME,
+                    'common-name': fake.VSERVER_NAME,
+                    'certificate-authority': fake.VSERVER_NAME,
+                    'type': 'server',
+                },
+            },
+            'desired-attributes': {
+                'certificate-info': {
+                    'serial-number': None,
+                },
+            },
+        }
+
+        certificate_delete_args = {
+            'certificate-authority': fake.VSERVER_NAME,
+            'common-name': fake.VSERVER_NAME,
+            'serial-number': '12345',
+            'type': 'server',
+            'vserver': fake.VSERVER_NAME,
+        }
+
         self.client.create_vserver(fake.VSERVER_NAME,
                                    fake.ROOT_VOLUME_AGGREGATE_NAME,
                                    fake.ROOT_VOLUME_NAME,
                                    fake.SHARE_AGGREGATE_NAMES,
                                    fake.IPSPACE_NAME,
                                    24,
-                                   False)
+                                   False,
+                                   fake.SECURITY_CERT_EXPIRE_DAYS)
 
         self.client.send_request.assert_has_calls([
             mock.call('vserver-create', vserver_create_args),
-            mock.call('vserver-modify', vserver_modify_args)])
+            mock.call('vserver-modify', vserver_modify_args),
+            mock.call(
+                'security-certificate-create', certificate_create_args),
+            mock.call(
+                'security-certificate-delete', certificate_delete_args)])
+
+        self.client.send_iter_request.assert_has_calls([
+            mock.call('security-certificate-get-iter', certificate_get_args)])
 
     def test_create_vserver_dp_destination(self):
 
@@ -517,7 +603,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                           fake.SHARE_AGGREGATE_NAMES,
                           fake.IPSPACE_NAME,
                           17,
-                          False)
+                          False,
+                          fake.SECURITY_CERT_EXPIRE_DAYS)
 
     def test_get_vserver_root_volume_name(self):
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -612,7 +612,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                 fake.NETWORK_INFO)
         self.library._client.create_vserver.assert_called_once_with(
             vserver_name, fake.ROOT_VOLUME_AGGREGATE, fake.ROOT_VOLUME,
-            set(fake.AGGREGATES), fake.IPSPACE, 12, False)
+            set(fake.AGGREGATES), fake.IPSPACE, 12, False,
+            fake.SECURITY_CERT_EXPIRE_DAYS)
         self.library._get_api_client.assert_called_once_with(
             vserver=vserver_name)
         self.library._create_vserver_lifs.assert_called_once_with(

--- a/manila/tests/share/drivers/netapp/dataontap/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/fakes.py
@@ -69,6 +69,7 @@ AGGREGATE = 'manila_aggr_1'
 AGGREGATES = ('manila_aggr_1', 'manila_aggr_2')
 ROOT_AGGREGATES = ('root_aggr_1', 'root_aggr_2')
 ROOT_VOLUME_AGGREGATE = 'manila1'
+SECURITY_CERT_EXPIRE_DAYS = 2190
 ROOT_VOLUME = 'root'
 CLUSTER_NODE = 'cluster1_01'
 CLUSTER_NODES = ('cluster1_01', 'cluster1_02')


### PR DESCRIPTION
The certificate is automatically created on NetApp with 1 year i.e. 365 days of expiration time, and admin needs to manually extend it. It would be nice Manila can take care to create certs with admin configuable expiration time. Manila can first delete the cert, and then create a new cert with given expiration time while creating share server.