### PR TITLE
sapcc: add new digicert root ca

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -58,6 +58,7 @@ client_cmode_opts = [
             "/etc/ssl/certs/SAP_Global_Sub_CA_04.pem",
             "/etc/ssl/certs/SAP_Global_Sub_CA_05.pem",
             "/etc/ssl/certs/DigiCert_Global_Root_CA.pem",
+            "/etc/ssl/certs/DigiCert_Global_Root_G2.pem",
             ],
         help="Path to the x509 certificate used for secure ldap "
              "connections.")


### PR DESCRIPTION
beginning March 8, 2023 it will be used for issued certs according to https://knowledge.digicert.com/generalinformation/digicert-root-and-intermediate-ca-certificate-updates-2023.html

Change-Id: Ie3a7213bd6fa940110a05c023b56d6c8c5966a80