### PR TITLE
sqlalchemy: add generic repr to base model

### DIFF
--- a/manila/db/sqlalchemy/models.py
+++ b/manila/db/sqlalchemy/models.py
@@ -27,6 +27,7 @@ from sqlalchemy import Column, Integer, String, schema
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import orm
 from sqlalchemy import ForeignKey, DateTime, Boolean, Enum
+from sqlalchemy_utils import generic_repr
 
 from manila.common import constants
 
@@ -35,6 +36,7 @@ BASE = declarative_base()
 LOG = log.getLogger(__name__)
 
 
+@generic_repr
 class ManilaBase(models.ModelBase,
                  models.TimestampMixin,
                  models.SoftDeleteMixin):

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ tenacity>=6.3.1  # Apache-2.0
 Routes>=2.4.1 # MIT
 six>=1.15.0 # MIT
 SQLAlchemy>=1.3.17 # MIT
+SQLAlchemy-Utils>=0.32.12 # BSD License
 stevedore>=3.2.2 # Apache-2.0
 tooz[memcached]>2.7.1 # Apache-2.0
 python-cinderclient!=4.0.0,>=3.3.0 # Apache-2.0


### PR DESCRIPTION
Instead of
`<manila.db.sqlalchemy.models.ShareServer object at 0x7f603645bf40>` we now get
```
ShareServer(created_at=datetime.datetime(2023, 4, 18, 15, 44, 43, 741302),
updated_at=datetime.datetime(2023, 4, 19, 10, 18, 59, 614018),
deleted_at=datetime.datetime(2023, 4, 19, 10, 18, 59, 613577),
id='3363dcd4-fcdd-4cfa-b02d-5899fba3d413',
deleted='3363dcd4-fcdd-4cfa-b02d-5899fba3d413',
share_network_subnet_id='8d4365dc-0869-4896-8049-6455f84ad08f', ...)
```
e.g. in error messages of failed purges or in interactive shell sessions.

Change-Id: I5e6513e7ca7b4a9d4d7261f873cbf3f5bf3c83ab