### PR TITLE
ensure share server: skip default policy rules

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1556,7 +1556,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 raise exception.NetAppException(msg % security_service['type'])
 
     @na_utils.trace
-    def enable_nfs(self, versions, nfs_config=None):
+    def enable_nfs(self, versions, nfs_config=None,
+                   create_default_nfs_export_rules=True):
         """Enables NFS on Vserver."""
         self.send_request('nfs-enable')
         self._enable_nfs_protocols(versions)
@@ -1564,7 +1565,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         if nfs_config:
             self._configure_nfs(nfs_config)
 
-        self._create_default_nfs_export_rules()
+        if create_default_nfs_export_rules:
+            self._create_default_nfs_export_rules()
 
     @na_utils.trace
     def _enable_nfs_protocols(self, versions):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -528,7 +528,8 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         vserver_client = self._get_api_client(vserver=vserver)
         self._create_vserver_routes(vserver_client, network_info)
         vserver_client.enable_nfs(
-            self.configuration.netapp_enabled_share_protocols)
+            self.configuration.netapp_enabled_share_protocols,
+            create_default_nfs_export_rules=False)
         security_services = network_info.get('security_services')
         if security_services:
             for security_service in security_services:


### PR DESCRIPTION
We have been accumulating thousands of those rules. Apparently ontap does not check if such rule is already existing.

Change-Id: I73b02b05c8a3ba6f0eeda0f87f444cb12c550445