### PR TITLE
propogate port quota limit exceeded error

### DIFF
--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -144,6 +144,12 @@ class Detail(object):
           "ticket."))
     FILTER_AFFINITY = ('027', FILTER_MSG % 'AffinityFilter')
     FILTER_ANTI_AFFINITY = ('028', FILTER_MSG % 'AntiAffinityFilter')
+    SHARE_NETWORK_PORT_QUOTA_LIMIT_EXCEEDED = (
+        '029',
+        _("Share Driver failed to create share server on share network "
+          "due to port limit exceeded. You may increase quota of network "
+          "ports and retry your request. If this doesn't work, contact your "
+          "administrator to troubleshoot issues with your network."))
 
     ALL = (
         UNKNOWN_ERROR,
@@ -173,7 +179,8 @@ class Detail(object):
         MISSING_SECURITY_SERVICE,
         DRIVER_FAILED_DELETE_SHARE_SNAPMIRROR,
         FILTER_AFFINITY,
-        FILTER_ANTI_AFFINITY
+        FILTER_ANTI_AFFINITY,
+        SHARE_NETWORK_PORT_QUOTA_LIMIT_EXCEEDED
     )
 
     # Exception and detail mappings

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2113,6 +2113,23 @@ class ShareManager(manager.SchedulerDependentManager):
                         share_group=share_group_ref,
                     )
                 )
+            except exception.PortLimitExceeded:
+                with excutils.save_and_reraise_exception():
+                    error = ("Creation of share instance %s failed: "
+                             "failed to allocate network")
+                    LOG.error(error, share_instance_id)
+                    self.db.share_instance_update(
+                        context, share_instance_id,
+                        {'status': constants.STATUS_ERROR}
+                    )
+                    self.message_api.create(
+                        context,
+                        message_field.Action.CREATE,
+                        share['project_id'],
+                        resource_type=message_field.Resource.SHARE,
+                        resource_id=share_id,
+                        detail=(message_field.Detail
+                                .SHARE_NETWORK_PORT_QUOTA_LIMIT_EXCEEDED))
             except exception.SecurityServiceFailedAuth:
                 with excutils.save_and_reraise_exception():
                     error = ("Provision of share server failed: "

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2117,7 +2117,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "
                              "failed to allocate network")
-                    LOG.error(error, share_instance_id)
+                    LOG.warning(error, share_instance_id)
                     self.db.share_instance_update(
                         context, share_instance_id,
                         {'status': constants.STATUS_ERROR}


### PR DESCRIPTION
When share creation fails due to missing ports quota (' manila.exception.PortLimitExceeded: Maximum number of ports exceeded.'), error message propogated to user is not useful. Improve user message in this scenario.