### PR TITLE
Add error handling in modify_volume()

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2952,7 +2952,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 'volume-space-attributes'][
                     'is-space-enforcement-logical'] = logical_space_reporting
 
-        self.send_request('volume-modify-iter', api_args)
+        result = self.send_request('volume-modify-iter', api_args)
+        failures = result.get_child_content('num-failed')
+        if failures and int(failures) > 0:
+            failure_list = result.get_child_by_name(
+                'failure-list') or netapp_api.NaElement('none')
+            errors = failure_list.get_children()
+            if errors:
+                raise netapp_api.NaApiError(
+                    errors[0].get_child_content('error-code'),
+                    errors[0].get_child_content('error-message'))
 
         if not replica:
             # Efficiency options must be handled separately
@@ -3031,7 +3040,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 },
             },
         }
-        self.send_request('volume-modify-iter', api_args)
+        result = self.send_request('volume-modify-iter', api_args)
+        failures = result.get_child_content('num-failed')
+        if failures and int(failures) > 0:
+            failure_list = result.get_child_by_name(
+                'failure-list') or netapp_api.NaElement('none')
+            errors = failure_list.get_children()
+            if errors:
+                raise netapp_api.NaApiError(
+                    errors[0].get_child_content('error-code'),
+                    errors[0].get_child_content('error-message'))
 
     @na_utils.trace
     def volume_exists(self, volume_name):
@@ -4223,7 +4241,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 },
             },
         }
-        self.send_request('volume-modify-iter', api_args)
+        result = self.send_request('volume-modify-iter', api_args)
+        failures = result.get_child_content('num-failed')
+        if failures and int(failures) > 0:
+            failure_list = result.get_child_by_name(
+                'failure-list') or netapp_api.NaElement('none')
+            errors = failure_list.get_children()
+            if errors:
+                raise netapp_api.NaApiError(
+                    errors[0].get_child_content('error-code'),
+                    errors[0].get_child_content('error-message'))
 
     @na_utils.trace
     def set_qos_policy_group_for_volume(self, volume_name,
@@ -4244,7 +4271,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 },
             },
         }
-        self.send_request('volume-modify-iter', api_args)
+        result = self.send_request('volume-modify-iter', api_args)
+        failures = result.get_child_content('num-failed')
+        if failures and int(failures) > 0:
+            failure_list = result.get_child_by_name(
+                'failure-list') or netapp_api.NaElement('none')
+            errors = failure_list.get_children()
+            if errors:
+                raise netapp_api.NaApiError(
+                    errors[0].get_child_content('error-code'),
+                    errors[0].get_child_content('error-message'))
 
     @na_utils.trace
     def set_qos_adaptive_policy_group_for_volume(self, volume_name,
@@ -4269,7 +4305,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 },
             },
         }
-        self.send_request('volume-modify-iter', api_args)
+        result = self.send_request('volume-modify-iter', api_args)
+        failures = result.get_child_content('num-failed')
+        if failures and int(failures) > 0:
+            failure_list = result.get_child_by_name(
+                'failure-list') or netapp_api.NaElement('none')
+            errors = failure_list.get_children()
+            if errors:
+                raise netapp_api.NaApiError(
+                    errors[0].get_child_content('error-code'),
+                    errors[0].get_child_content('error-message'))
 
     @na_utils.trace
     def get_nfs_export_policy_for_volume(self, volume_name):

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -3696,8 +3696,11 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
     @ddt.data(True, False)
     def test_modify_volume_no_optional_args(self, is_flexgroup):
+        api_response = netapp_api.NaElement(fake.VOLUME_MODIFY_ITER_RESPONSE)
+        self.mock_object(self.client,
+                         'send_request',
+                         mock.Mock(return_value=api_response))
 
-        self.mock_object(self.client, 'send_request')
         mock_update_volume_efficiency_attributes = self.mock_object(
             self.client, 'update_volume_efficiency_attributes')
 
@@ -3750,7 +3753,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
     def test_modify_volume_all_optional_args(self, qos_group,
                                              adaptive_qos_group):
         self.client.features.add_feature('ADAPTIVE_QOS')
-        self.mock_object(self.client, 'send_request')
+        api_response = netapp_api.NaElement(fake.VOLUME_MODIFY_ITER_RESPONSE)
+        self.mock_object(self.client,
+                         'send_request',
+                         mock.Mock(return_value=api_response))
         mock_update_volume_efficiency_attributes = self.mock_object(
             self.client, 'update_volume_efficiency_attributes')
 
@@ -5637,7 +5643,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
     def test_set_nfs_export_policy_for_volume(self):
 
-        self.mock_object(self.client, 'send_request')
+        api_response = netapp_api.NaElement(fake.VOLUME_MODIFY_ITER_RESPONSE)
+        self.mock_object(self.client,
+                         'send_request',
+                         mock.Mock(return_value=api_response))
 
         self.client.set_nfs_export_policy_for_volume(fake.SHARE_NAME,
                                                      fake.EXPORT_POLICY_NAME)
@@ -5663,7 +5672,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
     def test_set_qos_policy_group_for_volume(self):
 
-        self.mock_object(self.client, 'send_request')
+        api_response = netapp_api.NaElement(fake.VOLUME_MODIFY_ITER_RESPONSE)
+        self.mock_object(self.client,
+                         'send_request',
+                         mock.Mock(return_value=api_response))
 
         self.client.set_qos_policy_group_for_volume(fake.SHARE_NAME,
                                                     fake.QOS_POLICY_GROUP_NAME)
@@ -7806,8 +7818,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
     def test_set_qos_adaptive_policy_group_for_volume(self):
 
         self.client.features.add_feature('ADAPTIVE_QOS')
-
-        self.mock_object(self.client, 'send_request')
+        api_response = netapp_api.NaElement(fake.VOLUME_MODIFY_ITER_RESPONSE)
+        self.mock_object(self.client,
+                         'send_request',
+                         mock.Mock(return_value=api_response))
 
         self.client.set_qos_adaptive_policy_group_for_volume(
             fake.SHARE_NAME,


### PR DESCRIPTION
Modify_volume() makes NetApp API call 'volume-modify-iter', but response of API call is not validated against possible errors difficult to debug failure. For example, observed that volume comment not being set on volume created from snapshot (likely due to busy doing clone split)