### PR TITLE
sapcc: go back to default settings for nfsv41

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1711,10 +1711,11 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
         if 'nfs4.1' in versions:
             nfs41_opts = {
-                'is-nfsv41-pnfs-enabled': 'true',
-                'is-nfsv41-acl-enabled': 'true',
-                'is-nfsv41-read-delegation-enabled': 'true',
-                'is-nfsv41-write-delegation-enabled': 'true',
+                # 'is-nfsv41-pnfs-enabled': 'false',               # default false, use default on new vservers, don't touch old vservers  # noqa: E501
+                # 'nfsv4-lease-seconds': 30                        # default 30, HANA multiple host systems would like 10 better  # noqa: E501
+                'is-nfsv41-acl-enabled': 'false',               # default false
+                'is-nfsv41-read-delegation-enabled': 'false',   # default false
+                'is-nfsv41-write-delegation-enabled': 'false',  # default false
             }
 
             nfs_service_modify_args.update(nfs41_opts)

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -2614,10 +2614,9 @@ class NetAppClientCmodeTestCase(test.TestCase):
             nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
         if v41:
             nfs41_opts = {
-                'is-nfsv41-pnfs-enabled': 'true',
-                'is-nfsv41-acl-enabled': 'true',
-                'is-nfsv41-read-delegation-enabled': 'true',
-                'is-nfsv41-write-delegation-enabled': 'true',
+                'is-nfsv41-acl-enabled': 'false',
+                'is-nfsv41-read-delegation-enabled': 'false',
+                'is-nfsv41-write-delegation-enabled': 'false',
             }
 
             nfs_service_modify_args.update(nfs41_opts)


### PR DESCRIPTION
ensure will apply this to all existing vservers. But not for pfns, this will be left untouched and only new vservers will get the default value. This default value is 'false' beginning with ONTAP 9.8, see https://docs.netapp.com/us-en/ontap/nfs-admin/enable-disable-pnfs-task.html

Background: we had trouble with HANA corruption, most likely related to the delegation settings.

Change-Id: Iaad11a79cdbd6955a229eaa20c3320492b87a940