### PR TITLE
sapcc: skip ensure share server on flag

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -464,6 +464,18 @@ class ShareManager(manager.SchedulerDependentManager):
                 )
                 continue
 
+            server_details = share_server.backend_details
+            if 'skip_ensure' in server_details:
+                if server_details['skip_ensure'] == 'yes':
+                    LOG.info(
+                        "Share server %(id)s: skipping export, "
+                        "because it has skip_ensure flag set with reason "
+                        "'%(reason)s'.",
+                        {'id': share_server['id'],
+                         'reason': server_details.get('skip_ensure_comment')},
+                    )
+                    continue
+
             share_network_subnet = self.db.share_network_subnet_get(
                 ctxt, share_server['share_network_subnet_id'])
             share_network = self.db.share_network_get(


### PR DESCRIPTION
if share server details key 'skip_ensure' is set to 'yes' skip the share server ensure run and log a message with the reason given at key 'skip_ensure_comment'

e.g.

```
2023-06-02 09:25:17,935 9 INFO manila.share.manager [req-XXX gNone - - - - -] Share server 7fd26b08-3b4e-42b6-bf75-1c312b80c8ab: skipping export, because it has skip_ensure flag set with reason 'special vserver nfs config for valued client Z'.
```

Change-Id: I5632706ef201c48949544057be4db93ff2f8aff3