### PR TITLE
Delete failed snapshot entry using correct db api

### DIFF
--- a/manila/api/common.py
+++ b/manila/api/common.py
@@ -258,6 +258,16 @@ def check_share_network_is_active(share_network):
         raise webob.exc.HTTPBadRequest(explanation=msg)
 
 
+def check_display_field_length(field, field_name):
+    if field:
+        length = len(field)
+        if length > constants.DB_DISPLAY_FIELDS_MAX_LENGTH:
+            raise exception.InvalidInput(
+                reason=("Please use %(field_name)s up to %(len)d characters."
+                        % {'field_name': field_name,
+                           'len': constants.DB_DISPLAY_FIELDS_MAX_LENGTH}))
+
+
 class ViewBuilder(object):
     """Model API responses as dictionaries."""
 

--- a/manila/api/v1/share_snapshots.py
+++ b/manila/api/v1/share_snapshots.py
@@ -159,6 +159,11 @@ class ShareSnapshotMixin(object):
                        for key in valid_update_keys
                        if key in snapshot_data}
 
+        common.check_display_field_length(
+            update_dict.get('display_name'), 'name')
+        common.check_display_field_length(
+            update_dict.get('display_description'), 'description')
+
         try:
             snapshot = self.share_api.get_snapshot(context, id)
         except exception.NotFound:
@@ -195,12 +200,15 @@ class ShareSnapshotMixin(object):
         # NOTE(rushiagr): v2 API allows name instead of display_name
         if 'name' in snapshot:
             snapshot['display_name'] = snapshot.get('name')
+            common.check_display_field_length(snapshot['display_name'], 'name')
             del snapshot['name']
 
         # NOTE(rushiagr): v2 API allows description instead of
         #                display_description
         if 'description' in snapshot:
             snapshot['display_description'] = snapshot.get('description')
+            common.check_display_field_length(
+                snapshot['display_description'], 'description')
             del snapshot['description']
 
         new_snapshot = self.share_api.create_snapshot(

--- a/manila/api/v1/shares.py
+++ b/manila/api/v1/shares.py
@@ -219,6 +219,11 @@ class ShareMixin(object):
                        for key in valid_update_keys
                        if key in share_data}
 
+        common.check_display_field_length(
+            update_dict.get('display_name'), 'name')
+        common.check_display_field_length(
+            update_dict.get('display_description'), 'description')
+
         try:
             share = self.share_api.get(context, id)
         except exception.NotFound:
@@ -254,12 +259,15 @@ class ShareMixin(object):
         # NOTE(rushiagr): Manila API allows 'name' instead of 'display_name'.
         if share.get('name'):
             share['display_name'] = share.get('name')
+            common.check_display_field_length(share['display_name'], 'name')
             del share['name']
 
         # NOTE(rushiagr): Manila API allows 'description' instead of
         #                 'display_description'.
         if share.get('description'):
             share['display_description'] = share.get('description')
+            common.check_display_field_length(
+                share['display_description'], 'description')
             del share['description']
 
         size = share['size']

--- a/manila/common/constants.py
+++ b/manila/common/constants.py
@@ -16,6 +16,9 @@
 # The maximum value a signed INT type may have
 DB_MAX_INT = 0x7FFFFFFF
 
+# The maximum length a display field may have
+DB_DISPLAY_FIELDS_MAX_LENGTH = 255
+
 # SHARE AND GENERAL STATUSES
 STATUS_CREATING = 'creating'
 STATUS_CREATING_FROM_SNAPSHOT = 'creating_from_snapshot'

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -1372,6 +1372,7 @@ class API(base.Base):
                    'share_proto': share['share_proto']}
 
         try:
+            snapshot = None
             snapshot = self.db.share_snapshot_create(context, options)
             QUOTAS.commit(
                 context, reservations,
@@ -1379,7 +1380,9 @@ class API(base.Base):
         except Exception:
             with excutils.save_and_reraise_exception():
                 try:
-                    self.db.snapshot_delete(context, share['id'])
+                    if snapshot and snapshot['instance']:
+                        self.db.share_snapshot_instance_delete(
+                            context, snapshot['instance']['id'])
                 finally:
                     QUOTAS.rollback(
                         context, reservations,

--- a/manila/tests/api/v1/test_shares.py
+++ b/manila/tests/api/v1/test_shares.py
@@ -449,6 +449,30 @@ class ShareAPITest(test.TestCase):
         self.mock_policy_check.assert_called_once_with(
             req.environ['manila.context'], self.resource_name, 'create')
 
+    @ddt.data(
+        {'name': 'name1', 'description': 'x' * 256},
+        {'name': 'x' * 256, 'description': 'description1'},
+    )
+    @ddt.unpack
+    def test_share_create_invalid_input(self, name, description):
+        self.mock_object(share_api.API, 'create')
+        shr = {
+            "size": 100,
+            "name": name,
+            "description": description,
+            "share_proto": "fakeproto",
+            "availability_zone": "zone1:host1",
+        }
+        body = {"share": shr}
+        req = fakes.HTTPRequest.blank('/v1/fake/shares')
+
+        self.assertRaises(exception.InvalidInput,
+                          self.controller.create,
+                          req,
+                          body)
+        self.mock_policy_check.assert_called_once_with(
+            req.environ['manila.context'], self.resource_name, 'create')
+
     @ddt.data("1.0", "2.0")
     def test_share_create_from_snapshot_not_supported(self, microversion):
         # This create operation should work, because the 1.0 API doesn't check

--- a/releasenotes/notes/bug-1475351-handle-successful-deletion-of-snapshot-if-quota-commit-fails-4d150bf0b71a2fd9.yaml
+++ b/releasenotes/notes/bug-1475351-handle-successful-deletion-of-snapshot-if-quota-commit-fails-4d150bf0b71a2fd9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue during snapshot creation where a database error was being
+    mishandled with dead code. See `Launchpad bug 1475351
+    <https://launchpad.net/bugs/1475351>`_ for more details.


### PR DESCRIPTION
When manila snapshot fails to create either due to DB error or quota error, an exception raised. But this exception fails to delete snapshot in db due to wrong db api call. Fix it by validating presence of snapshot in db and using correct db api calls.