### PR TITLE
NetApp: don't raise filesys-size-fixed on svm migrate

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -4173,7 +4173,7 @@ class NetAppCmodeFileStorageLibrary(object):
                 msg += ("Check if this is due to an ongoing SVM move "
                         "(DR or other migration).")
 
-            LOG.error(msg)
+            LOG.exception(msg)
 
         return server_info
 


### PR DESCRIPTION
most likely the setting will be already set to 'false' anyway and this way extend and shrink can happen

Change-Id: I6703d52e0ee475cf1cf652aff6e95eebd06ec1e1

fixes #105 