### PR TITLE
Add count info in 'snapshot list' API

### DIFF
--- a/manila/api/v1/share_snapshots.py
+++ b/manila/api/v1/share_snapshots.py
@@ -27,6 +27,7 @@ from manila import db
 from manila import exception
 from manila.i18n import _
 from manila import share
+from manila import utils
 
 LOG = log.getLogger(__name__)
 
@@ -97,6 +98,13 @@ class ShareSnapshotMixin(object):
         # Remove keys that are not related to share attrs
         search_opts.pop('limit', None)
         search_opts.pop('offset', None)
+
+        show_count = False
+        if 'with_count' in search_opts:
+            show_count = utils.get_bool_from_api_params(
+                'with_count', search_opts)
+            search_opts.pop('with_count')
+
         sort_key, sort_dir = common.get_sort_params(search_opts)
         key_dict = {"name": "display_name",
                     "description": "display_description"}
@@ -122,19 +130,23 @@ class ShareSnapshotMixin(object):
         common.remove_invalid_options(context, search_opts,
                                       self._get_snapshots_search_options())
 
-        snapshots = self.share_api.get_all_snapshots(
-            context,
-            search_opts=search_opts,
-            limit=limit,
-            offset=offset,
-            sort_key=sort_key,
-            sort_dir=sort_dir,
-        )
+        total_count = None
+        if show_count:
+            count, snapshots = self.share_api.get_all_snapshots_with_count(
+                context, search_opts=search_opts, limit=limit, offset=offset,
+                sort_key=sort_key, sort_dir=sort_dir)
+            total_count = count
+        else:
+            snapshots = self.share_api.get_all_snapshots(
+                context, search_opts=search_opts, limit=limit, offset=offset,
+                sort_key=sort_key, sort_dir=sort_dir)
 
         if is_detail:
-            snapshots = self._view_builder.detail_list(req, snapshots)
+            snapshots = self._view_builder.detail_list(
+                req, snapshots, total_count)
         else:
-            snapshots = self._view_builder.summary_list(req, snapshots)
+            snapshots = self._view_builder.summary_list(
+                req, snapshots, total_count)
         return snapshots
 
     def _get_snapshots_search_options(self):

--- a/manila/api/views/share_snapshots.py
+++ b/manila/api/views/share_snapshots.py
@@ -25,13 +25,13 @@ class ViewBuilder(common.ViewBuilder):
         "add_project_and_user_ids",
     ]
 
-    def summary_list(self, request, snapshots):
+    def summary_list(self, request, snapshots, count=None):
         """Show a list of share snapshots without many details."""
-        return self._list_view(self.summary, request, snapshots)
+        return self._list_view(self.summary, request, snapshots, count)
 
-    def detail_list(self, request, snapshots):
+    def detail_list(self, request, snapshots, count=None):
         """Detailed view of a list of share snapshots."""
-        return self._list_view(self.detail, request, snapshots)
+        return self._list_view(self.detail, request, snapshots, count)
 
     def summary(self, request, snapshot):
         """Generic, non-detailed view of an share snapshot."""
@@ -74,7 +74,7 @@ class ViewBuilder(common.ViewBuilder):
         snapshot_dict['user_id'] = snapshot.get('user_id')
         snapshot_dict['project_id'] = snapshot.get('project_id')
 
-    def _list_view(self, func, request, snapshots):
+    def _list_view(self, func, request, snapshots, count=None):
         """Provide a view for a list of share snapshots."""
         snapshots_list = [func(request, snapshot)['snapshot']
                           for snapshot in snapshots]
@@ -83,6 +83,8 @@ class ViewBuilder(common.ViewBuilder):
                                                      self._collection_name)
         snapshots_dict = {self._collection_name: snapshots_list}
 
+        if count is not None:
+            snapshots_dict['count'] = count
         if snapshots_links:
             snapshots_dict['share_snapshots_links'] = snapshots_links
 

--- a/manila/db/api.py
+++ b/manila/db/api.py
@@ -624,11 +624,30 @@ def share_snapshot_get_all(context, filters=None, limit=None, offset=None,
         sort_key=sort_key, sort_dir=sort_dir)
 
 
+def share_snapshot_get_all_with_count(context, filters=None, limit=None,
+                                      offset=None, sort_key=None,
+                                      sort_dir=None):
+    """Get all snapshots."""
+    return IMPL.share_snapshot_get_all_with_count(
+        context, filters=filters, limit=limit, offset=offset,
+        sort_key=sort_key, sort_dir=sort_dir)
+
+
 def share_snapshot_get_all_by_project(context, project_id, filters=None,
                                       limit=None, offset=None, sort_key=None,
                                       sort_dir=None):
     """Get all snapshots belonging to a project."""
     return IMPL.share_snapshot_get_all_by_project(
+        context, project_id, filters=filters, limit=limit, offset=offset,
+        sort_key=sort_key, sort_dir=sort_dir)
+
+
+def share_snapshot_get_all_by_project_with_count(context, project_id,
+                                                 filters=None, limit=None,
+                                                 offset=None, sort_key=None,
+                                                 sort_dir=None):
+    """Get all snapshots belonging to a project."""
+    return IMPL.share_snapshot_get_all_by_project_with_count(
         context, project_id, filters=filters, limit=limit, offset=offset,
         sort_key=sort_key, sort_dir=sort_dir)
 

--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -3006,7 +3006,8 @@ def share_snapshot_get(context, snapshot_id, session=None):
 def _share_snapshot_get_all_with_filters(context, project_id=None,
                                          share_id=None, filters=None,
                                          limit=None, offset=None,
-                                         sort_key=None, sort_dir=None):
+                                         sort_key=None, sort_dir=None,
+                                         show_count=False):
     """Retrieves all snapshots.
 
     If no sorting parameters are specified then returned snapshots are sorted
@@ -3067,13 +3068,25 @@ def _share_snapshot_get_all_with_filters(context, project_id=None,
     query = exact_filter(query, models.ShareSnapshot,
                          filters, legal_filter_keys)
 
-    query = utils.paginate_query(query, models.ShareSnapshot, limit,
-                                 sort_key=sort_key,
-                                 sort_dir=sort_dir,
-                                 offset=offset)
+    query = apply_sorting(models.ShareSnapshot, query, sort_key, sort_dir)
 
-    # Returns list of shares that satisfy filters
-    return query.all()
+    count = None
+    if show_count:
+        count = query.count()
+
+    if limit is not None:
+        query = query.limit(limit)
+
+    if offset:
+        query = query.offset(offset)
+
+    # Returns list of share snapshots that satisfy filters
+    query = query.all()
+
+    if show_count:
+        return count, query
+
+    return query
 
 
 @require_admin_context
@@ -3084,6 +3097,17 @@ def share_snapshot_get_all(context, filters=None, limit=None, offset=None,
         offset=offset, sort_key=sort_key, sort_dir=sort_dir)
 
 
+@require_admin_context
+def share_snapshot_get_all_with_count(context, filters=None, limit=None,
+                                      offset=None, sort_key=None,
+                                      sort_dir=None):
+    count, query = _share_snapshot_get_all_with_filters(
+        context, filters=filters, limit=limit,
+        offset=offset, sort_key=sort_key, sort_dir=sort_dir,
+        show_count=True)
+    return count, query
+
+
 @require_context
 def share_snapshot_get_all_by_project(context, project_id, filters=None,
                                       limit=None, offset=None,
@@ -3092,6 +3116,19 @@ def share_snapshot_get_all_by_project(context, project_id, filters=None,
     return _share_snapshot_get_all_with_filters(
         context, project_id=project_id, filters=filters, limit=limit,
         offset=offset, sort_key=sort_key, sort_dir=sort_dir)
+
+
+@require_context
+def share_snapshot_get_all_by_project_with_count(context, project_id,
+                                                 filters=None, limit=None,
+                                                 offset=None, sort_key=None,
+                                                 sort_dir=None):
+    authorize_project_context(context, project_id)
+    count, query = _share_snapshot_get_all_with_filters(
+        context, project_id=project_id, filters=filters, limit=limit,
+        offset=offset, sort_key=sort_key, sort_dir=sort_dir,
+        show_count=True)
+    return count, query
 
 
 @require_context

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -1936,6 +1936,21 @@ class API(base.Base):
 
     def get_all_snapshots(self, context, search_opts=None, limit=None,
                           offset=None, sort_key='share_id', sort_dir='desc'):
+        return self._get_all_snapshots(context, search_opts=search_opts,
+                                       limit=limit, offset=offset,
+                                       sort_key=sort_key, sort_dir=sort_dir)
+
+    def get_all_snapshots_with_count(self, context, search_opts=None,
+                                     limit=None, offset=None,
+                                     sort_key='share_id', sort_dir='desc'):
+        return self._get_all_snapshots(context, search_opts=search_opts,
+                                       limit=limit, offset=offset,
+                                       sort_key=sort_key, sort_dir=sort_dir,
+                                       show_count=True)
+
+    def _get_all_snapshots(self, context, search_opts=None, limit=None,
+                           offset=None, sort_key='share_id', sort_dir='desc',
+                           show_count=False):
         policy.check_policy(context, 'share_snapshot', 'get_all_snapshots')
 
         search_opts = search_opts or {}
@@ -1952,17 +1967,32 @@ class API(base.Base):
                         "'%(v)s'.") % {'k': k, 'v': string_args[k]}
                 raise exception.InvalidInput(reason=msg)
 
+        get_methods = {
+            'get_all': (
+                self.db.share_snapshot_get_all_with_count
+                if show_count else self.db.share_snapshot_get_all),
+            'get_all_by_project': (
+                self.db.share_snapshot_get_all_by_project_with_count
+                if show_count else self.db.share_snapshot_get_all_by_project)}
+
         if context.is_admin and all_tenants:
-            snapshots = self.db.share_snapshot_get_all(
+            result = get_methods['get_all'](
                 context, filters=search_opts, limit=limit, offset=offset,
                 sort_key=sort_key, sort_dir=sort_dir)
         else:
-            snapshots = self.db.share_snapshot_get_all_by_project(
+            result = get_methods['get_all_by_project'](
                 context, context.project_id, filters=search_opts,
                 limit=limit, offset=offset, sort_key=sort_key,
                 sort_dir=sort_dir)
 
-        return snapshots
+        if show_count:
+            count = result[0]
+            snapshots = result[1]
+        else:
+            snapshots = result
+
+        result = (count, snapshots) if show_count else snapshots
+        return result
 
     def get_latest_snapshot_for_share(self, context, share_id):
         """Get the newest snapshot of a share."""

--- a/manila/tests/db/sqlalchemy/test_api.py
+++ b/manila/tests/db/sqlalchemy/test_api.py
@@ -3297,6 +3297,42 @@ class ShareServerDatabaseAPITestCase(test.TestCase):
             self.ctxt, host, updated_before)
         self.assertEqual(expected_len, len(unused_deletable))
 
+    @ddt.data(
+        ({'with_count': True}, 3, 3),
+        ({'with_count': True, 'limit': 2}, 3, 2)
+    )
+    @ddt.unpack
+    def test_share_snapshot_get_all_with_count(self, filters,
+                                               amount_of_share_snapshots,
+                                               expected_share_snapshots_len):
+        share = db_utils.create_share(size=1)
+        values = {
+            'share_id': share['id'],
+            'size': share['size'],
+            'user_id': share['user_id'],
+            'project_id': share['project_id'],
+            'status': constants.STATUS_CREATING,
+            'progress': '0%',
+            'share_size': share['size'],
+            'display_description': 'fake_count_test',
+            'share_proto': share['share_proto'],
+        }
+
+        # consider only shares created in this function
+        filters.update({'share_id': share['id']})
+
+        for i in range(amount_of_share_snapshots):
+            tmp_values = copy.deepcopy(values)
+            tmp_values['display_name'] = 'fake_name_%s' % str(i)
+            db_api.share_snapshot_create(self.ctxt, tmp_values)
+
+        limit = filters.get('limit')
+        count, share_snapshots = db_api.share_snapshot_get_all_with_count(
+            self.ctxt, filters=filters, limit=limit)
+
+        self.assertEqual(count, amount_of_share_snapshots)
+        self.assertEqual(expected_share_snapshots_len, len(share_snapshots))
+
     @ddt.data({'host': 'fakepool@fakehost'},
               {'status': constants.STATUS_SERVER_MIGRATING_TO},
               {'source_share_server_id': 'fake_ss_id'},


### PR DESCRIPTION
Added support for display count info in share snapshot list&detail APIs:

1. /v2/snapshots?with_count=True
2. /v2/snapshots/detail?with_count=True

Note - New version added 2.79 in upstream master and not in xena-m3.

Closes-bug: #2024556