### PR TITLE
sapcc: raise again on share from snap az mismatch

### DIFF
--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -229,17 +229,16 @@ class API(base.Base):
                 availability_zone = source_share_az
             elif (availability_zone != source_share_az
                   and not CONF.use_scheduler_creating_share_from_snapshot):
-                error_msg = (_("az: %(az)s, source:  %(source_az)s."
-                               "The specified availability zone must be the "
-                               "same as parent share when you have the "
-                               "configuration option "
-                               "'use_scheduler_creating_share_from_snapshot' "
-                               "set to False.") % dict(
+                msg = ("The specified availability zone must be the same "
+                       "as the parent share when creating from snapshot.")
+                error_msg = (("az: %(az)s, source:  %(source_az)s. %(msg)s"
+                              "You have the configuration option "
+                              "'use_scheduler_creating_share_from_snapshot' "
+                              "set to False.") % dict(
+                             msg=msg,
                              az=availability_zone,
                              source_az=source_share_az))
                 LOG.error(error_msg)
-                msg = _("The specified availability zone must be the same "
-                        "as the parent share when creating from snapshot.")
                 raise exception.InvalidInput(reason=msg)
             if share_type is None:
                 # Grab the source share's share_type if no new share type

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -238,9 +238,9 @@ class API(base.Base):
                              az=availability_zone,
                              source_az=source_share_az))
                 LOG.error(error_msg)
-                # msg = _("The specified availability zone must be the same "
-                #         "as the parent share when creating from snapshot.")
-                # raise exception.InvalidInput(reason=msg)
+                msg = _("The specified availability zone must be the same "
+                        "as the parent share when creating from snapshot.")
+                raise exception.InvalidInput(reason=msg)
             if share_type is None:
                 # Grab the source share's share_type if no new share type
                 # has been provided.

--- a/manila/tests/share/test_api.py
+++ b/manila/tests/share/test_api.py
@@ -2315,18 +2315,18 @@ class ShareAPITestCase(test.TestCase):
             self.context, 'reservation', share_type_id=share_type['id']
         )
 
-    # def test_create_from_snapshot_az_different_from_source(self):
-    #     snapshot, share, share_data, request_spec = (
-    #         self._setup_create_from_snapshot_mocks(use_scheduler=False)
-    #     )
-    #
-    #     self.assertRaises(exception.InvalidInput, self.api.create,
-    #                       self.context, share_data['share_proto'],
-    #                       share_data['size'],
-    #                       share_data['display_name'],
-    #                       share_data['display_description'],
-    #                       snapshot_id=snapshot['id'],
-    #                       availability_zone='fake_different_az')
+    def test_create_from_snapshot_az_different_from_source(self):
+        snapshot, share, share_data, request_spec = (
+            self._setup_create_from_snapshot_mocks(use_scheduler=False)
+        )
+
+        self.assertRaises(exception.InvalidInput, self.api.create,
+                          self.context, share_data['share_proto'],
+                          share_data['size'],
+                          share_data['display_name'],
+                          share_data['display_description'],
+                          snapshot_id=snapshot['id'],
+                          availability_zone='fake_different_az')
 
     def test_create_from_snapshot_with_different_share_type(self):
         snapshot, share, share_data, request_spec = (


### PR DESCRIPTION
error is no popping up, on the other hand not throwing the excpetion causes inconsistencies (shares reporting wrong AZ)

Change-Id: I562a4bfb3339b738c4d67f78166bbc3e1b3b0a11

undo https://github.com/sapcc/manila/commit/ed19c196df72a3bdac833364c8c8868765b7d542