### PR TITLE
Add pyreloader to custom requirements

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,5 +1,6 @@
 raven
 paste
+pyreloader
 
 git+https://github.com/sapcc/python-agentliveness.git#egg=agentliveness
 git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
@@ -9,4 +10,3 @@ git+https://github.com/sapcc/manila-extensions.git@master#egg=manila-extensions
 
 # needs for osprofiler
 jaeger-client
-


### PR DESCRIPTION
The package `pyreloader` can reload the service on SIGHUP. It makes debugging easier in the k8s container. To use it, just start the service with pyreloader. E.g. `dumb-init pyreloader maila-share ...`.