### PR TITLE
sapcc: fix postponing "clone split" to last step

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -1713,12 +1713,16 @@ class NetAppCmodeFileStorageLibrary(object):
 
         hide_snapdir = provisioning_options.pop('hide_snapdir')
 
+        # sapcc: Override split option from share type specs. Also clone split
+        # is postponed to last step, to avoid busy volume error.
+        split = provisioning_options.pop('split', split)
+
         LOG.debug('Creating share from snapshot %s', snapshot['id'])
         vserver_client.create_volume_clone(
-            share_name, parent_share_name, parent_snapshot_name,
+            share_name, parent_share_name, parent_snapshot_name, split=False,
             **provisioning_options)
 
-        # ccloud: set share comment
+        # sapcc: set share comment
         vserver_client.modify_volume(aggregate_name, share_name,
                                      comment=share_comment,
                                      **provisioning_options)
@@ -1747,7 +1751,7 @@ class NetAppCmodeFileStorageLibrary(object):
                                                **provisioning_options)
 
         # split at the end: not be blocked by a busy volume
-        if split is not None:
+        if split:
             vserver_client.volume_clone_split_start(share_name)
 
     @na_utils.trace

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -2086,7 +2086,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             fake_share_inst, fake.VSERVER1, vserver_client=vserver_client)
         vserver_client.create_volume_clone.assert_called_once_with(
             share_name, parent_share_name, parent_snapshot_name,
-            **provisioning_options)
+            split=False, **provisioning_options)
         if size > original_snapshot_size:
             vserver_client.set_volume_size.assert_called_once_with(
                 share_name, size, snapshot_reserve_percent=8,


### PR DESCRIPTION
When creating a share from Snapshot and clone split needed, we want to postpone it to the last step. But it didn't happen as expected. The split controlling variable is overriden by share type specs. This PR fixes the issue by explictly reading the corresponding specs option into the controlling vairable. Fixes issue https://github.com/sapcc/manila/issues/118.