### PR TITLE
Fix delay clone split when creating share from snapshot

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -3575,7 +3575,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
     @na_utils.trace
     def create_volume_clone(self, volume_name, parent_volume_name,
-                            parent_snapshot_name=None, split=False,
+                            parent_snapshot_name=None,
                             qos_policy_group=None,
                             adaptive_qos_policy_group=None, **options):
         """Clones a volume."""
@@ -3590,9 +3590,6 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             api_args['qos-policy-group-name'] = qos_policy_group
 
         self.send_request('volume-clone-create', api_args)
-
-        if split:
-            self.volume_clone_split_start(volume_name)
 
         if adaptive_qos_policy_group is not None:
             self.set_qos_adaptive_policy_group_for_volume(

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -1713,16 +1713,12 @@ class NetAppCmodeFileStorageLibrary(object):
 
         hide_snapdir = provisioning_options.pop('hide_snapdir')
 
-        # sapcc: Override split option from share type specs. Also clone split
-        # is postponed to last step, to avoid busy volume error.
-        split = provisioning_options.pop('split', split)
-
         LOG.debug('Creating share from snapshot %s', snapshot['id'])
         vserver_client.create_volume_clone(
-            share_name, parent_share_name, parent_snapshot_name, split=False,
+            share_name, parent_share_name, parent_snapshot_name,
             **provisioning_options)
 
-        # sapcc: set share comment
+        # ccloud: set share comment
         vserver_client.modify_volume(aggregate_name, share_name,
                                      comment=share_comment,
                                      **provisioning_options)
@@ -1751,7 +1747,7 @@ class NetAppCmodeFileStorageLibrary(object):
                                                **provisioning_options)
 
         # split at the end: not be blocked by a busy volume
-        if split:
+        if split is not None:
             vserver_client.volume_clone_split_start(share_name)
 
     @na_utils.trace

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -1713,6 +1713,10 @@ class NetAppCmodeFileStorageLibrary(object):
 
         hide_snapdir = provisioning_options.pop('hide_snapdir')
 
+        # split in args takes precedence over split in provisioning_options
+        if split is None:
+            split = provisioning_options.pop('split')
+
         LOG.debug('Creating share from snapshot %s', snapshot['id'])
         vserver_client.create_volume_clone(
             share_name, parent_share_name, parent_snapshot_name,
@@ -1747,7 +1751,7 @@ class NetAppCmodeFileStorageLibrary(object):
                                                **provisioning_options)
 
         # split at the end: not be blocked by a busy volume
-        if split is not None:
+        if split:
             vserver_client.volume_clone_split_start(share_name)
 
     @na_utils.trace

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -4619,7 +4619,6 @@ class NetAppClientCmodeTestCase(test.TestCase):
                                  adaptive_qos_policy_group_name):
         self.client.features.add_feature('ADAPTIVE_QOS')
         self.mock_object(self.client, 'send_request')
-        self.mock_object(self.client, 'volume_clone_split_start')
         set_qos_adapt_mock = self.mock_object(
             self.client,
             'set_qos_adaptive_policy_group_for_volume')
@@ -4645,35 +4644,6 @@ class NetAppClientCmodeTestCase(test.TestCase):
             set_qos_adapt_mock.assert_called_once_with(
                 fake.SHARE_NAME, fake.ADAPTIVE_QOS_POLICY_GROUP_NAME
             )
-        self.client.send_request.assert_has_calls([
-            mock.call('volume-clone-create', volume_clone_create_args)])
-        self.assertFalse(self.client.volume_clone_split_start.called)
-
-    @ddt.data(True, False)
-    def test_create_volume_clone_split(self, split):
-
-        self.mock_object(self.client, 'send_request')
-        self.mock_object(self.client, 'volume_clone_split_start')
-
-        self.client.create_volume_clone(fake.SHARE_NAME,
-                                        fake.PARENT_SHARE_NAME,
-                                        fake.PARENT_SNAPSHOT_NAME,
-                                        split=split)
-
-        volume_clone_create_args = {
-            'volume': fake.SHARE_NAME,
-            'parent-volume': fake.PARENT_SHARE_NAME,
-            'parent-snapshot': fake.PARENT_SNAPSHOT_NAME,
-            'junction-path': '/%s' % fake.SHARE_NAME
-        }
-
-        self.client.send_request.assert_has_calls([
-            mock.call('volume-clone-create', volume_clone_create_args)])
-        if split:
-            self.client.volume_clone_split_start.assert_called_once_with(
-                fake.SHARE_NAME)
-        else:
-            self.assertFalse(self.client.volume_clone_split_start.called)
 
     @ddt.data(None,
               mock.Mock(side_effect=netapp_api.NaApiError(

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -2074,6 +2074,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             fake_snapshot,
             vserver,
             vserver_client,
+            split=split,
             create_fpolicy=create_fpolicy)
 
         share_name = self.library._get_backend_share_name(
@@ -2106,6 +2107,15 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                 **provisioning_options)
         else:
             mock_create_fpolicy.assert_not_called()
+
+        if split is None:
+            vserver_client.volume_clone_split_start.assert_called_once_with(
+                fake.SHARE_INSTANCE_NAME)
+        if split:
+            vserver_client.volume_clone_split_start.assert_called_once_with(
+                fake.SHARE_INSTANCE_NAME)
+        if split is False:
+            vserver_client.volume_clone_split_start.assert_not_called()
 
     def test_share_exists(self):
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -2086,7 +2086,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             fake_share_inst, fake.VSERVER1, vserver_client=vserver_client)
         vserver_client.create_volume_clone.assert_called_once_with(
             share_name, parent_share_name, parent_snapshot_name,
-            split=False, **provisioning_options)
+            **provisioning_options)
         if size > original_snapshot_size:
             vserver_client.set_volume_size.assert_called_once_with(
                 share_name, size, snapshot_reserve_percent=8,


### PR DESCRIPTION
We want to delay split clone to avoid "Volume busy" errors.  However, previous fix dd13d5a does not work properly, see the issue #118. This is also a rework of #117, which follows the fix and did not consider that `split` argument should take precedence over the `split` field in `provisioning_options`.