### PR TITLE
Fix count response of shares/snapshots list API

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -2297,7 +2297,7 @@ def _share_get_all_with_filters(context, project_id=None, share_server_id=None,
     # NOTE(carloss): Count must be calculated before limit and offset are
     # applied into the query.
     if show_count:
-        count = query.count()
+        count = query.order_by(models.Share.id).distinct().count()
 
     # Returns list of shares that satisfy filters.
     query = query.all()
@@ -3072,7 +3072,7 @@ def _share_snapshot_get_all_with_filters(context, project_id=None,
 
     count = None
     if show_count:
-        count = query.count()
+        count = query.order_by(models.ShareSnapshot.id).distinct().count()
 
     if limit is not None:
         query = query.limit(limit)

--- a/manila/tests/db/sqlalchemy/test_api.py
+++ b/manila/tests/db/sqlalchemy/test_api.py
@@ -584,9 +584,16 @@ class ShareDatabaseAPITestCase(test.TestCase):
     @ddt.unpack
     def test_share_get_all_with_count(self, filters, amount_of_shares,
                                       expected_shares_len):
-        [db_utils.create_share(display_name='fake_name_%s' % str(i))
-         for i in range(amount_of_shares)]
+        c_shares = [
+            db_utils.create_share(display_name='fake_name_%s' % str(i))
+            for i in range(amount_of_shares)]
 
+        # create one more share instance
+        db_utils.create_share_instance(share_id=c_shares[0]['id'])
+        db_utils.create_share_instance(share_id=c_shares[1]['id'])
+        db_utils.create_share_instance(share_id=c_shares[2]['id'])
+
+        # make sure we return shares count and not share instances.
         count, shares = db_api.share_get_all_with_count(
             self.ctxt, filters=filters)
 


### PR DESCRIPTION
Share/Snapshot list API return count of shares/snapshots. But it return the wrong count as it consider ShareInstances/SnapshotInstances. So filter queries by unique share_id/snapshot_id.