### PR TITLE
fix port network type

### DIFF
--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -446,6 +446,7 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
             for segment in neutron_network['segments']:
                 if (segment['provider:physical_network'] == phys_net):
                     vlan = segment['provider:segmentation_id']
+                    network_type = segment['provider:network_type']
                     break
             if vlan is None:
                 msg = _('Network segment not found on host %s') % host
@@ -457,7 +458,9 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
                 port_data = self.db.network_allocation_get(context, port.id)
                 port_data['label'] = phys_net
                 port_data['segmentation_id'] = vlan
+                port_data['network_type'] = network_type
                 port_data['id'] = None
+                port_data['created_at'] = None
                 dest_port_bindings.append(
                     self.db.network_allocation_create(context, port_data))
 


### PR DESCRIPTION
network_type should not be empty when extending networks with new network allocations

e.g. in NetApp driver the network type is important to determine the multi-tenancy, i.e. usage of ipspaces or not

Change-Id: If665346925c1000a47962248fff712069d7cd529