### PR TITLE
Delete share network subnet during network deletion

### DIFF
--- a/manila/api/v2/share_networks.py
+++ b/manila/api/v2/share_networks.py
@@ -131,6 +131,7 @@ class ShareNetworkController(wsgi.Controller, wsgi.AdminActionsMixin):
         for subnet in share_network['share_network_subnets']:
             for share_server in subnet['share_servers']:
                 self.share_rpcapi.delete_share_server(context, share_server)
+            db_api.share_network_subnet_delete(context, subnet['id'])
 
         db_api.share_network_delete(context, id)
 

--- a/manila/tests/api/v2/test_share_networks.py
+++ b/manila/tests/api/v2/test_share_networks.py
@@ -334,6 +334,7 @@ class ShareNetworkAPITest(test.TestCase):
                          '_all_share_servers_are_auto_deletable',
                          mock.Mock(return_value=True))
         self.mock_object(db_api, 'share_network_delete')
+        self.mock_object(db_api, 'share_network_subnet_delete')
 
         self.controller.delete(self.req, share_nw['id'])
 
@@ -347,6 +348,8 @@ class ShareNetworkAPITest(test.TestCase):
             mock.call(self.req.environ['manila.context'], 'bar')])
         db_api.share_network_delete.assert_called_once_with(
             self.req.environ['manila.context'], share_nw['id'])
+        db_api.share_network_subnet_delete.assert_called_once_with(
+            self.req.environ['manila.context'], subnet['id'])
 
     def test_delete_not_found(self):
         share_nw = 'fake network id'
@@ -375,6 +378,7 @@ class ShareNetworkAPITest(test.TestCase):
                          mock.Mock(return_value=True))
         self.mock_object(self.controller.share_rpcapi, 'delete_share_server')
         self.mock_object(db_api, 'share_network_delete')
+        self.mock_object(db_api, 'share_network_subnet_delete')
         self.mock_object(share_networks.QUOTAS, 'reserve',
                          mock.Mock(side_effect=Exception))
         self.mock_object(share_networks.QUOTAS, 'commit')


### PR DESCRIPTION
Share network subnet is deleted during share network deletion which was missing earlier causing lots of stale db entries.

Change-Id: Idb58b4ca389cfb1aaf8f9f1f8aa2fd15979c4872