### PR TITLE
Use share server name from share server identifier

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -1221,7 +1221,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         if (dest_client.is_svm_migrate_supported()
                 and src_client.is_svm_migrate_supported()):
             source_share_server_name = self._get_vserver_name(
-                source_share_server['id'])
+                source_share_server['identifier'])
 
             # Check if the migration is supported.
             try:
@@ -1451,7 +1451,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         # Prepare the migration request.
         src_cluster_name = src_client.get_cluster_name()
         source_share_server_name = self._get_vserver_name(
-            source_share_server['id'])
+            source_share_server['identifier'])
 
         # 3. Send the migration request to ONTAP.
         try:

--- a/manila/tests/share/drivers/netapp/dataontap/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/fakes.py
@@ -530,6 +530,7 @@ NETWORK_INFO_NETMASK = '255.255.255.0'
 SHARE_SERVER = {
     'id': 'fake_id',
     'share_network_id': 'c5b3a865-56d0-4d88-abe5-879965e099c9',
+    'identifier': 'fake_id',
     'backend_details': {
         'vserver_name': VSERVER1
     },


### PR DESCRIPTION
Instead of using the identifier the migration methods are deriving the vserver name from the share server id. This causes failure for migrate a share server that had been migrated before.