### PR TITLE
Improve logging when creating shares

### DIFF
--- a/manila/api/v1/shares.py
+++ b/manila/api/v1/shares.py
@@ -436,6 +436,18 @@ class ShareMixin(object):
                                           display_description,
                                           **kwargs)
 
+        msg = "Share {share_id} created".format(share_id=new_share['id'])
+        if kwargs.get('snapshot_id'):
+            msg += " from snapshot {snapshot_id}".format(
+                snapshot_id=kwargs['snapshot_id'])
+        if kwargs.get('share_network_id'):
+            msg += " in share network {share_network_id}".format(
+                share_network_id=kwargs['share_network_id'])
+        if kwargs.get('scheduler_hints'):
+            msg += " with scheduler hints: {hints}".format(
+                hints=kwargs['scheduler_hints'])
+        LOG.info(msg, context=context)
+
         return self._view_builder.detail(req, new_share)
 
     @staticmethod

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2135,7 +2135,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "
                              "failed to allocate network")
-                    LOG.warning(error, share_instance_id)
+                    LOG.error(error, share_instance_id)
                     self.db.share_instance_update(
                         context, share_instance_id,
                         {'status': constants.STATUS_ERROR}
@@ -2170,7 +2170,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "
                              "failed to get share server.")
-                    LOG.warning(error, share_instance_id)
+                    LOG.error(error, share_instance_id)
                     self.db.share_instance_update(
                         context, share_instance_id,
                         {'status': constants.STATUS_ERROR}
@@ -2278,7 +2278,7 @@ class ShareManager(manager.SchedulerDependentManager):
                     self.db.share_export_locations_update(
                         context, share_instance['id'], export_locations)
                 else:
-                    LOG.warning('Share instance information in exception '
+                    LOG.error('Share instance information in exception '
                                 'can not be written to db because it '
                                 'contains %s and it is not a dictionary.',
                                 detail_data)

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2135,7 +2135,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "
                              "failed to allocate network")
-                    LOG.error(error, share_instance_id)
+                    LOG.warning(error, share_instance_id)
                     self.db.share_instance_update(
                         context, share_instance_id,
                         {'status': constants.STATUS_ERROR}
@@ -2153,7 +2153,7 @@ class ShareManager(manager.SchedulerDependentManager):
                     error = ("Provision of share server failed: "
                              "failed to authenticate user "
                              "against security server.")
-                    LOG.error(error)
+                    LOG.warning(error)
                     self.db.share_instance_update(
                         context, share_instance_id,
                         {'status': constants.STATUS_ERROR}
@@ -2170,7 +2170,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "
                              "failed to get share server.")
-                    LOG.error(error, share_instance_id)
+                    LOG.warning(error, share_instance_id)
                     self.db.share_instance_update(
                         context, share_instance_id,
                         {'status': constants.STATUS_ERROR}
@@ -2278,10 +2278,10 @@ class ShareManager(manager.SchedulerDependentManager):
                     self.db.share_export_locations_update(
                         context, share_instance['id'], export_locations)
                 else:
-                    LOG.error(('Share instance information in exception '
-                               'can not be written to db because it '
-                               'contains %s and it is not a dictionary.'),
-                              detail_data)
+                    LOG.warning('Share instance information in exception '
+                                'can not be written to db because it '
+                                'contains %s and it is not a dictionary.',
+                                detail_data)
                 self.db.share_instance_update(
                     context, share_instance_id,
                     {'status': constants.STATUS_ERROR}

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2278,10 +2278,10 @@ class ShareManager(manager.SchedulerDependentManager):
                     self.db.share_export_locations_update(
                         context, share_instance['id'], export_locations)
                 else:
-                    LOG.error('Share instance information in exception '
-                                'can not be written to db because it '
-                                'contains %s and it is not a dictionary.',
-                                detail_data)
+                    LOG.error(('Share instance information in exception '
+                               'can not be written to db because it '
+                               'contains %s and it is not a dictionary.'),
+                              detail_data)
                 self.db.share_instance_update(
                     context, share_instance_id,
                     {'status': constants.STATUS_ERROR}

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -2202,7 +2202,7 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(db,
                          'share_network_subnet_get_by_availability_zone_id',
                          mock.Mock(return_value=share_net_subnet))
-        self.mock_object(manager.LOG, 'warning')
+        self.mock_object(manager.LOG, 'error')
 
         def raise_share_server_not_found(*args, **kwargs):
             raise exception.ShareServerNotFound(
@@ -2241,8 +2241,8 @@ class ShareManagerTestCase(test.TestCase):
         self.share_manager._setup_server.assert_called_once_with(
             utils.IsAMatcher(context.RequestContext), fake_server,
             fake_metadata)
-        manager.LOG.warning.assert_called_with(mock.ANY,
-                                               fake_share.instance['id'])
+        manager.LOG.error.assert_called_with(mock.ANY,
+                                             fake_share.instance['id'])
         self.share_manager.message_api.create.assert_called_once_with(
             utils.IsAMatcher(context.RequestContext),
             message_field.Action.CREATE,
@@ -2254,7 +2254,7 @@ class ShareManagerTestCase(test.TestCase):
     def test_create_share_instance_with_share_network_subnet_not_found(self):
         """Test creation fails if share network not found."""
 
-        self.mock_object(manager.LOG, 'warning')
+        self.mock_object(manager.LOG, 'error')
 
         share = db_utils.create_share(share_network_id='fake-net-id')
         share_id = share['id']
@@ -2264,7 +2264,7 @@ class ShareManagerTestCase(test.TestCase):
             self.context,
             share.instance['id']
         )
-        manager.LOG.warning.assert_called_with(mock.ANY, share.instance['id'])
+        manager.LOG.error.assert_called_with(mock.ANY, share.instance['id'])
         shr = db.share_get(self.context, share_id)
         self.assertEqual(constants.STATUS_ERROR, shr['status'])
         self.share_manager.message_api.create.assert_called_once_with(

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -2202,7 +2202,7 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(db,
                          'share_network_subnet_get_by_availability_zone_id',
                          mock.Mock(return_value=share_net_subnet))
-        self.mock_object(manager.LOG, 'error')
+        self.mock_object(manager.LOG, 'warning')
 
         def raise_share_server_not_found(*args, **kwargs):
             raise exception.ShareServerNotFound(
@@ -2241,8 +2241,8 @@ class ShareManagerTestCase(test.TestCase):
         self.share_manager._setup_server.assert_called_once_with(
             utils.IsAMatcher(context.RequestContext), fake_server,
             fake_metadata)
-        manager.LOG.error.assert_called_with(mock.ANY,
-                                             fake_share.instance['id'])
+        manager.LOG.warning.assert_called_with(mock.ANY,
+                                               fake_share.instance['id'])
         self.share_manager.message_api.create.assert_called_once_with(
             utils.IsAMatcher(context.RequestContext),
             message_field.Action.CREATE,
@@ -2254,7 +2254,7 @@ class ShareManagerTestCase(test.TestCase):
     def test_create_share_instance_with_share_network_subnet_not_found(self):
         """Test creation fails if share network not found."""
 
-        self.mock_object(manager.LOG, 'error')
+        self.mock_object(manager.LOG, 'warning')
 
         share = db_utils.create_share(share_network_id='fake-net-id')
         share_id = share['id']
@@ -2264,7 +2264,7 @@ class ShareManagerTestCase(test.TestCase):
             self.context,
             share.instance['id']
         )
-        manager.LOG.error.assert_called_with(mock.ANY, share.instance['id'])
+        manager.LOG.warning.assert_called_with(mock.ANY, share.instance['id'])
         shr = db.share_get(self.context, share_id)
         self.assertEqual(constants.STATUS_ERROR, shr['status'])
         self.share_manager.message_api.create.assert_called_once_with(


### PR DESCRIPTION
This PR includes two patches to improve debugging experiences.

- Add details after share is created by share manager. We can find the created share with request id in logs.
- Log error message with warning level on creating share instance failures.

Change-Id: I5cee640274a43c180b01704104cdf825139fac79
