### PR TITLE
Start reexport service via cli option

### DIFF
--- a/manila/cmd/share.py
+++ b/manila/cmd/share.py
@@ -40,6 +40,9 @@ from manila import version
 
 CONF = cfg.CONF
 
+CONF.register_cli_opt(
+    cfg.BoolOpt('reexport', default=False, help='Ensure share resources.'))
+
 
 def main():
     log.register_options(CONF)

--- a/manila/service.py
+++ b/manila/service.py
@@ -103,7 +103,8 @@ class Service(service.Service):
 
     def __init__(self, host, binary, topic, manager, report_interval=None,
                  periodic_interval=None, periodic_fuzzy_delay=None,
-                 service_name=None, coordination=False, *args, **kwargs):
+                 service_name=None, coordination=False, reexport=False,
+                 *args, **kwargs):
         super(Service, self).__init__()
         if not rpc.initialized():
             rpc.init(CONF)
@@ -125,11 +126,19 @@ class Service(service.Service):
         self.periodic_fuzzy_delay = periodic_fuzzy_delay
         self.saved_args, self.saved_kwargs = args, kwargs
         self.coordinator = coordination
+        self.reexport = reexport
 
         setup_profiler(binary, host)
         self.rpcserver = None
 
     def start(self):
+        # NOTE(chuan137) Do not start RPC listeners or periodic tasks if this
+        # is a re-exporting service. Re-exporting is started as a one-time task
+        # or periodic tasks in init_host() method.
+        if self.reexport:
+            self.manager.init_host(reexport=True)
+            return
+
         version_string = version.version_string()
         LOG.info('Starting %(topic)s node (version %(version_string)s)',
                  {'topic': self.topic, 'version_string': version_string})
@@ -190,7 +199,7 @@ class Service(service.Service):
     def create(cls, host=None, binary=None, topic=None, manager=None,
                report_interval=None, periodic_interval=None,
                periodic_fuzzy_delay=None, service_name=None,
-               coordination=False):
+               coordination=False, reexport=None):
         """Instantiates class and passes back application object.
 
         :param host: defaults to CONF.host
@@ -217,12 +226,15 @@ class Service(service.Service):
             periodic_interval = CONF.periodic_interval
         if periodic_fuzzy_delay is None:
             periodic_fuzzy_delay = CONF.periodic_fuzzy_delay
+        if reexport is None:
+            reexport = CONF.reexport
         service_obj = cls(host, binary, topic, manager,
                           report_interval=report_interval,
                           periodic_interval=periodic_interval,
                           periodic_fuzzy_delay=periodic_fuzzy_delay,
                           service_name=service_name,
-                          coordination=coordination)
+                          coordination=coordination,
+                          reexport=reexport)
 
         return service_obj
 

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -31,6 +31,7 @@ import os
 from oslo_config import cfg
 from oslo_log import log
 from oslo_serialization import jsonutils
+from oslo_service import loopingcall
 from oslo_service import periodic_task
 from oslo_utils import excutils
 from oslo_utils import importutils
@@ -154,6 +155,11 @@ share_manager_opts = [
                     'force delete fails, volume will be deleted in regular '
                     'way and it will stay in recovery queue for some time. '
                     'Value of 0 indicates disable force-delete feature.'),
+    cfg.IntOpt('ensure_driver_resources_interval',
+               default=-1,
+               help='This value, specified in seconds, determines how often '
+                    'the share manager will run periodic tasks that ensure '
+                    'driver resources.'),
 ]
 
 CONF = cfg.CONF
@@ -309,6 +315,7 @@ class ShareManager(manager.SchedulerDependentManager):
         self.hooks = []
         self._init_hook_drivers()
         self.service_id = None
+        self.ensure = False
 
     def _init_hook_drivers(self):
         # Try to initialize hook driver(s).
@@ -393,7 +400,18 @@ class ShareManager(manager.SchedulerDependentManager):
              setup_connectivity_with_service_instances())
 
         if reexport:
-            self.ensure_driver_resources(ctxt)
+            # NOTE(chuan137) To be compatible with the old behavior, we run
+            # ensure_driver_resources only once when its interval is set to
+            # ngeative.
+            if CONF.ensure_driver_resources_interval < 0:
+                self.ensure_driver_resources(ctxt)
+            else:
+                reexport_task = loopingcall.FixedIntervalLoopingCall(
+                    self.ensure_driver_resources, ctxt)
+                reexport_task.start(
+                    interval=CONF.ensure_driver_resources_interval,
+                    initial_delay=30,
+                    stop_on_exception=False)
         else:
             self.publish_service_capabilities(ctxt)
 


### PR DESCRIPTION
This patch allows to start a Share service with argument reexport by passing cli option '--reexport'.

Change-Id: Ic436124f705b029323bb75ccead86516de7ea2c9