### PR TITLE
Fix svm mig ipspace

### DIFF
--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -740,7 +740,7 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
         if len(inactive_allocations) == 0:
             msg = _(
                 'No target network allocations for cutover from '
-                '%{src_ss}s to %{dest_ss}s')
+                '%(src_ss)s to %(dest_ss)s')
             raise exception.NetworkException(
                 msg % {
                     'src_ss': src_share_server['id'],

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -675,7 +675,6 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
             for segment in neutron_network['segments']:
                 if (segment['provider:physical_network'] == phys_net):
                     vlan = segment['provider:segmentation_id']
-                    network_type = segment['provider:network_type']
                     break
             if vlan is None:
                 msg = _('Network segment not found on host %s') % host_id
@@ -693,7 +692,6 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
                 port_data = self.db.network_allocation_get(context, port.id)
                 port_data['label'] = phys_net
                 port_data['segmentation_id'] = vlan
-                port_data['network_type'] = network_type
                 port_data['id'] = None
                 port_data['created_at'] = None
                 dest_port_bindings.append(

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -1164,11 +1164,10 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         node_name = self._client.list_cluster_nodes()[0]
         port = self._get_node_data_port(node_name)
         vlan = network_info['network_allocations'][0]['segmentation_id']
-        destination_ipspace = self._client.get_ipspace_name_for_vlan_port(
-            node_name, port, vlan) or self._create_ipspace(
-            network_info, client=dest_client)
-        self._create_port_and_broadcast_domain(
-            destination_ipspace, network_info)
+        destination_ipspace = self._create_ipspace(network_info,
+                                                   client=dest_client)
+        self._create_port_and_broadcast_domain(destination_ipspace,
+                                               network_info)
 
         def _cleanup_ipspace(ipspace):
             try:
@@ -1443,14 +1442,10 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         }
 
         # 2. Create new ipspace, port and broadcast domain.
-        node_name = self._client.list_cluster_nodes()[0]
-        port = self._get_node_data_port(node_name)
-        vlan = network_info['network_allocations'][0]['segmentation_id']
-        destination_ipspace = self._client.get_ipspace_name_for_vlan_port(
-            node_name, port, vlan) or self._create_ipspace(
-            network_info, client=dest_client)
-        self._create_port_and_broadcast_domain(
-            destination_ipspace, network_info)
+        destination_ipspace = self._create_ipspace(network_info,
+                                                   client=dest_client)
+        self._create_port_and_broadcast_domain(destination_ipspace,
+                                               network_info)
 
         # Prepare the migration request.
         src_cluster_name = src_client.get_cluster_name()
@@ -1473,7 +1468,6 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             # As it failed, we must remove the ipspace, ports and broadcast
             # domain.
             dest_client.delete_ipspace(destination_ipspace)
-
             vlan = network_info['network_allocations'][0]['segmentation_id']
             if vlan:
                 port = None

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -1160,10 +1160,9 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                     'neutron_subnet_id')
         }
 
-        # 2. Create new ipspace, port and broadcast domain.
-        node_name = self._client.list_cluster_nodes()[0]
-        port = self._get_node_data_port(node_name)
         vlan = network_info['network_allocations'][0]['segmentation_id']
+
+        # 2. Create new ipspace, port and broadcast domain.
         destination_ipspace = self._create_ipspace(network_info,
                                                    client=dest_client)
         self._create_port_and_broadcast_domain(destination_ipspace,
@@ -1179,7 +1178,9 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                     'there are other entities consuming it.')
             else:
                 if vlan:
+                    port = None
                     for node in dest_client.list_cluster_nodes():
+                        port = port or self._get_node_data_port(node)
                         dest_client.delete_vlan(node, port, vlan)
 
         # 1. Sends the request to the backend.

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5306,11 +5306,9 @@ class ShareManager(manager.SchedulerDependentManager):
             # bindings, so that correct segmentation id is used during
             # compatibility check and migration.
             if CONF.server_migration_extend_neutron_network:
-                neutron_host = share_utils.extract_host(
-                    dest_host, level='host')
                 new_allocations = (
                     self.driver.network_api.extend_network_allocations(
-                        context, source_share_server, neutron_host))
+                        context, source_share_server))
                 source_share_server['network_allocations'] = new_allocations
 
             compatibility = (
@@ -5403,10 +5401,8 @@ class ShareManager(manager.SchedulerDependentManager):
                 snapshot_instance_ids=snapshot_instance_ids)
             # Rollback port bindings on destination host
             if new_allocations:
-                neutron_host = share_utils.extract_host(
-                    dest_host, level='host')
                 self.driver.network_api.delete_port_bindings(
-                    context, source_share_server, neutron_host)
+                    context, source_share_server)
             # Rollback read only access rules
             self._reset_read_only_access_rules_for_server(
                 context, share_instances, source_share_server,
@@ -5477,15 +5473,14 @@ class ShareManager(manager.SchedulerDependentManager):
         # compatibility check.
         if CONF.server_migration_extend_neutron_network:
             try:
-                neutron_host = share_utils.extract_host(
-                    dest_host, level='host')
                 new_allocations = (
                     self.driver.network_api.extend_network_allocations(
-                        context, share_server, neutron_host))
+                        context, share_server))
                 share_server['network_allocations'] = new_allocations
             except Exception:
-                self.driver.network_api.delete_port_bindings(
-                    context, share_server, neutron_host)
+                LOG.warning(
+                    'Failed to extend network allocations for '
+                    'share server %s.', share_server['id'])
                 return result
 
         # NOTE(dviroel): We'll build a list of request specs and send it to
@@ -5518,9 +5513,7 @@ class ShareManager(manager.SchedulerDependentManager):
         # NOTE(sapcc): Delete port bindings on destination host after
         # compatibility check
         if CONF.server_migration_extend_neutron_network:
-            neutron_host = share_utils.extract_host(dest_host, level='host')
-            self.driver.network_api.delete_port_bindings(
-                context, share_server, neutron_host)
+            self.driver.network_api.delete_port_bindings(context, share_server)
         result.update(driver_result)
 
         return result

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5297,7 +5297,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 availability_zone_id=service['availability_zone_id'],
                 share_network_id=new_share_network_id))
 
-        extended_allocations = None
+        extended_allocs = None
         dest_share_server = None
         try:
             # NOTE(sapcc): Extend network allocations to destination host, i.e.
@@ -5306,10 +5306,10 @@ class ShareManager(manager.SchedulerDependentManager):
             # bindings, so that correct segmentation id is used during
             # compatibility check and migration.
             if CONF.server_migration_extend_neutron_network:
-                extended_allocations = (
+                extended_allocs = (
                     self.driver.network_api.extend_network_allocations(
                         context, source_share_server))
-                source_share_server['network_allocations'] = extended_allocations
+                source_share_server['network_allocations'] = extended_allocs
 
             compatibility = (
                 self.driver.share_server_migration_check_compatibility(
@@ -5327,11 +5327,11 @@ class ShareManager(manager.SchedulerDependentManager):
                 service['availability_zone_id'], dest_host,
                 create_on_backend=create_server_on_backend)
 
-            if extended_allocations:
+            if extended_allocs:
                 # NOTE(sapcc) The destination share server is created, so
                 # update extended network allocations with destination share
                 # server id.
-                for alloc in extended_allocations:
+                for alloc in extended_allocs:
                     alloc['share_server_id'] = dest_share_server['id']
                     self.db.network_allocation_update(context, alloc['id'],
                                                       alloc)
@@ -5412,7 +5412,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 share_instance_ids=share_instance_ids,
                 snapshot_instance_ids=snapshot_instance_ids)
             # Rollback port bindings on destination host
-            if extended_allocations:
+            if extended_allocs:
                 self.driver.network_api.delete_extended_allocations(
                     context, source_share_server, dest_share_server)
             # Rollback read only access rules

--- a/manila/tests/network/neutron/test_neutron_plugin.py
+++ b/manila/tests/network/neutron/test_neutron_plugin.py
@@ -28,8 +28,8 @@ from manila import exception
 from manila.network.neutron import api as neutron_api
 from manila.network.neutron import constants as neutron_constants
 from manila.network.neutron import neutron_network_plugin as plugin
-from manila import test
 from manila.share import utils as share_utils
+from manila import test
 from manila.tests import utils as test_utils
 
 CONF = cfg.CONF

--- a/manila/tests/network/neutron/test_neutron_plugin.py
+++ b/manila/tests/network/neutron/test_neutron_plugin.py
@@ -29,6 +29,7 @@ from manila.network.neutron import api as neutron_api
 from manila.network.neutron import constants as neutron_constants
 from manila.network.neutron import neutron_network_plugin as plugin
 from manila import test
+from manila.share import utils as share_utils
 from manila.tests import utils as test_utils
 
 CONF = cfg.CONF
@@ -132,6 +133,11 @@ fake_nw_info = {
             'provider:segmentation_id': 3926,
         },
         {
+            'provider:network_type': 'vlan',
+            'provider:physical_network': 'net2',
+            'provider:segmentation_id': 1249,
+        },
+        {
             'provider:network_type': 'vxlan',
             'provider:physical_network': None,
             'provider:segmentation_id': 2000,
@@ -193,6 +199,23 @@ fake_binding_profile = {
     'neutron_switch_id': 'fake switch id',
     'neutron_port_id': 'fake port id',
     'neutron_switch_info': 'fake switch info'
+}
+
+fake_network_allocation_ext = {
+    'id': 'fake port binding id',
+    'share_server_id': fake_share_server['id'],
+    'ip_address': fake_neutron_port['fixed_ips'][0]['ip_address'],
+    'mac_address': fake_neutron_port['mac_address'],
+    'status': constants.STATUS_ACTIVE,
+    'label': fake_nw_info['segments'][1]['provider:physical_network'],
+    'network_type': fake_share_network_subnet['network_type'],
+    'segmentation_id': (
+        fake_nw_info['segments'][1]['provider:segmentation_id']
+    ),
+    'ip_version': fake_share_network_subnet['ip_version'],
+    'cidr': fake_share_network_subnet['cidr'],
+    'gateway': fake_share_network_subnet['gateway'],
+    'mtu': 1509,
 }
 
 
@@ -1071,6 +1094,207 @@ class NeutronBindNetworkPluginTest(test.TestCase):
                 self.fake_context,
                 fake_neutron_port['id'],
                 network_allocation_update_data)
+
+    def test_extend_network_allocations(self):
+        old_network_allocation = copy.deepcopy(fake_network_allocation)
+        new_network_allocation = copy.deepcopy(fake_network_allocation_ext)
+        fake_network = copy.deepcopy(fake_neutron_network_multi)
+        fake_ss = copy.deepcopy(fake_share_server)
+        fake_ss["share_network_subnet"] = fake_share_network_subnet
+
+        fake_host_id = "fake_host_id"
+        fake_physical_net = "net2"
+        fake_port_id = old_network_allocation["id"]
+        fake_vnic_type = "baremetal"
+        config_data = {
+            'DEFAULT': {
+                "neutron_host_id": fake_host_id,
+                "neutron_vnic_type": fake_vnic_type,
+                'neutron_physical_net_name': fake_physical_net,
+            }
+        }
+        self.bind_plugin = self._get_neutron_network_plugin_instance(
+            config_data
+        )
+        self.mock_object(
+            self.bind_plugin.neutron_api,
+            "get_network",
+            mock.Mock(return_value=fake_network),
+        )
+        self.mock_object(self.bind_plugin.neutron_api, "bind_port_to_host")
+        self.mock_object(self.bind_plugin.db, "network_allocation_create")
+
+        # mocking the db.network_allocations_get_for_share_server method to
+        # return the old network allocation for old host and no network
+        # allocation for the new host
+        def get_nalloc_side_effect(*args, **kwargs):
+            if kwargs["label"] == "user":
+                return [old_network_allocation]
+            elif kwargs["label"] == fake_physical_net:
+                return []
+
+        self.mock_object(
+            self.bind_plugin.db,
+            "network_allocations_get_for_share_server",
+            mock.Mock(side_effect=get_nalloc_side_effect),
+        )
+
+        # calling the extend_network_allocations method
+        self.bind_plugin.extend_network_allocations(self.fake_context, fake_ss)
+
+        # testing the calls, we expect the port to be bound to the current host
+        # and the new network allocation to be created
+        self.bind_plugin.neutron_api.bind_port_to_host.assert_called_once_with(
+            fake_port_id, fake_host_id, fake_vnic_type
+        )
+        new_network_allocation["id"] = None
+        new_network_allocation["created_at"] = None
+        self.bind_plugin.db.network_allocation_create.assert_called_once_with(
+            self.fake_context, new_network_allocation
+        )
+
+    def test_delete_extended_allocations(self):
+        old_network_allocation = copy.deepcopy(fake_network_allocation)
+        new_network_allocation = copy.deepcopy(fake_network_allocation_ext)
+        fake_ss = copy.deepcopy(fake_share_server)
+
+        fake_host_id = "fake_host_id"
+        fake_physical_net = "net2"
+        fake_port_id = old_network_allocation["id"]
+        fake_vnic_type = "baremetal"
+        config_data = {
+            "DEFAULT": {
+                "neutron_host_id": fake_host_id,
+                "neutron_vnic_type": fake_vnic_type,
+                "neutron_physical_net_name": fake_physical_net,
+            }
+        }
+        self.bind_plugin = self._get_neutron_network_plugin_instance(
+            config_data
+        )
+        self.mock_object(self.bind_plugin.neutron_api, "delete_port_binding")
+        self.mock_object(self.bind_plugin.db, "network_allocation_delete")
+
+        def get_nalloc_side_effect(*args, **kwargs):
+            if kwargs["label"] == "user":
+                return [old_network_allocation]
+            elif kwargs["label"] == fake_physical_net:
+                return [new_network_allocation]
+
+        self.mock_object(
+            self.bind_plugin.db,
+            "network_allocations_get_for_share_server",
+            mock.Mock(side_effect=get_nalloc_side_effect),
+        )
+
+        self.bind_plugin.delete_extended_allocations(
+            self.fake_context, fake_ss
+        )
+        neutron_api = self.bind_plugin.neutron_api
+        neutron_api.delete_port_binding.assert_called_once_with(
+            fake_port_id, fake_host_id
+        )
+        self.bind_plugin.db.network_allocation_delete.assert_called_once_with(
+            self.fake_context, new_network_allocation["id"]
+        )
+
+    @ddt.data(
+        {
+            "old_alloc": fake_network_allocation,
+            "new_alloc": None,
+        },
+        {
+            "old_alloc": fake_network_allocation,
+            "new_alloc": fake_network_allocation_ext,
+        },
+    )
+    @ddt.unpack
+    def test_cutover_network_allocation(self, old_alloc, new_alloc):
+        fake_network = copy.deepcopy(fake_neutron_network_multi)
+        fake_old_ss = copy.deepcopy(fake_share_server)
+        fake_old_ss["share_network_subnet"] = fake_share_network_subnet
+        fake_dest_ss = copy.deepcopy(fake_share_server)
+        fake_dest_ss["host"] = "fake_host2@backend2#pool2"
+        fake_old_host = share_utils.extract_host(fake_old_ss["host"], "host")
+        fake_dest_host = share_utils.extract_host(fake_dest_ss["host"], "host")
+
+        fake_host_id = "fake_host_id"
+        fake_physical_net = "net2"
+        fake_port_id = old_alloc["id"]
+        fake_vnic_type = "baremetal"
+        config_data = {
+            "DEFAULT": {
+                "neutron_host_id": fake_host_id,
+                "neutron_vnic_type": fake_vnic_type,
+                "neutron_physical_net_name": fake_physical_net,
+            }
+        }
+        self.bind_plugin = self._get_neutron_network_plugin_instance(
+            config_data
+        )
+        self.mock_object(
+            self.bind_plugin.neutron_api,
+            "get_network",
+            mock.Mock(return_value=fake_network),
+        )
+        self.mock_object(self.bind_plugin.neutron_api, "bind_port_to_host")
+        self.mock_object(self.bind_plugin.db, "network_allocation_create")
+
+        def get_nalloc_side_effect(*args, **kwargs):
+            if kwargs["label"] == "user":
+                return [old_alloc]
+            elif kwargs["label"] == fake_physical_net:
+                return [new_alloc] if new_alloc else []
+
+        self.mock_object(
+            self.bind_plugin.db,
+            "network_allocations_get_for_share_server",
+            mock.Mock(side_effect=get_nalloc_side_effect),
+        )
+
+        neutron_api = self.bind_plugin.neutron_api
+        db_api = self.bind_plugin.db
+        self.mock_object(neutron_api, "activate_port_binding")
+        self.mock_object(neutron_api, "delete_port_binding")
+        self.mock_object(db_api, "network_allocation_update")
+        self.mock_object(db_api, "network_allocation_delete")
+        self.mock_object(db_api, "share_network_subnet_update")
+
+        if not new_alloc:
+            self.assertRaises(
+                exception.NetworkException,
+                self.bind_plugin.cutover_network_allocations,
+                self.fake_context, fake_old_ss, fake_dest_ss,
+            )
+        else:
+            self.bind_plugin.cutover_network_allocations(
+                self.fake_context,
+                fake_old_ss,
+                fake_dest_ss,
+            )
+            neutron_api.activate_port_binding.assert_called_once_with(
+                fake_port_id,
+                fake_dest_host,
+            )
+            neutron_api.delete_port_binding.assert_called_once_with(
+                fake_port_id, fake_old_host
+            )
+            db_api.network_allocation_update.assert_called_once_with(
+                self.fake_context,
+                old_alloc["id"],
+                {
+                    "share_server_id": fake_dest_ss["id"],
+                    "segmentation_id": new_alloc["segmentation_id"],
+                },
+            )
+            db_api.network_allocation_delete.assert_called_once_with(
+                self.fake_context, new_alloc["id"]
+            )
+            db_api.share_network_subnet_update.assert_called_once_with(
+                self.fake_context,
+                fake_old_ss["share_network_subnet"]["id"],
+                {"segmentation_id": new_alloc["segmentation_id"]},
+            )
 
     @ddt.data({
         'neutron_binding_profiles': None,


### PR DESCRIPTION
This patch fixes the issue, where sometimes the destination share server is created in Default ipspace on NetApp filer. We make sure that the ipspace name is determined from configuration. The vlan is also ensured to move into the right broadcast domain if it already exists. 