### PR TITLE
Fix prune deleted volumes for clones

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -3963,9 +3963,14 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 try:
                     client.send_request(
                         'volume-destroy', {'name': volume_name})
-                except netapp_api.NaApiError:
+                except netapp_api.NaApiError as e:
                     LOG.error(
                         'Pruning soft-deleted volume %s failed', volume_name)
+                    if e.code == netapp_api.EVOLDEL_NOT_ALLOW_BY_CLONE:
+                        if self.volume_clone_split_status(volume_name) != 100:
+                            self.volume_clone_split_start(volume_name)
+                            LOG.debug('Starting clone split for '
+                                      'volume %s ', volume_name)
 
     @na_utils.trace
     def create_snapshot(self, volume_name, snapshot_name):


### PR DESCRIPTION
During prune deleted volumes option, if volume is offline, manila calls for ONTAP volume-destroy API. However if volume has one or more clones, the destroy operation fails. So upon receving clone related error, check clone spilt status and if not started, start it.