### PR TITLE
increase max val for unused_share_server_cleanup_interval

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -93,7 +93,7 @@ share_manager_opts = [
     cfg.IntOpt('unused_share_server_cleanup_interval',
                default=10,
                help='Unallocated share servers reclamation time interval '
-                    '(minutes). Minimum value is 10 minutes, maximum is 60 '
+                    '(minutes). Minimum value is 10 minutes, maximum is 1440 '
                     'minutes. The reclamation function is run every '
                     '10 minutes and delete share servers which were unused '
                     'more than unused_share_server_cleanup_interval option '
@@ -101,7 +101,7 @@ share_manager_opts = [
                     'will wait for a share server to go unutilized before '
                     'deleting it.',
                min=10,
-               max=60),
+               max=1440),
     cfg.IntOpt('replica_state_update_interval',
                default=300,
                help='This value, specified in seconds, determines how often '

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -3911,7 +3911,7 @@ class ShareManagerTestCase(test.TestCase):
                           self.share_manager._validate_segmentation_id,
                           network_info)
 
-    @ddt.data(10, 36, 60)
+    @ddt.data(10, 36, 1440)
     def test_verify_server_cleanup_interval_valid_cases(self, val):
         data = dict(DEFAULT=dict(unused_share_server_cleanup_interval=val))
         with test_utils.create_temp_config_with_opts(data):


### PR DESCRIPTION
Allow to delay the cleanup of unused share servers to 1 day.
Old setting was capped at 1 hour.

Change-Id: If8f170ffef63532915c34d378529e70bfe72977f
