### PR TITLE
sapcc: allow to ensure share instances in 'creating'

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -4171,7 +4171,8 @@ class NetAppCmodeFileStorageLibrary(object):
                     'export_locations': self.update_share(
                         share,
                         share_server=share_server
-                    )
+                    ),
+                    'status': constants.STATUS_AVAILABLE
                 }
             except (exception.NetAppException,
                     netapp_api.NaApiError,

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -543,7 +543,8 @@ class ShareManager(manager.SchedulerDependentManager):
                 )
                 continue
 
-            if share_instance['status'] != constants.STATUS_AVAILABLE:
+            if (share_instance['status'] != constants.STATUS_AVAILABLE and
+                    share_instance['status'] != constants.STATUS_CREATING):
                 LOG.info(
                     "Share instance %(id)s: skipping export, "
                     "because it has '%(status)s' status.",


### PR DESCRIPTION
The list that is checked has only share instances that already
got a host field set, i.e. the creation stuck at a late stage
(after scheduling). Those should be recoverable here.

In the NetApp driver: always set the status to 'available'.
In case something goes wrong, the share instance is not returned
at all (and therefore not updated) in favor of setting status to
'error', which would be too invasive in certain situation.

Change-Id: I8e25e2bc8880e587457fd4e8cb3fa62868f29f9c
