### PR TITLE
allow specify pool as server migration destination

### DIFF
--- a/manila/api/v2/share_servers.py
+++ b/manila/api/v2/share_servers.py
@@ -239,12 +239,6 @@ class ShareServerController(share_servers.ShareServerController,
         utils.check_params_exist(mandatory_params, params)
         bool_param_values = utils.check_params_are_boolean(bool_params, params)
 
-        pool_was_specified = len(params['host'].split('#')) > 1
-
-        if pool_was_specified:
-            msg = _('The destination host can not contain pool information.')
-            raise exc.HTTPBadRequest(explanation=msg)
-
         new_share_network = None
 
         new_share_network_id = params.get('new_share_network_id', None)
@@ -366,12 +360,6 @@ class ShareServerController(share_servers.ShareServerController,
 
         utils.check_params_exist(mandatory_params, params)
         bool_param_values = utils.check_params_are_boolean(bool_params, params)
-
-        pool_was_specified = len(params['host'].split('#')) > 1
-
-        if pool_was_specified:
-            msg = _('The destination host can not contain pool information.')
-            raise exc.HTTPBadRequest(explanation=msg)
 
         new_share_network = None
         new_share_network_id = params.get('new_share_network_id', None)

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5386,6 +5386,8 @@ class ShareManager(manager.SchedulerDependentManager):
                 {'task_state': (
                     constants.TASK_STATE_MIGRATION_DRIVER_STARTING)})
 
+            dest_share_server['volume_placement'] = dest_host
+
             server_info = self.driver.share_server_migration_start(
                 context, source_share_server, dest_share_server,
                 share_instances, snapshot_instances)

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -1920,17 +1920,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library, '_get_pools',
                          mock.Mock(return_value=pools))
 
-    def test_share_server_migration_check_compatibility_dest_with_pool(
-            self):
-        not_compatible = fake.SERVER_MIGRATION_CHECK_NOT_COMPATIBLE
-        self.library._have_cluster_creds = True
-
-        result = self.library.share_server_migration_check_compatibility(
-            None, self.fake_src_share_server, fake.MANILA_HOST_NAME,
-            None, None, None)
-
-        self.assertEqual(not_compatible, result)
-
     def test_share_server_migration_check_compatibility_same_cluster(
             self):
         not_compatible = fake.SERVER_MIGRATION_CHECK_NOT_COMPATIBLE


### PR DESCRIPTION
This patch allows specifying a single pool as destination of server migration using SVM migrate with NetApp Driver.

Change-Id: I659b14f204aabf4515ac97e928bc14a58ef662f0