### PR TITLE
ensure: don't overwrite with potentially outdated host value

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -599,8 +599,7 @@ class ShareManager(manager.SchedulerDependentManager):
                     ctxt, share_instance['id'],
                     {'status': (
                         update_share_instances[share_instance['id']].
-                        get('status')),
-                     'host': share_instance['host']}
+                        get('status'))}
                 )
 
             update_export_location = (


### PR DESCRIPTION
it may have been changed earlier in _ensure_share_instance_has_pool()

Change-Id: I53a65649ff1a589ce2c9ecec8ff0525f4d800925
