### PR TITLE
ensure: non busy shares should have pools

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -543,6 +543,10 @@ class ShareManager(manager.SchedulerDependentManager):
                 )
                 continue
 
+            # only busy aka shares undergoing a migration might not have
+            # their pool fixed, but other skip reasons do not apply
+            self._ensure_share_instance_has_pool(ctxt, share_instance)
+
             if (share_instance['status'] != constants.STATUS_AVAILABLE and
                     share_instance['status'] != constants.STATUS_CREATING):
                 LOG.info(
@@ -564,7 +568,6 @@ class ShareManager(manager.SchedulerDependentManager):
                     )
                     continue
 
-            self._ensure_share_instance_has_pool(ctxt, share_instance)
             share_instance = self.db.share_instance_get(
                 ctxt, share_instance['id'], with_share_data=True)
             share_instance_dict = self._get_share_instance_dict(

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -403,7 +403,13 @@ class ShareManagerTestCase(test.TestCase):
                     mock.call(utils.IsAMatcher(context.RequestContext),
                               instances[0]),
                     mock.call(utils.IsAMatcher(context.RequestContext),
+                              instances[1]),
+                    mock.call(utils.IsAMatcher(context.RequestContext),
                               instances[2]),
+                    mock.call(utils.IsAMatcher(context.RequestContext),
+                              instances[4]),
+                    mock.call(utils.IsAMatcher(context.RequestContext),
+                              instances[6]),
                 ]))
             self.share_manager._get_share_server.assert_has_calls([
                 mock.call(utils.IsAMatcher(context.RequestContext),
@@ -515,7 +521,10 @@ class ShareManagerTestCase(test.TestCase):
         self.share_manager.driver.check_for_setup_error.assert_called_with()
         self.share_manager._ensure_share_instance_has_pool.assert_has_calls([
             mock.call(utils.IsAMatcher(context.RequestContext), instances[0]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[1]),
             mock.call(utils.IsAMatcher(context.RequestContext), instances[2]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[4]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[6]),
         ])
         self.share_manager.driver.ensure_shares.assert_called_once_with(
             utils.IsAMatcher(context.RequestContext),
@@ -620,7 +629,10 @@ class ShareManagerTestCase(test.TestCase):
         self.share_manager.driver.check_for_setup_error.assert_called_with()
         self.share_manager._ensure_share_instance_has_pool.assert_has_calls([
             mock.call(utils.IsAMatcher(context.RequestContext), instances[0]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[1]),
             mock.call(utils.IsAMatcher(context.RequestContext), instances[2]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[4]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[6]),
         ])
         self.share_manager.driver.ensure_shares.assert_called_once_with(
             utils.IsAMatcher(context.RequestContext),
@@ -706,7 +718,10 @@ class ShareManagerTestCase(test.TestCase):
         smanager.driver.check_for_setup_error.assert_called_with()
         smanager._ensure_share_instance_has_pool.assert_has_calls([
             mock.call(utils.IsAMatcher(context.RequestContext), instances[0]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[1]),
             mock.call(utils.IsAMatcher(context.RequestContext), instances[2]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[4]),
+            mock.call(utils.IsAMatcher(context.RequestContext), instances[6]),
         ])
         smanager.driver.ensure_shares.assert_called_once_with(
             utils.IsAMatcher(context.RequestContext),


### PR DESCRIPTION
especially shares that ended up in extending_error due to not
having a pool should be fixed here

Change-Id: Ie924e6fbe402a2ca1fb534bde178cd78a3eb5341
