### PR TITLE
share servers in state 'deleting' are deletable

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -4514,6 +4514,7 @@ def share_server_get_all_unused_deletable(context, host, updated_before):
         constants.STATUS_ACTIVE,
         constants.STATUS_ERROR,
         constants.STATUS_CREATING,
+        constants.STATUS_DELETING,
     )
     result = (_server_get_query(context)
               .filter_by(is_auto_deletable=True)


### PR DESCRIPTION
The delete operation may have been interrupted by service stop.
Should be picked up and retried.

Change-Id: I432991f86f12ef09e2b1691a7b895742f9220dc6
