### PR TITLE
skip auto deleting servers from broken migration

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -3696,6 +3696,25 @@ class ShareManager(manager.SchedulerDependentManager):
                                                                 self.host,
                                                                 updated_before)
         for server in servers:
+            src_server_id = server['source_share_server_id']
+            if src_server_id:
+                src_server = self.db.share_server_get(ctxt, src_server_id)
+                if src_server:
+                    msg = ("Share server %s has source share server %s."
+                           "Skipping deletion.")
+                    LOG.warning(msg, server['id'], src_server_id)
+                    continue
+
+            dest_servers = self.db.share_server_get_all_with_filters(ctxt, {
+                'source_share_server_id': server['id']
+            })
+            if len(dest_servers) > 0:
+                dest_server_id = dest_servers[0]['id']
+                msg = ("Share server %s has existing destination share "
+                       "servers %s. Skipping deletion.")
+                LOG.warning(msg, server['id'], dest_server_id)
+                continue
+
             self.delete_share_server(ctxt, server)
 
     @add_hooks

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -3942,21 +3942,29 @@ class ShareManagerTestCase(test.TestCase):
             self.assertFalse(db.share_server_get_all_unused_deletable.called)
             self.assertFalse(share_manager.delete_share_server.called)
 
-    @mock.patch.object(db, 'share_server_get_all_unused_deletable',
-                       mock.Mock(return_value=['server1', ]))
     @mock.patch.object(manager.ShareManager, 'delete_share_server',
                        mock.Mock())
     @mock.patch.object(timeutils, 'utcnow', mock.Mock(
                        return_value=datetime.timedelta(minutes=20)))
     def test_delete_free_share_servers(self):
+        fake_servers = [
+            fakes.fake_share_server_get() for _ in range(2)]
+        fake_servers[0]['source_share_server_id'] = None
+        fake_servers[1]['source_share_server_id'] = 'fake_id'
+
+        self.mock_object(db, 'share_server_get', mock.Mock(
+            return_value=fakes.fake_share_server_get()
+        ))
+        self.mock_object(db, 'share_server_get_all_unused_deletable',
+                         mock.Mock(return_value=fake_servers))
+
         self.share_manager.delete_free_share_servers(self.context)
         db.share_server_get_all_unused_deletable.assert_called_once_with(
             self.context,
             self.share_manager.host,
             datetime.timedelta(minutes=10))
         self.share_manager.delete_share_server.assert_called_once_with(
-            self.context,
-            'server1')
+            self.context, fake_servers[0])
         timeutils.utcnow.assert_called_once_with()
 
     @mock.patch('manila.tests.fake_notifier.FakeNotifier._notify')


### PR DESCRIPTION
Skip share servers linked to incomplete migrations in periodic cleanup job. Deleting them risks removing associated objects, such as network ports, unexpectedly. Admins should inspect the affected share servers and cleanup manually.

Change-Id: Ie0e5fa9cd6d527d382f275ba8b3710ee18ef1c0a