### PR TITLE
ccloud: fallback for flexgroup

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2996,6 +2996,10 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                          aggregate_name]
             api_args['query']['volume-attributes']['volume-id-attributes'][
                 'aggr-list'] = aggr_list
+        else:
+            # ccloud: empty aggregate name in short time window after
+            # backend svm migration. Only done for flexvols, not flexgroups.
+            is_flexgroup = False
         if language:
             api_args['attributes']['volume-attributes'][
                 'volume-language-attributes']['language'] = language


### PR DESCRIPTION
in case of svm migration from backend we clean the aggregate part of
the host field to let manila ensure rediscover the actual aggregate.
This is currently only done (and supported) for
non flexgroup (i.e. flexvol) shares.

Change-Id: Ib7643d66615ecdb67a80a516f261d8ee670b547d
