### PR TITLE
[netapp] continue server migration complete on create export errors

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -1851,11 +1851,16 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 share_host = share_host.replace(
                     old_aggregate, dest_aggregate)
 
-            export_locations = self._create_export(
-                instance, dest_share_server, dest_vserver, dest_client,
-                clear_current_export_policy=False,
-                ensure_share_already_exists=True,
-                share_host=share_host)
+            try:
+                export_locations = self._create_export(
+                    instance, dest_share_server, dest_vserver, dest_client,
+                    clear_current_export_policy=False,
+                    ensure_share_already_exists=True,
+                    share_host=share_host)
+            except netapp_api.NaApiError as e:
+                LOG.warning("Could not create export for share %s. Reason: %s",
+                            instance['id'], e)
+                export_locations = None
             new_share_data.update({'export_locations': export_locations})
 
             share_updates.update({instance['id']: new_share_data})


### PR DESCRIPTION
NetApp driver tries to update  export locations for all share instances on the server after server migration is completed on the back end. We could safely continue to next instances if creating export location for one had failed. In most cases, the export locations are not changed during server migration; and Manila ensure will update the share info including the export locations periodically.

Change-Id: I9c2174c55eb1101d085d83e621e224c5add7551f