### PR TITLE
delete ports before share server deletion

### DIFF
--- a/manila/network/__init__.py
+++ b/manila/network/__init__.py
@@ -107,7 +107,8 @@ class NetworkBaseAPI(db_base.Base, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def deallocate_network(self, context, share_server_id):
+    def deallocate_network(self, context, share_server_id, share_network=None,
+                           share_network_subnet=None):
         pass
 
     @abc.abstractmethod

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -285,7 +285,9 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
                                                             ip_version}
         raise exception.NetworkBadConfigurationException(reason=msg)
 
-    def deallocate_network(self, context, share_server_id):
+    def deallocate_network(self, context, share_server_id,
+                           share_network=None,
+                           share_network_subnet=None):
         """Deallocate neutron network resources for the given share server.
 
         Delete previously allocated neutron ports, delete manila db
@@ -293,6 +295,8 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
 
         :param context: RequestContext object
         :param share_server_id: id of share server
+        :param share_network: share network data
+        :param share_network_subnet: share network subnet data
         :rtype: None
         """
         ports = self.db.network_allocations_get_for_share_server(
@@ -300,6 +304,20 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
 
         for port in ports:
             self._delete_port(context, port)
+
+        # It may be possible that there are ports existing without a
+        # corresponding manila network allocation entry in the manila db,
+        # because port create request may have been successfully sent to
+        # neutron, but the response, the created port could not be stored
+        # in manila due to unreachable db
+        if share_network_subnet:
+            ports = self.neutron_api.list_ports(
+                network_id=share_network_subnet['neutron_net_id'],
+                device_owner='manila:share',
+                device_id=share_server_id)
+
+            for port in ports:
+                self._delete_port(context, port, ignore_db=True)
 
     def _get_port_create_args(self, share_server, share_network_subnet,
                               device_owner, count=0):
@@ -337,7 +355,7 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
         }
         return self.db.network_allocation_create(context, port_dict)
 
-    def _delete_port(self, context, port):
+    def _delete_port(self, context, port, ignore_db=False):
         try:
             self.neutron_api.delete_port(port['id'])
         except exception.NetworkException:
@@ -345,7 +363,8 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
                 context, port['id'], {'status': constants.STATUS_ERROR})
             raise
         else:
-            self.db.network_allocation_delete(context, port['id'])
+            if not ignore_db:
+                self.db.network_allocation_delete(context, port['id'])
 
     def _has_provider_network_extension(self):
         extensions = self.neutron_api.list_extensions()

--- a/manila/network/standalone_network_plugin.py
+++ b/manila/network/standalone_network_plugin.py
@@ -307,7 +307,8 @@ class StandaloneNetworkPlugin(network.NetworkBaseAPI):
                 self.db.network_allocation_create(context, data))
         return allocations
 
-    def deallocate_network(self, context, share_server_id):
+    def deallocate_network(self, context, share_server_id,
+                           share_network=None, share_network_subnet=None):
         """Deallocate network resources for share server."""
         allocations = self.db.network_allocations_get_for_share_server(
             context, share_server_id)

--- a/manila/share/driver.py
+++ b/manila/share/driver.py
@@ -946,10 +946,13 @@ class ShareDriver(object):
             self.admin_network_api.allocate_network(
                 context, share_server, **kwargs)
 
-    def deallocate_network(self, context, share_server_id):
+    def deallocate_network(self, context, share_server_id, share_network=None,
+                           share_network_subnet=None):
         """Deallocate network resources for the given share server."""
         if self.get_network_allocations_number():
-            self.network_api.deallocate_network(context, share_server_id)
+            self.network_api.deallocate_network(
+                context, share_server_id, share_network=share_network,
+                share_network_subnet=share_network_subnet)
 
     def choose_share_server_compatible_with_share(self, context, share_servers,
                                                   share, snapshot=None,

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -4626,7 +4626,18 @@ class ShareManager(manager.SchedulerDependentManager):
                                         {'status': constants.STATUS_DELETING})
             try:
                 LOG.debug("Deleting network of share server '%s'", server_id)
-                self.driver.deallocate_network(context, share_server['id'])
+                share_network_subnet = None
+                share_network = None
+
+                share_network_subnet = share_server['share_network_subnet']
+                if share_network_subnet:
+                    share_network_id = share_network_subnet['share_network_id']
+                    share_network = self.db.share_network_get(
+                        context, share_network_id)
+
+                self.driver.deallocate_network(context, share_server['id'],
+                                               share_network,
+                                               share_network_subnet)
 
                 LOG.debug("Deleting share server '%s'", server_id)
                 security_services = []

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -4625,6 +4625,9 @@ class ShareManager(manager.SchedulerDependentManager):
             self.db.share_server_update(context, server_id,
                                         {'status': constants.STATUS_DELETING})
             try:
+                LOG.debug("Deleting network of share server '%s'", server_id)
+                self.driver.deallocate_network(context, share_server['id'])
+
                 LOG.debug("Deleting share server '%s'", server_id)
                 security_services = []
                 for ss_name in constants.SECURITY_SERVICES_ALLOWED_TYPES:
@@ -4649,7 +4652,6 @@ class ShareManager(manager.SchedulerDependentManager):
         LOG.info(
             "Share server '%s' has been deleted successfully.",
             share_server['id'])
-        self.driver.deallocate_network(context, share_server['id'])
 
     @add_hooks
     @utils.require_driver_initialized


### PR DESCRIPTION
Share server deletion if causes any exception, Manila end up having orphaned ports. So first deallocate network and then proceed with share server deletion.

Change-Id: Ibba5326177417bb4e56c19c59040c40b7886d58b