### PR TITLE
ccloud: remove check last transfer size in update_replica_state

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -3035,18 +3035,6 @@ class NetAppCmodeFileStorageLibrary(object):
                 .isoformat(), (2 * self._snapmirror_schedule)))):
             return constants.REPLICA_STATE_OUT_OF_SYNC
 
-        replica_backend = share_utils.extract_host(replica['host'],
-                                                   level='backend_name')
-        config = data_motion.get_backend_configuration(replica_backend)
-        config_size = (int(config.safe_get(
-            'netapp_snapmirror_last_transfer_size_limit')) * units.Ki)
-        last_transfer_size = int(snapmirror.get('last-transfer-size', 0))
-        if last_transfer_size > config_size:
-            LOG.debug('Found last-transfer-size %(size)d for replica: '
-                      '%(replica)s.', {'replica': replica['id'],
-                                       'size': last_transfer_size})
-            return constants.REPLICA_STATE_OUT_OF_SYNC
-
         last_transfer_error = snapmirror.get('last-transfer-error', None)
         if last_transfer_error:
             LOG.debug('Found last-transfer-error: %(error)s for replica: '
@@ -3319,8 +3307,7 @@ class NetAppCmodeFileStorageLibrary(object):
             }
             msg = ('failed to update snapmirror from %(source)s to '
                    '%(target)s: %(error)s') % msg_args
-            LOG.warning(msg)
-            pass
+            LOG.error(msg)
         # 2. Break SnapMirror
         dm_session.break_snapmirror(orig_active_replica, replica)
 

--- a/manila/share/drivers/netapp/options.py
+++ b/manila/share/drivers/netapp/options.py
@@ -250,12 +250,6 @@ netapp_data_motion_opts = [
                help='An interval in either minutes or hours used used to '
                     'update the SnapMirror relationship. Few valid values '
                     'are: 5min, 30min, hourly etc.'),
-    cfg.IntOpt('netapp_snapmirror_last_transfer_size_limit',
-               min=512,
-               default=1024,  # One MB
-               help='This option set the last transfer size limit (in KB) '
-                    'of snapmirror to decide whether replica is in sync or '
-                    'out of sync.'),
     cfg.IntOpt('netapp_volume_move_cutover_timeout',
                min=0,
                default=3600,  # One Hour,


### PR DESCRIPTION
The check implemented in https://github.com/sapcc/manila/commit/9bd0fc9. But the check leaves replica in `out-of-sync` state for those with frequent data changes. This pull request removes the check in `update_replica_state'. The replication status check will be implemented in promoting replica in a different PR.

Change-Id: If16a92460a3c1debc217755075f7578c515d89f6