### PR TITLE
ccloud: force promote replica

### DIFF
--- a/manila/api/v2/share_replicas.py
+++ b/manila/api/v2/share_replicas.py
@@ -30,6 +30,7 @@ from manila import db
 from manila import exception
 from manila.i18n import _
 from manila import share
+from manila import utils
 
 
 LOG = log.getLogger(__name__)
@@ -277,8 +278,11 @@ class ShareReplicationController(wsgi.Controller, wsgi.AdminActionsMixin):
         if replica_state == constants.REPLICA_STATE_ACTIVE:
             return webob.Response(status_int=http_client.OK)
 
+        force = utils.get_bool_from_api_params('force', body, default=False)
+
         try:
-            replica = self.share_api.promote_share_replica(context, replica)
+            replica = self.share_api.promote_share_replica(context, replica,
+                                                           force)
         except exception.ReplicationException as e:
             raise exc.HTTPBadRequest(explanation=six.text_type(e))
         except exception.AdminRequired as e:

--- a/manila/api/v2/share_replicas.py
+++ b/manila/api/v2/share_replicas.py
@@ -278,7 +278,8 @@ class ShareReplicationController(wsgi.Controller, wsgi.AdminActionsMixin):
         if replica_state == constants.REPLICA_STATE_ACTIVE:
             return webob.Response(status_int=http_client.OK)
 
-        force = utils.get_bool_from_api_params('force', body, default=False)
+        params = body.get('promote') or {}
+        force = utils.get_bool_from_api_params('force', params, default=False)
 
         try:
             replica = self.share_api.promote_share_replica(context, replica,

--- a/manila/exception.py
+++ b/manila/exception.py
@@ -986,6 +986,8 @@ class ShareCopyDataException(ManilaException):
 class ReplicationException(ManilaException):
     message = _("Unable to perform a replication action: %(reason)s.")
 
+class ReplicationUnhealthy(ManilaException):
+    message = _("Replication is unhealthy: %(reason)s.")
 
 class ShareReplicaNotFound(NotFound):
     message = _("Share Replica %(replica_id)s could not be found.")

--- a/manila/exception.py
+++ b/manila/exception.py
@@ -986,8 +986,10 @@ class ShareCopyDataException(ManilaException):
 class ReplicationException(ManilaException):
     message = _("Unable to perform a replication action: %(reason)s.")
 
+
 class ReplicationUnhealthy(ManilaException):
     message = _("Replication is unhealthy: %(reason)s.")
+
 
 class ShareReplicaNotFound(NotFound):
     message = _("Share Replica %(replica_id)s could not be found.")

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -789,7 +789,7 @@ class API(base.Base):
                                                    share_replica,
                                                    force=force)
 
-    def promote_share_replica(self, context, share_replica):
+    def promote_share_replica(self, context, share_replica, force):
 
         if share_replica.get('status') != constants.STATUS_AVAILABLE:
             msg = _("Replica %(replica_id)s must be in %(status)s state to be "
@@ -812,7 +812,7 @@ class API(base.Base):
             context, share_replica['id'],
             {'status': constants.STATUS_REPLICATION_CHANGE})
 
-        self.share_rpcapi.promote_share_replica(context, share_replica)
+        self.share_rpcapi.promote_share_replica(context, share_replica, force)
 
         return self.db.share_replica_get(context, share_replica['id'])
 

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -789,7 +789,7 @@ class API(base.Base):
                                                    share_replica,
                                                    force=force)
 
-    def promote_share_replica(self, context, share_replica, force):
+    def promote_share_replica(self, context, share_replica, force=False):
 
         if share_replica.get('status') != constants.STATUS_AVAILABLE:
             msg = _("Replica %(replica_id)s must be in %(status)s state to be "

--- a/manila/share/driver.py
+++ b/manila/share/driver.py
@@ -2069,7 +2069,7 @@ class ShareDriver(object):
         raise NotImplementedError()
 
     def promote_replica(self, context, replica_list, replica, access_rules,
-                        share_server=None):
+                        share_server=None, force=False):
         """Promote a replica to 'active' replica state.
 
         .. note::

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -375,8 +375,8 @@ class DataMotionSession(object):
     def check_snapmirror_health(self, source_share_obj, dest_share_obj):
         """Check if SnapMirror relationship is in sync."""
         snapmirror = self.get_snapmirrors(source_share_obj, dest_share_obj)[0]
-        if snapmirror.get('relationship-status') != 'idle':
-            reason = "Snapmirror relationship is not idle."
+        if snapmirror.get('relationship-status') not in ('idle', 'quiesced'):
+            reason = "Snapmirror relationship is not idle or quiesced."
             return False, reason
         if snapmirror.get('mirror-state') != 'snapmirrored':
             reason = "Snapmirror relationship is not snapmirrored."
@@ -426,7 +426,7 @@ class DataMotionSession(object):
             ok, reason = self.check_snapmirror_health(source_share_obj,
                                                       dest_share_obj)
             if not ok:
-                raise exception.ReplicationException(reason=reason)
+                raise exception.ReplicationUnhealthy(reason=reason)
 
         dest_client.break_snapmirror_vol(src_vserver,
                                          src_volume_name,

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/drv_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/drv_multi_svm.py
@@ -152,10 +152,11 @@ class NetAppCmodeMultiSvmShareDriver(driver.ShareDriver):
                                     replica_snapshots)
 
     def promote_replica(self, context, replica_list, replica, access_rules,
-                        share_server=None):
+                        share_server=None, force=False):
         return self.library.promote_replica(context, replica_list, replica,
                                             access_rules,
-                                            share_server=share_server)
+                                            share_server=share_server,
+                                            force=force)
 
     def update_replica_state(self, context, replica_list, replica,
                              access_rules, replica_snapshots,

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/drv_single_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/drv_single_svm.py
@@ -143,10 +143,11 @@ class NetAppCmodeSingleSvmShareDriver(driver.ShareDriver):
                                     replica_snapshots, **kwargs)
 
     def promote_replica(self, context, replica_list, replica, access_rules,
-                        share_server=None):
+                        share_server=None, force=False):
         return self.library.promote_replica(context, replica_list, replica,
                                             access_rules,
-                                            share_server=share_server)
+                                            share_server=share_server,
+                                            force=force)
 
     def update_replica_state(self, context, replica_list, replica,
                              access_rules, replica_snapshots,

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -3124,6 +3124,8 @@ class NetAppCmodeFileStorageLibrary(object):
                 constants.STATUS_ERROR)
             new_active_replica['status'] = constants.STATUS_ERROR
             return [new_active_replica]
+        except exception.ReplicationException as e:
+            LOG.exception("Could not promote replica %s. %s", replica['id'], e)
 
         new_replica_list.append(new_active_replica)
 
@@ -3322,7 +3324,8 @@ class NetAppCmodeFileStorageLibrary(object):
             LOG.warning(msg)
             pass
         # 2. Break SnapMirror
-        dm_session.break_snapmirror(orig_active_replica, replica)
+        dm_session.break_snapmirror(orig_active_replica, replica,
+                                    check_health=True)
 
         # 3. Setup access rules
         new_active_replica = replica.copy()

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2637,7 +2637,8 @@ class ShareManager(manager.SchedulerDependentManager):
     @add_hooks
     @utils.require_driver_initialized
     @locked_share_replica_operation
-    def promote_share_replica(self, context, share_replica_id, share_id=None):
+    def promote_share_replica(self, context, share_replica_id, share_id=None,
+                              force=False):
         """Promote a share replica to active state."""
         context = context.elevated()
         share_replica = self.db.share_replica_get(
@@ -2692,7 +2693,7 @@ class ShareManager(manager.SchedulerDependentManager):
             updated_replica_list = (
                 self.driver.promote_replica(
                     context, replica_list, share_replica, access_rules,
-                    share_server=share_server)
+                    share_server=share_server, force=force)
             )
         except Exception as excep:
             with excutils.save_and_reraise_exception():

--- a/manila/share/rpcapi.py
+++ b/manila/share/rpcapi.py
@@ -377,13 +377,14 @@ class ShareAPI(object):
                           share_id=share_replica['share_id'],
                           force=force)
 
-    def promote_share_replica(self, context, share_replica):
+    def promote_share_replica(self, context, share_replica, force=False):
         host = utils.extract_host(share_replica['host'])
         call_context = self.client.prepare(server=host, version='1.8')
         call_context.cast(context,
                           'promote_share_replica',
                           share_replica_id=share_replica['id'],
-                          share_id=share_replica['share_id'])
+                          share_id=share_replica['share_id'],
+                          force=force)
 
     def update_share_replica(self, context, share_replica):
         host = utils.extract_host(share_replica['host'])

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -4903,7 +4903,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_dm_session.update_snapmirror.assert_called_once_with(
             self.fake_replica, self.fake_replica_2)
         self.mock_dm_session.break_snapmirror.assert_called_once_with(
-            self.fake_replica, self.fake_replica_2)
+            self.fake_replica, self.fake_replica_2, check_health=True)
 
         self.assertEqual('fake_export_location',
                          replica['export_locations'])
@@ -4931,7 +4931,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_dm_session.update_snapmirror.assert_called_once_with(
             self.fake_replica, self.fake_replica_2)
         self.mock_dm_session.break_snapmirror.assert_called_once_with(
-            self.fake_replica, self.fake_replica_2)
+            self.fake_replica, self.fake_replica_2, check_health=True)
 
         self.assertEqual('fake_export_location',
                          replica['export_locations'])
@@ -5017,7 +5017,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_dm_session.update_snapmirror.assert_called_once_with(
             self.fake_replica, self.fake_replica_2)
         self.mock_dm_session.break_snapmirror.assert_called_once_with(
-            self.fake_replica, self.fake_replica_2)
+            self.fake_replica, self.fake_replica_2, check_health=True)
 
         self.assertEqual('fake_export_location',
                          replica['export_locations'])
@@ -5052,7 +5052,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_dm_session.update_snapmirror.assert_called_once_with(
             self.fake_replica, self.fake_replica_2)
         self.mock_dm_session.break_snapmirror.assert_called_once_with(
-            self.fake_replica, self.fake_replica_2)
+            self.fake_replica, self.fake_replica_2, check_health=True)
 
         fake_helper.assert_has_calls([
             mock.call.set_client(mock.ANY),

--- a/manila/tests/share/test_api.py
+++ b/manila/tests/share/test_api.py
@@ -4316,7 +4316,7 @@ class ShareAPITestCase(test.TestCase):
             self.context, replica['id'],
             {'status': constants.STATUS_REPLICATION_CHANGE})
         mock_rpcapi_promote_share_replica_call.assert_called_once_with(
-            self.context, replica)
+            self.context, replica, False)
 
     def test_promote_share_replica(self):
         replica = fakes.fake_replica('FAKE_ID', host='HOSTA@BackendB#PoolC')
@@ -4329,7 +4329,7 @@ class ShareAPITestCase(test.TestCase):
         result = self.api.promote_share_replica(self.context, replica)
 
         mock_sched_rpcapi_call.assert_called_once_with(
-            self.context, replica)
+            self.context, replica, False)
         self.assertEqual(replica, result)
 
     def test_update_share_replica_no_host(self):

--- a/manila/tests/share/test_rpcapi.py
+++ b/manila/tests/share/test_rpcapi.py
@@ -321,7 +321,8 @@ class ShareRpcAPITestCase(test.TestCase):
         self._test_share_api('promote_share_replica',
                              rpc_method='cast',
                              version='1.8',
-                             share_replica=self.fake_share_replica)
+                             share_replica=self.fake_share_replica,
+                             force=False)
 
     def test_update_share_replica(self):
         self._test_share_api('update_share_replica',


### PR DESCRIPTION
This pull request introduces a force option to the share-replica-promote API. Normally, Manila drivers should verify that data replication is in sync with the source before promoting a replica to prevent data loss. Nevertheless, there are situations where promotion may proceed despite the status of the replication. The inclusion of this option in the API enables users to control the behavior of the driver. Additionally, it enhances verification in the NetApp driver by inspecting the health of SnapMirror before breaking it.

Change-Id: Ia08caf6d3f5864a112ce402567eddbd0d0aa1819