### PR TITLE
sapcc: double check status in second ensure loop

### DIFF
--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -343,9 +343,11 @@ class ShareManagerTestCase(test.TestCase):
         mock_share_get_all_by_host = self.mock_object(
             self.share_manager.db, 'share_instances_get_all_by_host',
             mock.Mock(return_value=instances))
+        # instance 0 and 2 are reloaded
         self.mock_object(self.share_manager.db, 'share_instance_get',
                          mock.Mock(side_effect=[instances[0], instances[2],
-                                                instances[4]]))
+                                                instances[4], instances[0],
+                                                instances[2]]))
         self.mock_object(self.share_manager.db,
                          'share_export_locations_update')
         mock_ensure_shares = self.mock_object(
@@ -685,9 +687,11 @@ class ShareManagerTestCase(test.TestCase):
         smanager = self.share_manager
         self.mock_object(smanager.db, 'share_instances_get_all_by_host',
                          mock.Mock(return_value=instances))
+        # instances are reloaded
         self.mock_object(self.share_manager.db, 'share_instance_get',
                          mock.Mock(side_effect=[instances[0], instances[2],
-                                                instances[4]]))
+                                                instances[4], instances[0],
+                                                instances[2], instances[4]]))
         self.mock_object(self.share_manager.driver, 'ensure_share',
                          mock.Mock(return_value=None))
         self.mock_object(self.share_manager.driver, 'ensure_shares',


### PR DESCRIPTION
in the meantime the share may have been deleted and
we don't want to update the status.

Especially with deferred deletion, shares are longer in that state,
where the backend share is still existing, i.e. the driver ensure
operations are working normally, but still we don't want to reset the
status to available.

followup to 24fb551ee4098fc219bc31b77895b2a8ef463d66

Change-Id: Ie949153e1bc2b854c4263f1899784b9dfe6ec094
