### PR TITLE
Fix share/snapshot show for deferred deletion

### DIFF
--- a/manila/policies/share_snapshot.py
+++ b/manila/policies/share_snapshot.py
@@ -222,6 +222,10 @@ share_snapshot_policies = [
             {
                 'method': 'GET',
                 'path': '/v2/snapshots',
+            },
+            {
+                'method': 'GET',
+                'path': '/snapshots/{snapshot_id}'
             }
         ],
         deprecated_rule=deprecated_list_snapshots_in_deferred_deletion_states

--- a/manila/policies/shares.py
+++ b/manila/policies/shares.py
@@ -620,6 +620,11 @@ shares_policies = [
                 'method': 'GET',
                 'path': '/v2/shares',
             },
+            {
+                'method': 'GET',
+                'path': '/shares/{share_id}',
+            }
+
         ],
         deprecated_rule=deprecated_list_shares_in_deferred_deletion_states
     ),

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -1854,10 +1854,21 @@ class API(base.Base):
         return self.db.share_snapshot_update(context, snapshot['id'], fields)
 
     def get(self, context, share_id):
-        rv = self.db.share_get(context, share_id)
-        if not rv['is_public']:
-            policy.check_policy(context, 'share', 'get', rv)
-        return rv
+        share = self.db.share_get(context, share_id)
+        if not share['is_public']:
+            authorized = policy.check_policy(
+                context, 'share', 'get', share, do_raise=False)
+            if not authorized:
+                raise exception.NotFound()
+        if share['status'] in (
+            constants.STATUS_DEFERRED_DELETING,
+                constants.STATUS_ERROR_DEFERRED_DELETING):
+            policy_str = "list_shares_in_deferred_deletion_states"
+            authorized = policy.check_policy(
+                context, 'share', policy_str, share, do_raise=False)
+            if not authorized:
+                raise exception.NotFound()
+        return share
 
     def get_all(self, context, search_opts=None, sort_key='created_at',
                 sort_dir='desc'):
@@ -1969,7 +1980,17 @@ class API(base.Base):
 
     def get_snapshot(self, context, snapshot_id):
         policy.check_policy(context, 'share_snapshot', 'get_snapshot')
-        return self.db.share_snapshot_get(context, snapshot_id)
+        snapshot = self.db.share_snapshot_get(context, snapshot_id)
+        if snapshot.get('status') in (
+            constants.STATUS_DEFERRED_DELETING,
+                constants.STATUS_ERROR_DEFERRED_DELETING):
+            policy_str = "list_snapshots_in_deferred_deletion_states"
+            authorized = policy.check_policy(
+                context, 'share_snapshot', policy_str,
+                snapshot, do_raise=False)
+            if not authorized:
+                raise exception.NotFound()
+        return snapshot
 
     def get_all_snapshots(self, context, search_opts=None, limit=None,
                           offset=None, sort_key='share_id', sort_dir='desc'):

--- a/manila/tests/api/v2/test_share_accesses.py
+++ b/manila/tests/api/v2/test_share_accesses.py
@@ -137,7 +137,7 @@ class ShareAccessesAPITest(test.TestCase):
             mock.call(req.environ['manila.context'],
                       'share', 'access_get'),
             mock.call(req.environ['manila.context'],
-                      'share', 'get', mock.ANY)])
+                      'share', 'get', mock.ANY, do_raise=False)])
         policy_check_call_args_list = policy.check_policy.call_args_list[2][0]
         share_being_checked = policy_check_call_args_list[3]
         self.assertEqual('c3c5ec1ccc4640d0af1914cbf11f05ad',

--- a/manila/tests/api/v2/test_share_instances.py
+++ b/manila/tests/api/v2/test_share_instances.py
@@ -184,7 +184,7 @@ class ShareInstancesAPITest(test.TestCase):
         req = self._get_request('fake', version=version)
         req_context = req.environ['manila.context']
         share_policy_check_call = mock.call(
-            req_context, 'share', 'get', mock.ANY)
+            req_context, 'share', 'get', mock.ANY, do_raise=False)
         get_instances_policy_check_call = mock.call(
             req_context, 'share_instance', 'index')
 


### PR DESCRIPTION
Deferred deletion states deferred_deleting, error_deferred_deleting are visible for non-admin user in 'share/snapshot show' command. Fixed this.

Closes-bug: #2067456
Change-Id: I42ddda3144a3f52b4bc0420d5acde1e5e7560264