### PR TITLE
Update share/snapshot instance deferred deletion

### DIFF
--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -1828,13 +1828,15 @@ class API(base.Base):
         if force and deferred_delete:
             deferred_delete = False
 
-        status = constants.STATUS_DELETING
-        if deferred_delete:
-            status = constants.STATUS_DEFERRED_DELETING
-
-        for snapshot_instance in snapshot_instances:
-            self.db.share_snapshot_instance_update(
-                context, snapshot_instance['id'], {'status': status})
+        current_status = snapshot['aggregate_status']
+        if current_status not in (constants.STATUS_DEFERRED_DELETING,
+                                  constants.STATUS_ERROR_DEFERRED_DELETING):
+            new_status = constants.STATUS_DELETING
+            if deferred_delete:
+                new_status = constants.STATUS_DEFERRED_DELETING
+            for snapshot_instance in snapshot_instances:
+                self.db.share_snapshot_instance_update(
+                    context, snapshot_instance['id'], {'status': new_status})
 
         if share['has_replicas']:
             self.share_rpcapi.delete_replicated_snapshot(

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -3609,9 +3609,9 @@ class ShareManager(manager.SchedulerDependentManager):
         if deferred_delete:
             try:
                 LOG.info(
-                    "Share instance %s has been added to a deferred deletion "
-                    "queue and will be deleted during the next iteration of "
-                    "the periodic deletion task", share_instance_id
+                    "Share instance %s has been deferred deleted i.e. "
+                    "quota is reclaimed and then resource will be deleted "
+                    "by driver.", share_instance_id
                 )
                 self.db.update_share_instance_quota_usages(
                     context, share_instance_id)
@@ -3619,7 +3619,20 @@ class ShareManager(manager.SchedulerDependentManager):
                 LOG.warning(
                     "Error occured during quota usage update. Administrator "
                     "must rectify quotas.")
-            return
+            snap_instances = (
+                self.db.share_snapshot_instance_get_all_with_filters(
+                    context, {'share_instance_ids': share_instance_id}))
+            if snap_instances:
+                # special case
+                # 1. snapshot deferred_deleted
+                # 2. share deleted
+                # 3. we just clean quota and then wait for periodic
+                #    task to delete share
+                self.db.share_instance_update(
+                    context,
+                    share_instance_id,
+                    {'status': constants.STATUS_ERROR_DEFERRED_DELETING})
+                return
 
         try:
             self.access_helper.update_access_rules(
@@ -3640,10 +3653,13 @@ class ShareManager(manager.SchedulerDependentManager):
                     LOG.error(msg, share_instance_id)
                     exc_context.reraise = False
                 else:
+                    error_state = constants.STATUS_ERROR_DELETING
+                    if deferred_delete:
+                        error_state = constants.STATUS_ERROR_DEFERRED_DELETING
                     self.db.share_instance_update(
                         context,
                         share_instance_id,
-                        {'status': constants.STATUS_ERROR_DELETING})
+                        {'status': error_state})
                 self.message_api.create(
                     context,
                     message_field.Action.DELETE_ACCESS_RULES,
@@ -3651,6 +3667,11 @@ class ShareManager(manager.SchedulerDependentManager):
                     resource_type=message_field.Resource.SHARE,
                     resource_id=share_instance_id,
                     exception=excep)
+
+        share_instance = self._get_share_instance(context, share_instance_id)
+        if share_instance['status'] == (
+                constants.STATUS_ERROR_DEFERRED_DELETING) and not force:
+            return
 
         try:
             scheduled_at = share_instance.get('scheduled_at')
@@ -3675,10 +3696,13 @@ class ShareManager(manager.SchedulerDependentManager):
                     LOG.error(msg, share_instance_id)
                     exc_context.reraise = False
                 else:
+                    error_state = constants.STATUS_ERROR_DELETING
+                    if deferred_delete:
+                        error_state = constants.STATUS_ERROR_DEFERRED_DELETING
                     self.db.share_instance_update(
                         context,
                         share_instance_id,
-                        {'status': constants.STATUS_ERROR_DELETING})
+                        {'status': error_state})
 
                 # NOTE: workaround to filter NetApp snapmirror error:
                 exc_msg = getattr(excep, 'message', '')
@@ -3700,6 +3724,11 @@ class ShareManager(manager.SchedulerDependentManager):
                         resource_type=message_field.Resource.SHARE,
                         resource_id=share_instance_id,
                         exception=excep)
+
+        share_instance = self._get_share_instance(context, share_instance_id)
+        if share_instance['status'] == (
+                constants.STATUS_ERROR_DEFERRED_DELETING) and not force:
+            return
 
         need_to_update_usages = True
         if share_instance['status'] in (
@@ -3737,27 +3766,6 @@ class ShareManager(manager.SchedulerDependentManager):
                 else:
                     self.delete_share_server(context, share_server)
 
-    def _get_share_instances_with_deferred_deletion(self, ctxt):
-        share_instances = self.db.share_instances_get_all(
-            ctxt,
-            filters={
-                'status': constants.STATUS_DEFERRED_DELETING,
-                'host': self.host,
-            })
-
-        share_instances_error_deferred_deleting = (
-            self.db.share_instances_get_all(
-                ctxt,
-                filters={
-                    'status': constants.STATUS_ERROR_DEFERRED_DELETING,
-                    'host': self.host,
-                }))
-        updated_del = timeutils.utcnow() - datetime.timedelta(minutes=30)
-        for share_instance in share_instances_error_deferred_deleting:
-            if share_instance.get('updated_at') < updated_del:
-                share_instances.append(share_instance)
-        return share_instances
-
     @periodic_task.periodic_task(
         spacing=CONF.periodic_deferred_delete_interval)
     @utils.require_driver_initialized
@@ -3766,7 +3774,12 @@ class ShareManager(manager.SchedulerDependentManager):
                   "process their deletion.")
         ctxt = ctxt.elevated()
         share_instances = (
-            self._get_share_instances_with_deferred_deletion(ctxt))
+            self.db.share_instances_get_all(
+                ctxt,
+                filters={
+                    'status': constants.STATUS_ERROR_DEFERRED_DELETING,
+                    'host': self.host,
+                }))
 
         for share_instance in share_instances:
             share_instance_id = share_instance['id']
@@ -3796,10 +3809,6 @@ class ShareManager(manager.SchedulerDependentManager):
                 msg = ("The driver was unable to delete access rules "
                        "for the instance: %s.")
                 LOG.error(msg, share_instance_id)
-                self.db.share_instance_update(
-                    ctxt,
-                    share_instance_id,
-                    {'status': constants.STATUS_ERROR_DEFERRED_DELETING})
                 continue
 
             try:
@@ -3818,10 +3827,6 @@ class ShareManager(manager.SchedulerDependentManager):
                 msg = ("The driver was unable to delete the share "
                        "instance: %s on the backend. ")
                 LOG.error(msg, share_instance_id)
-                self.db.share_instance_update(
-                    ctxt,
-                    share_instance_id,
-                    {'status': constants.STATUS_ERROR_DEFERRED_DELETING})
                 continue
 
             self.db.share_instance_delete(ctxt, share_instance_id)
@@ -3924,8 +3929,7 @@ class ShareManager(manager.SchedulerDependentManager):
         self.db.share_snapshot_instance_update(
             context, snapshot_instance_id, model_update)
 
-    def _delete_snapshot_quota(self, context, snapshot,
-                               deferred_delete=False):
+    def _delete_snapshot_quota(self, context, snapshot):
         share_type_id = snapshot['share']['instance']['share_type_id']
         reservations = None
         try:
@@ -3965,6 +3969,19 @@ class ShareManager(manager.SchedulerDependentManager):
 
         share_ref = self.db.share_get(context, snapshot_ref['share_id'])
 
+        if deferred_delete:
+            try:
+                LOG.info(
+                    "Snapshot instance %s has been deferred deleted i.e. "
+                    "quota is reclaimed and then resource will be deleted "
+                    "by driver.", snapshot_instance['id']
+                )
+                self._delete_snapshot_quota(context, snapshot_ref)
+            except Exception:
+                LOG.warning(
+                    "Error occured during quota usage update. Administrator "
+                    "must rectify quotas.")
+
         if share_ref['mount_snapshot_support']:
             try:
                 self.snapshot_access_helper.update_access_rules(
@@ -3977,23 +3994,6 @@ class ShareManager(manager.SchedulerDependentManager):
                 LOG.warning("The driver was unable to remove access rules "
                             "for snapshot %s. Moving on.",
                             snapshot_instance['snapshot_id'])
-
-        if deferred_delete:
-            try:
-                LOG.info(
-                    "Snapshot instance %s has been added to a deferred "
-                    "deletion queue and will be deleted during the next "
-                    "iteration of the periodic deletion task",
-                    snapshot_instance['id']
-                )
-                self._delete_snapshot_quota(
-                    context, snapshot_ref, deferred_delete=True)
-                return
-            except Exception:
-                LOG.warning(
-                    "Error occured during quota usage update. Administrator "
-                    "must rectify quotas.")
-                return
 
         try:
             self.driver.delete_snapshot(context, snapshot_instance,
@@ -4009,10 +4009,13 @@ class ShareManager(manager.SchedulerDependentManager):
                     LOG.exception(msg, snapshot_id)
                     exc.reraise = False
                 else:
+                    error_state = constants.STATUS_ERROR_DELETING
+                    if deferred_delete:
+                        error_state = constants.STATUS_ERROR_DEFERRED_DELETING
                     self.db.share_snapshot_instance_update(
                         context,
                         snapshot_instance_id,
-                        {'status': constants.STATUS_ERROR_DELETING})
+                        {'status': error_state})
                 self.message_api.create(
                     context,
                     message_field.Action.DELETE,
@@ -4021,21 +4024,18 @@ class ShareManager(manager.SchedulerDependentManager):
                     resource_id=snapshot_instance_id,
                     exception=excep)
 
+        snapshot_instance = self.db.share_snapshot_instance_get(
+            context, snapshot_ref.instance['id'])
+        if snapshot_instance['status'] == (
+                constants.STATUS_ERROR_DEFERRED_DELETING) and not force:
+            return
+
         self.db.share_snapshot_instance_delete(context, snapshot_instance_id)
-        self._delete_snapshot_quota(context, snapshot_ref)
-
-    def _get_snapshot_instances_with_deletion_deferred(self, ctxt):
-        snap_instances = self.db.share_snapshot_instance_get_all_with_filters(
-            ctxt, {'statuses': constants.STATUS_DEFERRED_DELETING})
-
-        snap_instances_error_deferred_deleting = \
-            self.db.share_snapshot_instance_get_all_with_filters(
-                ctxt, {'statuses': constants.STATUS_ERROR_DEFERRED_DELETING})
-        updated_del = timeutils.utcnow() - datetime.timedelta(minutes=30)
-        for snap_instance in snap_instances_error_deferred_deleting:
-            if snap_instance.get('updated_at') < updated_del:
-                snap_instances.append(snap_instance)
-        return snap_instances
+        if snapshot_instance['status'] not in (
+            constants.STATUS_DEFERRED_DELETING,
+            constants.STATUS_ERROR_DEFERRED_DELETING
+        ):
+            self._delete_snapshot_quota(context, snapshot_ref)
 
     @periodic_task.periodic_task(
         spacing=CONF.periodic_deferred_delete_interval)
@@ -4045,7 +4045,8 @@ class ShareManager(manager.SchedulerDependentManager):
                   "process their deletion.")
         ctxt = ctxt.elevated()
         snapshot_instances = (
-            self._get_snapshot_instances_with_deletion_deferred(ctxt))
+            self.db.share_snapshot_instance_get_all_with_filters(
+                ctxt, {'statuses': constants.STATUS_ERROR_DEFERRED_DELETING}))
 
         for snapshot_instance in snapshot_instances:
             snapshot_instance_id = snapshot_instance['id']
@@ -4058,10 +4059,6 @@ class ShareManager(manager.SchedulerDependentManager):
                 self.driver.delete_snapshot(ctxt, snapshot_instance,
                                             share_server=share_server)
             except Exception:
-                self.db.share_snapshot_instance_update(
-                    ctxt,
-                    snapshot_instance_id,
-                    {'status': constants.STATUS_ERROR_DEFERRED_DELETING})
                 continue
             self.db.share_snapshot_instance_delete(ctxt,
                                                    snapshot_instance_id)

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -2036,11 +2036,13 @@ class ShareManagerTestCase(test.TestCase):
         share_id = 'FAKE_SHARE_ID'
         share = fakes.fake_share(id=share_id)
         snapshot_instance = fakes.fake_snapshot_instance(
-            share_id=share_id, share=share, name='fake_snapshot')
+            share_id=share_id, share=share, name='fake_snapshot',
+            status=constants.STATUS_DEFERRED_DELETING)
         snapshot = fakes.fake_snapshot(
             share_id=share_id, share=share, instance=snapshot_instance,
             project_id=self.context.project_id, size=1)
         snapshot_id = snapshot['id']
+
         self.mock_object(self.share_manager.db, 'share_snapshot_get',
                          mock.Mock(return_value=snapshot))
         self.mock_object(self.share_manager.db, 'share_snapshot_instance_get',
@@ -2049,6 +2051,8 @@ class ShareManagerTestCase(test.TestCase):
                          mock.Mock(return_value=share))
         self.mock_object(self.share_manager, '_get_share_server',
                          mock.Mock(return_value=None))
+        self.mock_object(
+            self.share_manager.db, 'share_snapshot_instance_delete')
 
         self.mock_object(self.share_manager.driver, 'delete_snapshot')
         self.mock_object(quota.QUOTAS, 'reserve',
@@ -2058,7 +2062,8 @@ class ShareManagerTestCase(test.TestCase):
         self.share_manager.delete_snapshot(self.context, snapshot_id,
                                            deferred_delete=True)
 
-        self.share_manager.driver.delete_snapshot.assert_not_called()
+        self.share_manager.db.share_snapshot_instance_delete.assert_called()
+        self.share_manager.driver.delete_snapshot.assert_called()
         quota.QUOTAS.reserve.assert_called_once_with(
             mock.ANY, project_id=self.context.project_id, snapshots=-1,
             snapshot_gigabytes=-snapshot['size'], user_id=snapshot['user_id'],
@@ -2166,8 +2171,7 @@ class ShareManagerTestCase(test.TestCase):
             resource_id=snapshot_instance['id'],
             exception=mock.ANY)
 
-    @ddt.data(True, False)
-    def test_do_deferred_snapshot_deletion(self, consider_error_deleting):
+    def test_do_deferred_snapshot_deletion(self):
         instance_1 = db_utils.create_share_instance(
             share_id='fake_id',
             share_type_id='fake_type_id')
@@ -2181,14 +2185,10 @@ class ShareManagerTestCase(test.TestCase):
         db_utils.create_snapshot_instance(
             snapshot_id=snapshot['id'],
             share_instance_id=instance_1['id'],
-            status='deferred_deleting')
-        mins = 20
-        if consider_error_deleting:
-            mins = 40
+            status='error_deferred_deleting')
         db_utils.create_snapshot_instance(
             snapshot_id=snapshot['id'],
             share_instance_id=instance_2['id'],
-            updated_at=timeutils.utcnow() - datetime.timedelta(minutes=mins),
             status='error_deferred_deleting')
 
         self.mock_object(self.share_manager, '_get_share_server',
@@ -2198,10 +2198,7 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(self.share_manager.db,
                          'share_snapshot_instance_update')
         self.share_manager.do_deferred_snapshot_deletion(self.context)
-        if consider_error_deleting:
-            self.assertEqual(2, mock_delete_snapshot.call_count)
-        else:
-            self.assertEqual(1, mock_delete_snapshot.call_count)
+        self.assertEqual(2, mock_delete_snapshot.call_count)
 
     def test_do_deferred_snapshot_deletion_exception(self):
         instance_1 = db_utils.create_share_instance(
@@ -2211,10 +2208,10 @@ class ShareManagerTestCase(test.TestCase):
             id='fake_id',
             instances=[instance_1])
         snapshot = db_utils.create_snapshot(share_id=share['id'])
-        si = db_utils.create_snapshot_instance(
+        db_utils.create_snapshot_instance(
             snapshot_id=snapshot['id'],
             share_instance_id=instance_1['id'],
-            status='deferred_deleting')
+            status='error_deferred_deleting')
 
         self.mock_object(self.share_manager, '_get_share_server',
                          mock.Mock(return_value=None))
@@ -2228,9 +2225,6 @@ class ShareManagerTestCase(test.TestCase):
             'share_snapshot_instance_delete')
 
         self.share_manager.do_deferred_snapshot_deletion(self.context)
-        self.share_manager.db.share_snapshot_instance_update.assert_any_call(
-            mock.ANY, si['id'],
-            {'status': constants.STATUS_ERROR_DEFERRED_DELETING})
         mock_delete_snapshot_db.assert_not_called()
 
     def test_create_share_instance_with_share_network_dhss_false(self):
@@ -3642,9 +3636,11 @@ class ShareManagerTestCase(test.TestCase):
             host=self.share_manager.host
         )
         share_type = db_utils.create_share_type()
-        share = db_utils.create_share(share_network_id=share_net['id'],
-                                      share_server_id=share_srv['id'],
-                                      share_type_id=share_type['id'])
+        share = db_utils.create_share(
+            share_network_id=share_net['id'],
+            share_server_id=share_srv['id'],
+            share_type_id=share_type['id'],
+            status=constants.STATUS_DEFERRED_DELETING)
         share_srv = db.share_server_get(self.context, share_srv['id'])
 
         manager.CONF.delete_share_server_with_last_share = False
@@ -3659,6 +3655,7 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(manager.LOG, 'exception')
         self.mock_object(self.share_manager.db, 'share_instance_update',
                          mock.Mock(return_value=None))
+        self.mock_object(self.share_manager.driver, 'delete_share')
 
         self.share_manager.delete_share_instance(self.context,
                                                  share.instance['id'],
@@ -3675,6 +3672,7 @@ class ShareManagerTestCase(test.TestCase):
             mock.ANY, **reservation_params,
         )
         self.assertFalse(quota.QUOTAS.commit.called)
+        self.assertTrue(self.share_manager.driver.delete_share.called)
         self.assertFalse(self.share_manager.driver.teardown_network.called)
 
     def test_delete_share_instance_deferred_delete(self):
@@ -3683,9 +3681,11 @@ class ShareManagerTestCase(test.TestCase):
             host=self.share_manager.host
         )
         share_type = db_utils.create_share_type()
-        share = db_utils.create_share(share_network_id=share_net['id'],
-                                      share_server_id=share_srv['id'],
-                                      share_type_id=share_type['id'])
+        share = db_utils.create_share(
+            share_network_id=share_net['id'],
+            share_server_id=share_srv['id'],
+            share_type_id=share_type['id'],
+            status=constants.STATUS_DEFERRED_DELETING)
         share_srv = db.share_server_get(self.context, share_srv['id'])
 
         manager.CONF.delete_share_server_with_last_share = False
@@ -3699,6 +3699,7 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(manager.LOG, 'exception')
         self.mock_object(self.share_manager.db, 'share_instance_update',
                          mock.Mock(return_value=None))
+        self.mock_object(self.share_manager.driver, 'delete_share')
 
         self.share_manager.delete_share_instance(self.context,
                                                  share.instance['id'],
@@ -3718,10 +3719,10 @@ class ShareManagerTestCase(test.TestCase):
             mock.ANY, mock.ANY, project_id=share['project_id'],
             share_type_id=share_type['id'], user_id=share['user_id'],
         )
+        self.assertTrue(self.share_manager.driver.delete_share.called)
         self.assertFalse(self.share_manager.driver.teardown_network.called)
 
-    @ddt.data(True, False)
-    def test_do_deferred_share_deletion(self, consider_error_deleting):
+    def test_do_deferred_share_deletion(self):
         share = db_utils.create_share_without_instance(
             id='fake_id',
             status=constants.STATUS_AVAILABLE)
@@ -3730,7 +3731,7 @@ class ShareManagerTestCase(test.TestCase):
             'id': 1,
             'share_id': share['id'],
             'share_server_id': share_server['id'],
-            'status': 'deferred_deleting',
+            'status': 'error_deferred_deleting',
             'updated_at': timeutils.utcnow(),
             'host': self.host,
         }
@@ -3739,24 +3740,11 @@ class ShareManagerTestCase(test.TestCase):
             'id': 2,
             'share_id': share['id'],
             'share_server_id': share_server['id'],
-            'status': 'deferred_deleting',
+            'status': 'error_deferred_deleting',
             'updated_at': timeutils.utcnow(),
             'host': self.host,
         }
         si_2 = db_utils.create_share_instance(**kwargs)
-        mins = 20
-        if consider_error_deleting:
-            mins = 40
-        kwargs = {
-            'id': 3,
-            'share_id': share['id'],
-            'share_server_id': share_server['id'],
-            'status': 'error_deferred_deleting',
-            'updated_at': (
-                timeutils.utcnow() - datetime.timedelta(minutes=mins)),
-            'host': self.host,
-        }
-        si_3 = db_utils.create_share_instance(**kwargs)
 
         self.mock_object(self.share_manager.db, 'share_server_get',
                          mock.Mock(return_value=share_server))
@@ -3765,9 +3753,7 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(self.share_manager.db, 'share_instance_delete')
         self.mock_object(
             self.share_manager.db, 'share_instances_get_all',
-            mock.Mock(side_effect=[
-                [si_1, si_2],
-                [si_3] if consider_error_deleting else {}]))
+            mock.Mock(return_value=[si_1, si_2]))
 
         self.mock_object(self.share_manager, '_check_delete_share_server')
         self.mock_object(self.share_manager, '_notify_about_share_usage')
@@ -3775,10 +3761,7 @@ class ShareManagerTestCase(test.TestCase):
             self.share_manager.driver, 'delete_share')
 
         self.share_manager.do_deferred_share_deletion(self.context)
-        if consider_error_deleting:
-            self.assertEqual(3, mock_delete_share.call_count)
-        else:
-            self.assertEqual(2, mock_delete_share.call_count)
+        self.assertEqual(2, mock_delete_share.call_count)
 
     def test_do_deferred_share_deletion_exception(self):
         share = db_utils.create_share_without_instance(
@@ -3811,9 +3794,6 @@ class ShareManagerTestCase(test.TestCase):
             mock.Mock(side_effect=exception.ManilaException))
 
         self.share_manager.do_deferred_share_deletion(self.context)
-        self.share_manager.db.share_instance_update.assert_any_call(
-            mock.ANY, si['id'],
-            {'status': constants.STATUS_ERROR_DEFERRED_DELETING})
         mock_delete.assert_not_called()
 
     def test_setup_server(self):


### PR DESCRIPTION
- Deferred deletion would be regular deletion where quota is freed before resource deletion by driver and deletion states are hidden from end-user. Also, everything will be handled by Manila or admin if any error occurs in deletion.
- Any error during deferred deletion will put share/snapshot in error_deferrer_deleting state and periodic task will handle it.

Change-Id: I7852545b735b3d03096816e65af2a6a9de5c1391