### PR TITLE
fix share server migration KeyError

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -1801,7 +1801,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 self._setup_networking_for_destination_vserver(
                     dest_client, src_vserver, new_network_alloc)
 
-                server_backend_details.pop('ports')
+                server_backend_details.pop('ports', None)
                 ports = {}
                 for allocation in dest_share_server['network_allocations']:
                     ports[allocation['id']] = allocation['ip_address']


### PR DESCRIPTION
Old share servers may not have the 'ports' in the backend_details.
The old information is not used, it is just to make sure the key is
deleted before overwriting.

Change-Id: I8346a424f9d769eedf4f42e96d6918a5cb92585f

Also see https://docs.python.org/3/library/stdtypes.html#dict.pop
