### PR TITLE
improve 'NetApp: start vserver delete by disabling the interfaces'

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1248,6 +1248,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         interfaces = []
         for lif_info in lif_info_list.get_children():
             lif = {
+                'administrative-status': lif_info.get_child_content(
+                    'administrative-status'),
                 'address': lif_info.get_child_content('address'),
                 'home-node': lif_info.get_child_content('home-node'),
                 'home-port': lif_info.get_child_content('home-port'),

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -592,8 +592,9 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             # we already deleted the neutron network allocations,
             # make sure those are no longer used
             for interface in network_interfaces:
-                vserver_client.disable_network_interface(
-                    vserver, interface['interface-name'])
+                if interface['administrative-status'] != 'down':
+                    vserver_client.disable_network_interface(
+                        vserver, interface['interface-name'])
 
             # NOTE(dviroel): always delete all policies before deleting the
             # vserver

--- a/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
@@ -136,6 +136,7 @@ CDOT_CLONE_CHILDREN = [
 
 NETWORK_INTERFACES = [{
     'interface-name': 'fake_interface',
+    'administrative-status': 'up',
     'address': IP_ADDRESS,
     'vserver': VSERVER_NAME,
     'netmask': NETMASK,
@@ -147,6 +148,7 @@ NETWORK_INTERFACES = [{
 NETWORK_INTERFACES_MULTIPLE = [
     {
         'interface-name': 'fake_interface',
+        'administrative-status': 'up',
         'address': IP_ADDRESS,
         'vserver': VSERVER_NAME,
         'netmask': NETMASK,
@@ -156,6 +158,7 @@ NETWORK_INTERFACES_MULTIPLE = [
     },
     {
         'interface-name': 'fake_interface_2',
+        'administrative-status': 'up',
         'address': '10.10.12.10',
         'vserver': VSERVER_NAME,
         'netmask': NETMASK,
@@ -990,6 +993,7 @@ NET_INTERFACE_GET_ITER_RESPONSE_NFS = etree.XML("""
 
 LIFS = (
     {'address': '192.168.228.42',
+     'administrative-status': 'up',
      'home-node': NODE_NAME,
      'home-port': 'e0c',
      'interface-name': 'cluster_mgmt',
@@ -998,6 +1002,7 @@ LIFS = (
      'vserver': 'cluster3'
      },
     {'address': '192.168.228.43',
+     'administrative-status': 'up',
      'home-node': NODE_NAME,
      'home-port': 'e0d',
      'interface-name': 'mgmt1',
@@ -1006,6 +1011,7 @@ LIFS = (
      'vserver': 'cluster3-01'
      },
     {'address': IP_ADDRESS,
+     'administrative-status': 'up',
      'home-node': NODE_NAME,
      'home-port': VLAN_PORT,
      'interface-name': LIF_NAME,
@@ -1017,6 +1023,7 @@ LIFS = (
 
 NFS_LIFS = [
     {'address': IP_ADDRESS,
+     'administrative-status': 'up',
      'home-node': NODE_NAME,
      'home-port': VLAN_PORT,
      'interface-name': LIF_NAME,

--- a/manila/tests/share/drivers/netapp/dataontap/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/fakes.py
@@ -795,6 +795,7 @@ LIF_NAMES = []
 LIF_ADDRESSES = ['10.10.10.10', '10.10.10.20']
 LIFS = (
     {'address': LIF_ADDRESSES[0],
+     'administrative-status': 'up',
      'home-node': CLUSTER_NODES[0],
      'home-port': 'e0c',
      'interface-name': 'os_132dbb10-9a36-46f2-8d89-3d909830c356',
@@ -803,6 +804,7 @@ LIFS = (
      'vserver': VSERVER1
      },
     {'address': LIF_ADDRESSES[1],
+     'administrative-status': 'up',
      'home-node': CLUSTER_NODES[1],
      'home-port': 'e0c',
      'interface-name': 'os_7eabdeed-bad2-46ea-bd0f-a33884c869e0',


### PR DESCRIPTION
followup to 7f39c185560591df99bbba6b0a05286b925fc17e

We don't need to disable already disabled interfaces, which would
happen on the second and consecutive runs of the cleanup if it failed.
In fact this throws an error
'13005:Unable to find API: net-interface-modify on data vserver'

Change-Id: Ia34809d96097d684113e651e09676b4e8a643054
