### PR TITLE
use cluster client for interface api

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -593,7 +593,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             # make sure those are no longer used
             for interface in network_interfaces:
                 if interface['administrative-status'] != 'down':
-                    vserver_client.disable_network_interface(
+                    self._client.disable_network_interface(
                         vserver, interface['interface-name'])
 
             # NOTE(dviroel): always delete all policies before deleting the


### PR DESCRIPTION
If we turn off the vserver interface the vserver api will not work.
Fixes '13005:Unable to find API'

Change-Id: I57612fec5487aa229c4bf933696d00b7906319e6
