### PR TITLE
Improve server migration

### DIFF
--- a/manila/db/api.py
+++ b/manila/db/api.py
@@ -1120,6 +1120,12 @@ def share_server_backend_details_set(context, share_server_id, server_details):
                                                  server_details)
 
 
+def share_server_backend_details_get(context, share_server_id, meta_key):
+    """Get backend details."""
+    return IMPL.share_server_backend_details_get(context, share_server_id,
+                                                 meta_key)
+
+
 def share_server_backend_details_delete(context, share_server_id):
     """Delete backend details DB records for a share server."""
     return IMPL.share_server_backend_details_delete(context, share_server_id)

--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -4605,6 +4605,15 @@ def share_server_backend_details_set(context, share_server_id, server_details):
 
 
 @require_context
+def share_server_backend_details_get(context, share_server_id, meta_key):
+    session = get_session()
+    with session.begin():
+        meta_ref = _share_server_backend_details_get_item(
+            context, share_server_id, meta_key, session=session)
+        return meta_ref['value']
+
+
+@require_context
 def share_server_backend_details_delete(context, share_server_id,
                                         session=None):
     if not session:

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -682,114 +682,55 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
     def extend_network_allocations(self, context, share_server):
         """Extend network to target host.
 
-        Create extra (inactive) port bindings on given host. Network
-        is bound to the host with new segementation id.
+        This will create port bindings on target host without activating them.
+        If network segment does not exist on target host, it will be created.
+
+        :return: list of port bindings with new segmentation id on target host
         """
-        phys_net = self.config.neutron_physical_net_name
         vnic_type = self.config.neutron_vnic_type
         host_id = self.config.neutron_host_id
-        vlan = None
 
-        # Active port bindings are labeled as 'user'. Destination port bindings
-        # are labeled with physical network name.
         active_port_bindings = (
             self.db.network_allocations_get_for_share_server(
                 context, share_server['id'], label='user'))
-        dest_port_bindings = (
-            self.db.network_allocations_get_for_share_server(
-                context, share_server['id'], label=phys_net))
-
         if len(active_port_bindings) == 0:
             raise exception.NetworkException(
                 'Can not extend network with no active bindings')
 
-        if len(dest_port_bindings) == 0:
-            # Create port binding on destination backend. Exception is ignored
-            # in the neutron api call, if the port is already bound to
-            # destination host.
-            for port in active_port_bindings:
-                self.neutron_api.bind_port_to_host(port['id'], host_id,
-                                                   vnic_type)
+        # Create port binding on destination backend. It's safe to call neutron
+        # api bind_port_to_host if the port is already bound to destination
+        # host.
+        for port in active_port_bindings:
+            self.neutron_api.bind_port_to_host(port['id'], host_id,
+                                               vnic_type)
 
-            # Wait for network segment to be created on destination host.
-            vlan = self._wait_for_network_segment(share_server, host_id)
+        # Wait for network segment to be created on destination host.
+        vlan = self._wait_for_network_segment(share_server, host_id)
+        for port in active_port_bindings:
+            port['segmentation_id'] = vlan
 
-            # Label the new port bindings with physical network name.
-            dest_port_bindings = []
-            for port_data in active_port_bindings:
-                port_data['label'] = phys_net
-                port_data['segmentation_id'] = vlan
-                port_data['id'] = None
-                port_data['created_at'] = None
-                dest_port_bindings.append(
-                    self.db.network_allocation_create(context, port_data))
+        return active_port_bindings
 
-        return dest_port_bindings
-
-    def delete_extended_allocations(self, context, src_share_server,
-                                    dest_share_server=None):
+    def delete_extended_allocations(self, context, share_server):
         host_id = self.config.neutron_host_id
-        phys_net = self.config.neutron_physical_net_name
-
-        # Nuetron port ids are stored in 'id' field of active network
-        # allocations, which are bound to source share server.
         ports = self.db.network_allocations_get_for_share_server(
-            context, src_share_server['id'], label='user')
-
-        # Sometimes extended allocations are deleted before the destination
-        # server server is created.
-        share_server_to_get_alloc = dest_share_server or src_share_server
-        extended_allocs = self.db.network_allocations_get_for_share_server(
-            context, share_server_to_get_alloc['id'], label=phys_net)
+            context, share_server['id'], label='user')
         for port in ports:
             try:
                 self.neutron_api.delete_port_binding(port['id'], host_id)
             except exception.NetworkException as e:
-                msg = _(
-                    'Failed to delete port binding on port %{port}s: %{err}s')
+                msg = 'Failed to delete port binding on port %{port}s: %{err}s'
                 LOG.warning(msg, {'port': port['id'], 'err': e})
-        for alloc in extended_allocs:
-            self.db.network_allocation_delete(context, alloc['id'])
 
-    def cutover_network_allocations(self, context, src_share_server,
-                                    dest_share_server):
-        physnet = self.config.neutron_physical_net_name
+    def cutover_network_allocations(self, context, src_share_server):
         src_host = share_utils.extract_host(src_share_server['host'], 'host')
-        dest_host = share_utils.extract_host(dest_share_server['host'], 'host')
-
-        active_allocations = (
-            self.db.network_allocations_get_for_share_server(
-                context, src_share_server['id'], label='user'))
-        inactive_allocations = (
-            self.db.network_allocations_get_for_share_server(
-                context, dest_share_server['id'], label=physnet))
-
-        if len(inactive_allocations) == 0:
-            msg = _(
-                'No target network allocations for cutover from '
-                '%(src_ss)s to %(dest_ss)s')
-            raise exception.NetworkException(
-                msg % {
-                    'src_ss': src_share_server['id'],
-                    'dest_ss': dest_share_server['id']
-                })
-        vlan_to_activate = inactive_allocations[0]['segmentation_id']
-
-        # Cutting over network allocations
-        alloc_data = {
-            'share_server_id': dest_share_server['id'],
-            'segmentation_id': vlan_to_activate
-        }
-        for alloc in active_allocations:
-            self.neutron_api.activate_port_binding(alloc['id'], dest_host)
-            self.neutron_api.delete_port_binding(alloc['id'], src_host)
-            self.db.network_allocation_update(context, alloc['id'], alloc_data)
-        for alloc in inactive_allocations:
-            self.db.network_allocation_delete(context, alloc['id'])
-        # Update segmentation id of the share network subnet after cutting over
-        subnet_data = {'segmentation_id': vlan_to_activate}
-        sns_id = src_share_server['share_network_subnet']['id']
-        self.db.share_network_subnet_update(context, sns_id, subnet_data)
+        dest_host = self.config.neutron_host_id
+        ports = self.db.network_allocations_get_for_share_server(
+            context, src_share_server['id'], label='user')
+        for port in ports:
+            self.neutron_api.activate_port_binding(port['id'], dest_host)
+            self.neutron_api.delete_port_binding(port['id'], src_host)
+        return ports
 
 
 class NeutronBindSingleNetworkPlugin(NeutronSingleNetworkPlugin,

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5566,18 +5566,6 @@ class ShareManager(manager.SchedulerDependentManager):
                 service['availability_zone_id'], dest_host,
                 create_on_backend=create_server_on_backend)
 
-            if extended_allocs:
-                # NOTE(sapcc) The destination share server is created, so
-                # update extended network allocations with destination share
-                # server id.
-                for alloc in extended_allocs:
-                    alloc['share_server_id'] = dest_share_server['id']
-                    self.db.network_allocation_update(context, alloc['id'],
-                                                      alloc)
-                source_share_server['network_allocations'] = (
-                    self.db.network_allocations_get_for_share_server(
-                        context, source_share_server['id']))
-
             net_changes_identified = False
             if not create_server_on_backend:
                 dest_share_server = self.db.share_server_get(
@@ -5633,6 +5621,10 @@ class ShareManager(manager.SchedulerDependentManager):
 
             backend_details = (
                 server_info.get('backend_details') if server_info else None)
+            if extended_allocs:
+                backend_details = backend_details or {}
+                backend_details['segmentation_id'] = (
+                    extended_allocs[0]['segmentation_id'])
             if backend_details:
                 self.db.share_server_backend_details_set(
                     context, dest_share_server['id'], backend_details)
@@ -5726,10 +5718,9 @@ class ShareManager(manager.SchedulerDependentManager):
         # compatibility check.
         if CONF.server_migration_extend_neutron_network:
             try:
-                new_allocations = (
-                    self.driver.network_api.extend_network_allocations(
-                        context, share_server))
-                share_server['network_allocations'] = new_allocations
+                allocs = self.driver.network_api.extend_network_allocations(
+                    context, share_server)
+                share_server['network_allocations'] = allocs
             except Exception:
                 LOG.warning(
                     'Failed to extend network allocations for '
@@ -5766,8 +5757,9 @@ class ShareManager(manager.SchedulerDependentManager):
         # NOTE(sapcc): Delete port bindings on destination host after
         # compatibility check
         if CONF.server_migration_extend_neutron_network:
-            self.driver.network_api.delete_extended_allocations(context,
-                                                                share_server)
+            self.driver.network_api.delete_extended_allocations(
+                context, share_server)
+
         result.update(driver_result)
 
         return result
@@ -6010,20 +6002,27 @@ class ShareManager(manager.SchedulerDependentManager):
         dest_sn = self.db.share_network_get(context, dest_sn_id)
         dest_sns = self.db.share_network_subnet_get(context, dest_sns_id)
 
+        migration_extended_network_allocations = (
+            CONF.server_migration_extend_neutron_network)
+
         # NOTE(sapcc): Network allocations are extended to the destination host
         # on previous (migration_start) step, i.e. port bindings are created on
         # destination host with existing ports. The network allocations will be
         # cut over on this (migration_complete) step, i.e. port bindings on
         # destination host will be activated and bindings on source host will
-        # be deleted. Since manager takes care of the cutover of network
-        # allocations, driver should not touch them. Therefore the cached
-        # source_share_server and dest_share_server are not updated with the
-        # new network allocations after the cutover_network_allocations call.
-        # Only dest_sns is updated to have the correct segmentation id.
-        if CONF.server_migration_extend_neutron_network:
-            self.driver.network_api.cutover_network_allocations(
-                context, source_share_server, dest_share_server)
-            dest_sns = self.db.share_network_subnet_get(context, dest_sns_id)
+        # be deleted.
+        if migration_extended_network_allocations:
+            allocs = self.driver.network_api.cutover_network_allocations(
+                context, source_share_server)
+            segmentation_id = self.db.share_server_backend_details_get(
+                context, dest_share_server['id'], 'segmentation_id')
+            alloc_update = {
+                'segmentation_id': segmentation_id,
+                'share_server_id': dest_share_server['id']
+            }
+            subnet_update = {
+                'segmentation_id': segmentation_id,
+            }
 
         migration_reused_network_allocations = (len(
             self.db.network_allocations_get_for_share_server(
@@ -6041,7 +6040,13 @@ class ShareManager(manager.SchedulerDependentManager):
             context, source_share_server, dest_share_server, share_instances,
             snapshot_instances, new_network_allocations)
 
-        if not migration_reused_network_allocations:
+        if migration_extended_network_allocations:
+            for alloc in allocs:
+                self.db.network_allocation_update(context, alloc['id'],
+                                                  alloc_update)
+            self.db.share_network_subnet_update(context, dest_sns_id,
+                                                subnet_update)
+        elif not migration_reused_network_allocations:
             all_allocations = [
                 new_network_allocations['network_allocations'],
                 new_network_allocations['admin_network_allocations']
@@ -6185,7 +6190,7 @@ class ShareManager(manager.SchedulerDependentManager):
 
         if CONF.server_migration_extend_neutron_network:
             self.driver.network_api.delete_extended_allocations(
-                context, share_server, dest_share_server)
+                context, share_server)
 
         # NOTE(dviroel): After cancelling the migration we should set the new
         # share server to INVALID since it may contain an invalid configuration


### PR DESCRIPTION
This work follows up PR #60, #146 and #152. In previous PR's, we used a trick to save new segment id associated with target host in the network_allocations table.  Since we only extend network allocations during server migration, there is actually no new network allocations created. Therefore it's complicated to implement and difficult to read the code. More importantly, it introduces non-trivial side effect. In cutover stage, the driver tries to delete the ports and create them again. Only part of them are re-created when migrating a 4-lif share server, leading to losts of network interface. In this PR, we save the segment id in the backend details of the destination share server instead. The port-lost problem is avoided without the need of modifying driver.

Change-Id: Ifb492e3f832ac2598078082ad53150050a4f7616