### PR TITLE
ccloud: prevent new vserver created in cluster ipspaces

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -265,7 +265,9 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         port = self._get_node_data_port(node_name)
         vlan = network_info['segmentation_id']
         ipspace_name = self._client.get_ipspace_name_for_vlan_port(
-            node_name, port, vlan) or self._create_ipspace(network_info)
+            node_name, port, vlan)
+        if ipspace_name is None or ipspace_name in CLUSTER_IPSPACES:
+            ipspace_name = self._create_ipspace(network_info)
 
         aggregate_names = self._find_matching_aggregates()
         if is_dp_destination:


### PR DESCRIPTION
Orphan vlans are moved to DEFAULT ipspace when their originally associated ipspaces are deleted. As a result, new vserver will be put in the DEFAULT ipspace if it is on an orphan vlan. This PR will ensure a private ipspace is created and used for vserver. The vlans are then moved to the correct ipspace in the following steps.

Change-Id: I285a0e39603b6c144b3b8c8bafe61a48c420899d