### PR TITLE
(ccloud) fix exports for share with MULTI protocol

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -1861,7 +1861,7 @@ class NetAppCmodeFileStorageLibrary(object):
                 is_flexgroup=self._is_flexgroup_pool(pool))
 
             # Generate export locations using addresses, metadata and callback
-            export_locations = [
+            export_locations.extend([
                 {
                     'path': callback(export_address),
                     'is_admin_only': metadata.pop('is_admin_only', False),
@@ -1869,7 +1869,7 @@ class NetAppCmodeFileStorageLibrary(object):
                 }
                 for export_address, metadata
                 in copy.deepcopy(export_addresses).items()
-            ]
+            ])
 
         # Sort the export locations to report preferred paths first
         export_locations = self._sort_export_locations_by_preferred_paths(


### PR DESCRIPTION
Only CIFS export locations are generated. This fix adds NFS exports in addition.

Change-Id: Iea1b5d760702a691436a5e56faaea87a91c9294f