### PR TITLE
cifs: enable SMB signing

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1985,6 +1985,12 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 LOG.debug(f"Attempt ({attempt}): Trying to setup CIFS server "
                           f"with args: {api_args}")
                 self.send_request('cifs-server-create', api_args)
+                try:
+                    self.wait_for_cifs_server(vserver_name)
+                    self.configure_cifs_signing()
+                except exception.NetAppException as e:
+                    LOG.error(f"Gave up waiting and proceed for cifs server on"
+                              f" vserver {vserver_name}. {e.message}")
                 return
             except netapp_api.NaApiError as e:
                 LOG.debug("Failed to create CIFS server entry. %s", e.message)
@@ -2382,6 +2388,49 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         except netapp_api.NaApiError as e:
             msg = _("Failed to set aes encryption. %s")
             raise exception.NetAppException(msg % e.message)
+
+    @na_utils.trace
+    def cifs_server_exists(self, vserver_name):
+        """Checks if cifs server exists on vserver."""
+        cifs_server = self._get_cifs_server_name(vserver_name)
+        LOG.debug('Checking if cifs server %s exists', cifs_server)
+
+        api_args = {
+            'query': {
+                'cifs-server-config': {
+                    'cifs-server': cifs_server,
+                },
+            },
+            'desired-attributes': {
+                'cifs-server-config': {
+                    'cifs-server': None,
+                },
+            },
+        }
+
+        result = self.send_iter_request('cifs-server-get-iter', api_args)
+        return self._has_records(result)
+
+    @na_utils.trace
+    def configure_cifs_signing(self):
+        api_args = {
+            'is-signing-required': 'true',
+        }
+
+        try:
+            self.send_request('cifs-security-modify', api_args)
+        except netapp_api.NaApiError as e:
+            msg = _("Failed to enable SMB signing. %s")
+            raise exception.NetAppException(msg % e.message)
+
+    @manila_utils.retry(retry_param=exception.NetAppException,
+                        interval=5,
+                        retries=60,
+                        backoff_rate=1)
+    def wait_for_cifs_server(self, vserver_name):
+        if not self.cifs_server_exists(vserver_name):
+            msg = f"Cifs server on vserver {vserver_name} not found."
+            raise exception.NetAppException(msg)
 
     @na_utils.trace
     def configure_cifs_options(self, security_service={}):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -541,6 +541,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 if security_service['type'].lower() == 'active_directory':
                     try:
                         vserver_client.configure_certificates()
+                        vserver_client.configure_cifs_signing()
                         # vserver_client.configure_cifs_encryption()
                         # vserver_client.configure_cifs_options(security_service) # noqa: E501
                     except exception.NetAppException as e:


### PR DESCRIPTION
by default it would be disabled.
It can only be enabled after cifs server has been created.
Therefore this can not be coupled with the other cifs security settings
that are handled in configure_cifs_encryption() before cifs server
creation.

equivalent to ontap client
'vserver cifs security modify -is-signing-required true [...]'

Change-Id: I3f1bbf009f47ebcb00c4c19206e08f11a87da9f3
