### PR TITLE
NetApp: remove duplicated debug log

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/api.py
+++ b/manila/share/drivers/netapp/dataontap/client/api.py
@@ -601,8 +601,6 @@ class NaServer(object):
         )
         self._host = host
 
-        LOG.debug('Using NetApp controller: %s', self._host)
-
     def get_transport_type(self, use_zapi_client=True):
         """Get the transport type protocol."""
         return self.get_client(use_zapi=use_zapi_client).get_transport_type()


### PR DESCRIPTION
The same is already logged in the init of BaseClient, the parent of
ZapiClient, which gets initialized a few lines above.

Change-Id: I6cd6aa261d3fd29a162c1f7d51d7374894b5565f
