### PR TITLE
NetApp: take care to remove parent snapshot in child share

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -1755,6 +1755,10 @@ class NetAppCmodeFileStorageLibrary(object):
 
         # split at the end: not be blocked by a busy volume
         if split:
+            # can only delete the additional snap in child, if we plan to split
+            vserver_client.soft_delete_snapshot(share_name,
+                                                parent_snapshot_name,
+                                                soft_only=True)
             vserver_client.volume_clone_split_start(share_name)
 
     @na_utils.trace


### PR DESCRIPTION
When creating a share from snapshot (NetApp volume clone),
the parent snapshot is being copied into the child volume.
This is not expected/not being tracked by manila. So we handle the
soft deletion of that snapshot. It cannot be deleted immediately,
because the clone split needs to finish first.

Change-Id: I2556efe187d259f6624573f6690e89d05d554089
