### PR TITLE
modify lazy loading for ShareInstance model

### DIFF
--- a/manila/db/sqlalchemy/models.py
+++ b/manila/db/sqlalchemy/models.py
@@ -322,7 +322,7 @@ class Share(BASE, ManilaBase):
     task_state = Column(String(255))
     instances = orm.relationship(
         "ShareInstance",
-        lazy='subquery',
+        lazy='selectin',
         primaryjoin=(
             'and_('
             'Share.id == ShareInstance.share_id, '
@@ -404,7 +404,7 @@ class ShareInstance(BASE, ManilaBase):
                                   nullable=True)
     _availability_zone = orm.relationship(
         "AvailabilityZone",
-        lazy='subquery',
+        lazy='selectin',
         foreign_keys=availability_zone_id,
         primaryjoin=(
             'and_('
@@ -431,7 +431,7 @@ class ShareInstance(BASE, ManilaBase):
                              nullable=True)
     share_type = orm.relationship(
         "ShareTypes",
-        lazy='subquery',
+        lazy='selectin',
         foreign_keys=share_type_id,
         primaryjoin='and_('
                     'ShareInstance.share_type_id == ShareTypes.id, '


### PR DESCRIPTION
The ShareInstance model has relationships with AvailabilityZone and
ShareType models. These relationships are loaded lazily by subquery.
This emits sql queries for availability zone and share type with
subquery for all share instances, which is not efficient as the share
instance table grows. This change modifies the relationships to load the
availability zone and share type with selectin load, which will load all
items from the availability zone and share type tables in a single
query. It's acceptable because they are pretty small tables.

Reference for selectin loading: [link](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#selectin-eager-loading)

Change-Id: I0525b8cff6616e4e6f290de50dcdd50e1b7435d8
