### PR TITLE
db purge: raise on missing tables

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -5277,10 +5277,14 @@ def purge_deleted_records(context, age_in_days):
 
     metadata = MetaData()
     metadata.reflect(get_engine())
+    tables = metadata.sorted_tables
+    if not tables:
+        msg = 'No tables found, check database connection'
+        raise exception.InvalidResults(msg)
     session = get_session()
     deleted_age = timeutils.utcnow() - datetime.timedelta(days=age_in_days)
 
-    for table in reversed(metadata.sorted_tables):
+    for table in reversed(tables):
         if 'deleted' in table.columns.keys():
             session.begin()
             try:


### PR DESCRIPTION
If running with invalid db config, we get no tables and
the command silently finished. Change that and raise some
suspicion instead.

Change-Id: I8d45b4da1d586c83ab82b56af7c8770a9c4dcd1e
