### PR TITLE
cifs: don't ensure smb signing

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -541,7 +541,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 if security_service['type'].lower() == 'active_directory':
                     try:
                         vserver_client.configure_certificates()
-                        vserver_client.configure_cifs_signing()
+                        # vserver_client.configure_cifs_signing()
                         # vserver_client.configure_cifs_encryption()
                         # vserver_client.configure_cifs_options(security_service) # noqa: E501
                     except exception.NetAppException as e:


### PR DESCRIPTION
follow up to 688d856f31597ff27f678df6452e2c53aa4008eb

Now we have it enabled everywhere, we don't need to ensure this.
On demand we may even disable again(?).

If we want to enable this again, the code should be improved to
first check if it is already enabled, and send the enable call only
if necessary.

Change-Id: I40533ec3f40e53f06098260e2290247dd386878e
