### PR TITLE
Keep NetApp volume's name when managing it

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -2208,6 +2208,7 @@ def share_create(context, share_values, create_share_instance=True):
     values = ensure_model_dict_has_id(values)
     values['share_metadata'] = _metadata_refs(values.get('metadata'),
                                               models.ShareMetadata)
+
     session = get_session()
     share_ref = models.Share()
     share_instance_values, share_values = _extract_share_instance_values(
@@ -2220,6 +2221,8 @@ def share_create(context, share_values, create_share_instance=True):
         share_ref.save(session=session)
 
         if create_share_instance:
+            instance_id = values.pop('instance_id', None)
+            share_instance_values['id'] = instance_id
             _share_instance_create(context, share_ref['id'],
                                    share_instance_values, session=session)
 

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -896,6 +896,18 @@ class API(base.Base):
         share_data.update(
             self.get_share_attributes_from_share_type(share_type))
 
+        instance_id = driver_options.get('instance_id', None)
+        if instance_id:
+            if not uuidutils.is_uuid_like(instance_id):
+                msg = "Provided instance_id is not valid UUID: %s"
+                msg = msg % instance_id
+                raise exception.InvalidInput(reason=msg)
+
+            msg = "Manage share with provided instance_id %s"
+            msg = msg % instance_id
+            LOG.info(msg)
+            share_data['instance_id'] = driver_options.pop('instance_id')
+
         share = self.db.share_create(context, share_data)
 
         export_location_path = share_data.pop('export_location_path')

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -30,7 +30,6 @@ from oslo_config import cfg
 from oslo_log import log
 from oslo_service import loopingcall
 from oslo_utils import excutils
-from oslo_utils import strutils
 from oslo_utils import timeutils
 from oslo_utils import units
 from oslo_utils import uuidutils
@@ -2073,22 +2072,6 @@ class NetAppCmodeFileStorageLibrary(object):
             msg = _("Error deleting the snapshot %s: timeout waiting for "
                     "FlexGroup snapshot to not be busy.")
             raise exception.NetAppException(msg % snapshot_name)
-
-    def _get_driver_option(self, options, key, default=None, value_type=None):
-        """Get the value of the specified key from the dictionary."""
-        value = options.get(key, default) if options else default
-        try:
-            # Convert the option value to the correct type, ...
-            # but return None without converting if the value is None.
-            if value_type is int:
-                return int(value) if value else None
-            if value_type is bool:
-                return strutils.bool_from_string(value) if value else None
-        except (ValueError, TypeError):
-            msg = ("Invalid value '%(value)s' for option '%(key)s'. ")
-            msg_args = {'value': value, 'key': key}
-            raise exception.InvalidInput(reason=msg % msg_args)
-        return value
 
     @na_utils.trace
     def manage_existing(self, share, driver_options, share_server=None):


### PR DESCRIPTION
We are managing a NetApp volume, which was in Manila db, but currently not. We would like to keep the backend configurations unchanged, including volume name, junction-path, export-policy and etc. With this PR, we can achieve this by providing a driver option, i.e. "--driver-options instance_id=[uuid from volume nanme]". 

NOTE: This PR does not guarantee export policy rules are imported into manila DB. Updating share access rule may overwrite policy rules.

Change-Id: I7fa4788e6448e4f3b46258fa0da937cf2968d259
