### PR TITLE
sapcc: add netapp host in capabilities

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -182,6 +182,8 @@ class NetAppCmodeFileStorageLibrary(object):
                                self.configuration.netapp_api_trace_pattern)
         self._backend_name = self.configuration.safe_get(
             'share_backend_name') or driver_name
+        self._backend_host = self.configuration.safe_get(
+            'netapp_server_hostname') or self._backend_name
         self.message_api = message_api.API()
         self._snapmirror_schedule = self._convert_schedule_to_seconds(
             schedule=self.configuration.netapp_snapmirror_schedule)
@@ -420,6 +422,7 @@ class NetAppCmodeFileStorageLibrary(object):
 
         data = {
             'share_backend_name': self._backend_name,
+            'share_backend_host': self._backend_host,
             'driver_name': self.driver_name,
             'vendor_name': 'NetApp',
             'driver_version': self._client.get_system_version(

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -474,6 +474,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         expected = {
             'share_backend_name': fake.BACKEND_NAME,
+            'share_backend_host': fake.BACKEND_NAME,
             'driver_name': fake.DRIVER_NAME,
             'vendor_name': 'NetApp',
             'driver_version': system_version['version-tuple'],


### PR DESCRIPTION
We need the hostname to match metrics from netapp exporters.

Change-Id: Iec9c9d2a77e0054565697b14779c87c6003377ec
