### PR TITLE
db purge_deleted_records: make sure that entries are soft-deleted

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -2446,11 +2446,10 @@ def share_delete(context, share_id):
 ###################
 
 
-def _share_access_get_query(context, session, values, read_deleted='no'):
+def _share_access_get_query(context, session, values):
     """Get access record."""
     query = (model_query(
-        context, models.ShareAccessMapping, session=session,
-        read_deleted=read_deleted).options(
+        context, models.ShareAccessMapping, session=session).options(
             joinedload('share_access_rules_metadata')))
     return query.filter_by(**values)
 
@@ -5284,6 +5283,8 @@ def purge_deleted_records(context, age_in_days):
     if not tables:
         msg = 'No tables found, check database connection'
         raise exception.InvalidResults(msg)
+    tables_without_id = ['async_operation_data', 'backend_info',
+                         'drivers_private_data']
     session = get_session()
     deleted_age = timeutils.utcnow() - datetime.timedelta(days=age_in_days)
 
@@ -5298,8 +5299,18 @@ def purge_deleted_records(context, age_in_days):
                     # collect all soft-deleted records
                     with session.begin_nested():
                         model = mds[0]
-                        s_deleted_records = session.query(model).filter(
-                            model.deleted_at <= deleted_age)
+                        if str(table) in tables_without_id:
+                            s_deleted_records = session.query(model).filter(
+                                model.deleted_at <= deleted_age,
+                                model.deleted == 1)
+                        else:
+                            # NOTE: table.columns['deleted'].type.python_type
+                            # is str (default 'False') or int (default 0),
+                            # but both are set to the id on soft-delete
+                            s_deleted_records = session.query(model).filter(
+                                model.deleted_at <= deleted_age,
+                                model.deleted == model.id)
+
                     deleted_count = 0
                     # delete records one by one,
                     # skip the records which has FK constraints

--- a/manila/tests/api/v2/test_share_network_subnets.py
+++ b/manila/tests/api/v2/test_share_network_subnets.py
@@ -64,6 +64,7 @@ class ShareNetworkSubnetControllerTest(test.TestCase):
         self.share_server = db_utils.create_share_server(
             share_network_subnet_id='fake_sns_id')
         self.subnet = db_utils.create_share_network_subnet(
+            id='fake_sns_id',
             share_network_id=self.share_network['id'])
         self.share = db_utils.create_share()
 

--- a/manila/tests/db/sqlalchemy/test_api.py
+++ b/manila/tests/db/sqlalchemy/test_api.py
@@ -3712,7 +3712,9 @@ class PurgeDeletedTest(test.TestCase):
 
     def setUp(self):
         super(PurgeDeletedTest, self).setUp()
-        self.context = context.get_admin_context()
+        # FIXME: adjust to read_deleted="yes" after 2023.2 bobcat
+        # because of https://review.opendev.org/c/openstack/manila/+/879294
+        self.context = context.get_admin_context(read_deleted="only")
 
     def _days_ago(self, begin, end):
         return timeutils.utcnow() - datetime.timedelta(
@@ -3739,48 +3741,71 @@ class PurgeDeletedTest(test.TestCase):
             for start, end in ((0, 9), (10, 19)):
                 for unused in range(2):
                     # share type
-                    db_utils.create_share_type(id=uuidutils.generate_uuid(),
+                    type_id = uuidutils.generate_uuid()
+                    db_utils.create_share_type(context=self.context,
+                                               id=type_id,
+                                               deleted=type_id,
                                                deleted_at=self._days_ago(start,
                                                                          end))
                     # share
+                    share_id = uuidutils.generate_uuid()
                     share = db_utils.create_share_without_instance(
+                        context=self.context,
                         metadata={},
+                        id=share_id,
+                        deleted=share_id,
                         deleted_at=self._days_ago(start, end))
                     # create share network
+                    network_id = uuidutils.generate_uuid()
                     network = db_utils.create_share_network(
-                        id=uuidutils.generate_uuid(),
+                        context=self.context,
+                        id=network_id,
+                        deleted=network_id,
                         deleted_at=self._days_ago(start, end))
                     # create security service
+                    secserv_id = uuidutils.generate_uuid()
                     db_utils.create_security_service(
-                        id=uuidutils.generate_uuid(),
+                        context=self.context,
+                        id=secserv_id,
+                        deleted=secserv_id,
                         share_network_id=network.id,
                         deleted_at=self._days_ago(start, end))
                     # create share instance
                     s_instance = db_utils.create_share_instance(
-                        id=uuidutils.generate_uuid(),
+                        context=self.context,
                         share_network_id=network.id,
                         share_id=share.id)
                     # share access
+                    access_id = uuidutils.generate_uuid()
                     db_utils.create_share_access(
-                        id=uuidutils.generate_uuid(),
+                        context=self.context,
+                        id=access_id,
+                        deleted=access_id,
                         share_id=share['id'],
                         deleted_at=self._days_ago(start, end))
                     # create share server
+                    server_id = uuidutils.generate_uuid()
                     db_utils.create_share_server(
-                        id=uuidutils.generate_uuid(),
+                        context=self.context,
+                        id=server_id,
+                        deleted=server_id,
                         deleted_at=self._days_ago(start, end),
                         share_network_id=network.id)
                     # create snapshot
+                    snap_id = uuidutils.generate_uuid()
                     db_api.share_snapshot_create(
                         self.context, {'share_id': share['id'],
+                                       'id': snap_id,
+                                       'deleted': snap_id,
                                        'deleted_at': self._days_ago(start,
                                                                     end)},
                         create_snapshot_instance=False)
-                    # update share instance
+                    # soft-delete share instance
                     db_api.share_instance_update(
                         self.context,
                         s_instance.id,
-                        {'deleted_at': self._days_ago(start, end)})
+                        {'deleted': s_instance.id,
+                         'deleted_at': self._days_ago(start, end)})
 
             db_api.purge_deleted_records(self.context, age_in_days=del_days)
 
@@ -3802,11 +3827,14 @@ class PurgeDeletedTest(test.TestCase):
     def test_purge_records_with_constraint(self):
         self._turn_on_foreign_key()
         type_id = uuidutils.generate_uuid()
+        type_id2 = uuidutils.generate_uuid()
         # create share type1
         db_utils.create_share_type(id=type_id,
+                                   deleted=type_id,
                                    deleted_at=self._days_ago(1, 1))
         # create share type2
-        db_utils.create_share_type(id=uuidutils.generate_uuid(),
+        db_utils.create_share_type(id=type_id2,
+                                   deleted=type_id2,
                                    deleted_at=self._days_ago(1, 1))
         # create share
         share = db_utils.create_share(share_type_id=type_id)


### PR DESCRIPTION
In addition to solely relying on `deleted_at` column set, the purge
method now also checks the `deleted` column to safeguard only purging
records that really have been soft-deleted.

Outcome of an incident, where a soft-deleted record had been
restored/undeleted, but without touching the deleted_at field.
The idea was to not touch deleted_at at that time to have some history
on that previous delete. Now this history is only available for share
instances with the `terminated_at` column.

Change-Id: I23105561a2d7cc65d99da7f4d39d51886ea15a26
