### PR TITLE
allow force extend on shares in extending_error

### DIFF
--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -2366,13 +2366,18 @@ class API(base.Base):
         else:
             policy.check_policy(context, 'share', 'extend')
 
-        if share['status'] != constants.STATUS_AVAILABLE:
+        valid_statuses = [constants.STATUS_AVAILABLE]
+
+        if force:
+            valid_statuses.append(constants.STATUS_EXTENDING_ERROR)
+
+        if share['status'] not in valid_statuses:
             msg_params = {
-                'valid_status': constants.STATUS_AVAILABLE,
+                'valid_status': ", ".join(valid_statuses),
                 'share_id': share['id'],
                 'status': share['status'],
             }
-            msg = _("Share %(share_id)s status must be '%(valid_status)s' "
+            msg = _("Share %(share_id)s status must be in (%(valid_status)s) "
                     "to extend, but current status is: "
                     "%(status)s.") % msg_params
             raise exception.InvalidShare(reason=msg)
@@ -2478,6 +2483,7 @@ class API(base.Base):
 
         status = six.text_type(share['status']).lower()
         valid_statuses = (constants.STATUS_AVAILABLE,
+                          constants.STATUS_SHRINKING_ERROR,
                           constants.STATUS_SHRINKING_POSSIBLE_DATA_LOSS_ERROR)
 
         if status not in valid_statuses:
@@ -2486,7 +2492,7 @@ class API(base.Base):
                 'share_id': share['id'],
                 'status': status,
             }
-            msg = _("Share %(share_id)s status must in (%(valid_status)s) "
+            msg = _("Share %(share_id)s status must be in (%(valid_status)s) "
                     "to shrink, but current status is: "
                     "%(status)s.") % msg_params
             raise exception.InvalidShare(reason=msg)


### PR DESCRIPTION
removes the need to do extra API calls to check and reset the status.

Allow to to force extend on extending_error.
Allow to shrink on shrinking_error.

Change-Id: Ic6939e00960e9edae651036848436476b8610b8e

bonus for sapcc: autoscaling is using force and will be able to retry without additional action needed
(I think this is better than always magically resetting the state internally or via nanny)