### PR TITLE
CIFS: fix advertised encryption types

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2374,10 +2374,12 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     @na_utils.trace
     def configure_cifs_encryption(self, secure=True):
         api_args = {
-            'is-aes-encryption-enabled': 'true',
             'use-ldaps-for-ad-ldap': 'true',
             'session-security-for-ad-ldap': 'sign',
-            'advertised-enc-types': 'aes-256,aes-128',
+            'advertised-enc-types': [
+                {'cifskrbenctypes': 'aes_256'},
+                {'cifskrbenctypes': 'aes_128'}
+            ]
         }
 
         if not secure:


### PR DESCRIPTION
followup to 2caafda

advertised-enc-types is an array of cifskrbenctypes 🙄 
It is the replacement of pre ONTAP 9.12 `is-aes-encryption-enabled`
option - both cannot be configured.

Change-Id: I031800ed6309c66473032fd2fba4188e9ff091f9

- [x] tested in qa
