### PR TITLE
Move prune deletion tasks to ensure_shares.

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -4220,6 +4220,14 @@ class NetAppCmodeFileStorageLibrary(object):
                 else:
                     LOG.warning(msg)
 
+        try:
+            self._client.prune_deleted_nfs_export_policies()
+            self._client.prune_deleted_snapshots()
+            self._client.prune_deleted_volumes()
+        except Exception as e:
+            LOG.warning("Failed to cleanup resources in ensure share: "
+                        "Error - %s", e.message)
+
         return updates
 
     def ensure_share_server(self, context, share_server, network_info):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -134,9 +134,6 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
     @na_utils.trace
     def _handle_housekeeping_tasks(self):
         """Handle various cleanup activities."""
-        self._client.prune_deleted_nfs_export_policies()
-        self._client.prune_deleted_snapshots()
-        self._client.prune_deleted_volumes()
         self._client.remove_unused_qos_policy_groups()
 
         (super(NetAppCmodeMultiSVMFileStorageLibrary, self).

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_single_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_single_svm.py
@@ -118,12 +118,9 @@ class NetAppCmodeSingleSVMFileStorageLibrary(
     @na_utils.trace
     def _handle_housekeeping_tasks(self):
         """Handle various cleanup activities."""
-        vserver_client = self._get_api_client(vserver=self._vserver)
-        vserver_client.prune_deleted_nfs_export_policies()
-        vserver_client.prune_deleted_snapshots()
-        vserver_client.prune_deleted_volumes()
 
         if self._have_cluster_creds:
+            vserver_client = self._get_api_client(vserver=self._vserver)
             # Harvest soft-deleted QoS policy groups
             vserver_client.remove_unused_qos_policy_groups()
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -392,15 +392,13 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
     def test_handle_housekeeping_tasks(self):
 
-        self.mock_object(self.client, 'prune_deleted_nfs_export_policies')
-        self.mock_object(self.client, 'prune_deleted_snapshots')
+        self.mock_object(self.client, 'remove_unused_qos_policy_groups')
         mock_super = self.mock_object(lib_base.NetAppCmodeFileStorageLibrary,
                                       '_handle_housekeeping_tasks')
 
         self.library._handle_housekeeping_tasks()
 
-        self.assertTrue(self.client.prune_deleted_nfs_export_policies.called)
-        self.assertTrue(self.client.prune_deleted_snapshots.called)
+        self.assertTrue(self.client.remove_unused_qos_policy_groups.called)
         self.assertTrue(mock_super.called)
 
     def test_find_matching_aggregates(self):

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_single_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_single_svm.py
@@ -239,9 +239,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         self.library._handle_housekeeping_tasks()
 
-        self.assertTrue(
-            mock_vserver_client.prune_deleted_nfs_export_policies.called)
-        self.assertTrue(mock_vserver_client.prune_deleted_snapshots.called)
         self.assertIs(
             have_creds,
             mock_vserver_client.remove_unused_qos_policy_groups.called)


### PR DESCRIPTION
Since ensure_share and housekeeping task both run periodically, it create race condition sometimes. Moving all prune deletion/cleanup tasks to ensure_shares to fix.

Change-Id: I59f15077dd8c5f2977e28d196e0af4cbc1c74c56