### PR TITLE
provisioning with net capacity: flexgroup size fix

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2596,7 +2596,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             size_b = size_gb * units.Gi * 100 / (100 - snapshot_reserve)
         else:
             size_b = size_gb * units.Gi
-        api_args['size'] = six.text_type(size_b)
+        api_args['size'] = int(size_b)
 
         if options.get('unix-permissions') is not None:
             # special case for multi-protocol shares:

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -3287,7 +3287,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
         volume_create_args = {
             'volume-name': fake.SHARE_NAME,
-            'size': '1073741824'
+            'size': 1073741824
         }
         if auto_provisioned:
             volume_create_args['auto-provision-as'] = 'flexgroup'


### PR DESCRIPTION
Param 'size' of 'volume-create-async' must be an integer,
but it must stay a string at 'volume-create'.

Change-Id: I3332c873a683fa9710f9b117dffe1c0d8ec2b9fb
