### PR TITLE
sapcc: improve listing share servers with search option

### DIFF
--- a/manila/api/v1/share_servers.py
+++ b/manila/api/v1/share_servers.py
@@ -47,8 +47,27 @@ class ShareServerController(wsgi.Controller):
 
         search_opts = {}
         search_opts.update(req.GET)
-        share_servers = db_api.share_server_get_all(context)
-        share_networks = db_api.share_network_get_all(context)
+
+        ss_filters = {}
+        if 'host' in search_opts:
+            ss_filters['host'] = search_opts.pop('host')
+        if 'status' in search_opts:
+            ss_filters['status'] = search_opts.pop('status')
+        if 'source_share_server_id' in search_opts:
+            ss_filters['source_share_server_id'] = search_opts.pop(
+                'source_share_server_id')
+        if 'identifier' in search_opts:
+            ss_filters['identifier'] = search_opts.pop('identifier')
+        share_servers = db_api.share_server_get_all_with_filters(
+            context, ss_filters)
+
+        if 'share_network_id' in search_opts:
+            share_networks = [
+                db_api.share_network_get(context,
+                                         search_opts['share_network_id'])
+            ]
+        else:
+            share_networks = db_api.share_network_get_all(context)
         share_network_map = {s["id"]: s for s in share_networks}
         for s in share_servers:
             s.share_network_id = s.share_network_subnet['share_network_id']

--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -4517,7 +4517,6 @@ def share_server_get_all(context):
 
 @require_context
 def share_server_get_all_with_filters(context, filters):
-
     query = _server_get_query(context)
 
     if filters.get('host'):
@@ -4527,6 +4526,8 @@ def share_server_get_all_with_filters(context, filters):
     if filters.get('source_share_server_id'):
         query = query.filter_by(
             source_share_server_id=filters.get('source_share_server_id'))
+    if filters.get('identifier'):
+        query = query.filter_by(identifier=filters.get('identifier'))
     if filters.get('share_network_id'):
         query = query.join(
             models.ShareNetworkSubnet,


### PR DESCRIPTION
Use search options in DB query to filter share servers. This should be
faster than fetching all share server entries then filtering them in
memory.

Change-Id: Ibc043d9975fe611d74d380aa9732020d5cc7759b
