### PR TITLE
sapcc: improve error handling on prune deleted volumes

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -4202,7 +4202,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                                     client.volume_clone_split_start(
                                         volume_name)
                                     LOG.debug('Starting clone split for '
-                                            'volume %s ', volume_name)
+                                              'volume %s ', volume_name)
                             except Exception:
                                 LOG.error("Volume clone split failed for "
                                           "volume %s", volume_name)
@@ -4223,14 +4223,15 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 else:
                     for clone in clones:
                         try:
-                            clone_status = client.volume_clone_split_status(clone)
+                            clone_status = client.volume_clone_split_status(
+                                clone)
                             if clone_status == 'unknown':
                                 client.volume_clone_split_start(clone)
                                 LOG.debug('Starting clone split for '
-                                        'volume %s ', clone)
+                                          'volume %s ', clone)
                         except Exception:
                             LOG.error("Volume clone split failed for "
-                                    "volume %s", clone)
+                                      "volume %s", clone)
 
     @na_utils.trace
     def create_snapshot(self, volume_name, snapshot_name):

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -4124,6 +4124,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 'volume-attributes': {
                     'volume-id-attributes': {
                         'name': DELETED_PREFIX + '*',
+                        'type': 'rw',
                     },
                 },
             },
@@ -4195,11 +4196,17 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                         LOG.error('Pruning soft-deleted '
                                   'volume %s failed', volume_name)
                         if e.code == netapp_api.EVOLDEL_NOT_ALLOW_BY_CLONE:
-                            if client.volume_clone_split_status(
-                                    volume_name) == 'unknown':
-                                client.volume_clone_split_start(volume_name)
-                                LOG.debug('Starting clone split for '
-                                          'volume %s ', volume_name)
+                            try:
+                                if client.volume_clone_split_status(
+                                        volume_name) == 'unknown':
+                                    client.volume_clone_split_start(
+                                        volume_name)
+                                    LOG.debug('Starting clone split for '
+                                            'volume %s ', volume_name)
+                            except Exception:
+                                LOG.error("Volume clone split failed for "
+                                          "volume %s", volume_name)
+
             elif volume_state == 'online':
                 # These must be parent volume which was brought online in
                 # previous callback. If no clones found means all splits are
@@ -4215,11 +4222,15 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                                   "volume %s", volume_name)
                 else:
                     for clone in clones:
-                        clone_status = client.volume_clone_split_status(clone)
-                        if clone_status == 'unknown':
-                            client.volume_clone_split_start(clone)
-                            LOG.debug('Starting clone split for '
-                                      'volume %s ', volume_name)
+                        try:
+                            clone_status = client.volume_clone_split_status(clone)
+                            if clone_status == 'unknown':
+                                client.volume_clone_split_start(clone)
+                                LOG.debug('Starting clone split for '
+                                        'volume %s ', clone)
+                        except Exception:
+                            LOG.error("Volume clone split failed for "
+                                    "volume %s", clone)
 
     @na_utils.trace
     def create_snapshot(self, volume_name, snapshot_name):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -301,7 +301,9 @@ class NetAppCmodeFileStorageLibrary(object):
             housekeeping_periodic_task = loopingcall.FixedIntervalLoopingCall(
                 self._handle_housekeeping_tasks)
             housekeeping_periodic_task.start(
-                interval=self.HOUSEKEEPING_INTERVAL_SECONDS, initial_delay=0)
+                interval=self.HOUSEKEEPING_INTERVAL_SECONDS,
+                initial_delay=0,
+                stop_on_exception=False)
 
     def _get_backend_share_name(self, share_id):
         """Get share name according to share name template."""


### PR DESCRIPTION
don't make the loop stop on error, we want to try pruning again in the
next run.

The prune deleted volumes was operating on deleted volumes (type DEL)
that were already in the recovery queue. Those should not be touched,
they don't need to be brought back online to solve clone split
situations. We are only interested in type RW. So we also don't do
housekeeping on e.g. DP volumes.

Anyway we also catch errors on split start now for a smoother
continuation of the loop.

Change-Id: I7a3c83423d731c4922c8f0f570fa9309fc70db46
