### PR TITLE
purge deleted clone

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -4222,6 +4222,21 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                                   "volume %s", volume_name)
                 else:
                     for clone in clones:
+                        """TODO:
+                            if clone.type == DEL:
+                                recovery_queue.purge(clone)
+
+                            reasoning: we have a soft deleted volume that
+                            is going to be deleted, but it can't because it
+                            non-split child is still in the recovery queue.
+                            Let's remove the child for good (alternative would
+                            be to recover, split, delete the child again)
+                            We don't promise restore for complex parent-child
+                            relationships. And anyhow this is only a problem
+                            if clone split was not fast enough, which means
+                            the volume is short-lived
+                            (aka qualifies for force delete).
+                        """
                         try:
                             clone_status = client.volume_clone_split_status(
                                 clone)


### PR DESCRIPTION
[sapcc: purge clones from recovery queue](https://github.com/sapcc/manila/pull/229/commits/870ec4bb11f6b2c6d561011c47e3950ea31d1f19)
if those are blocking other deletions they have no right to be kept.

This is per se only a problem
if clone split was not fast enough, which means
the volume is short-lived
(aka qualifies for force delete)
