### PR TITLE
sapcc: no flexgroup encryption settings default

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2568,7 +2568,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                             thin_provisioned=False, snapshot_policy=None,
                             language=None, snapshot_reserve=None,
                             volume_type='rw', comment=None,
-                            qos_policy_group=None, encrypt=False,
+                            qos_policy_group=None, encrypt=None,
                             adaptive_qos_policy_group=None,
                             auto_provisioned=False,
                             logical_space_reporting=None, **options):

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -3304,7 +3304,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
         self.client._get_create_volume_api_args.assert_called_once_with(
             fake.SHARE_NAME, False, None, None, None, 'rw', None, None,
-            False, None, None)
+            None, None, None)
         self.client.send_request.assert_called_with('volume-create-async',
                                                     volume_create_args)
         self.assertEqual(expected_result, result)


### PR DESCRIPTION
if share type is not specifying if encryption should be set or not,
we no longer default to `False` but instead just don't touch the
encryption flag and keep whatever is the default on the backend

Fixes
"Unencrypted volumes are not supported in
NAE (NetApp Aggregate Encryption) aggregates" error without having
to enable encryption on all share types.

Change-Id: Iad4496c7856523820a1040248cd7d1317399f8db
