### PR TITLE
add x-openstack-request-id header

### DIFF
--- a/manila/api/openstack/wsgi.py
+++ b/manila/api/openstack/wsgi.py
@@ -1332,6 +1332,7 @@ def _set_request_id_header(req, headers):
     context = req.environ.get('manila.context')
     if context:
         headers['x-compute-request-id'] = context.request_id
+        headers['x-openstack-request-id'] = context.request_id
 
 
 class OverLimitFault(webob.exc.HTTPException):


### PR DESCRIPTION
in addition to x-compute-request-id to be conform with other
services.

This allows for maintaining less special cases e.g. in auditing and
logging.

Change-Id: I59d4bd74db603dd58ba71b7eaeb2f4417895a337
