### PR TITLE
NetApp: delete vlan even if ipspace is reused

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -40,6 +40,10 @@ CONF = cfg.CONF
 LOG = log.getLogger(__name__)
 DELETED_PREFIX = 'deleted_manila_'
 DEFAULT_IPSPACE = 'Default'
+IPSPACE_PREFIX = 'ipspace_'
+CLUSTER_IPSPACES = ('Cluster', DEFAULT_IPSPACE)
+DEFAULT_BROADCAST_DOMAIN = 'Default'
+BROADCAST_DOMAIN_PREFIX = 'domain_'
 DEFAULT_MAX_PAGE_LENGTH = 50
 CUTOVER_ACTION_MAP = {
     'defer': 'defer_on_failure',
@@ -976,6 +980,57 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 raise exception.NetAppException(msg % msg_args)
 
     @na_utils.trace
+    def get_degraded_ports(self, broadcast_domains, ipspace):
+        """Get degraded ports for broadcast domains and an ipspace."""
+
+        valid_domains = self._get_valid_broadcast_domains(broadcast_domains)
+
+        api_args = {
+            'query': {
+                'net-port-info': {
+                    'broadcast-domain': '|'.join(valid_domains),
+                    'health-degraded-reasons': {
+                        'netport-degraded-reason': 'l2_reachability'
+                    },
+                    'health-status': 'degraded',
+                    'ipspace': ipspace,
+                    'port-type': 'vlan',
+                },
+            },
+            'desired-attributes': {
+                'net-port-info': {
+                    'port': None,
+                    'node': None,
+                },
+            },
+        }
+
+        result = self.send_iter_request('net-port-get-iter', api_args)
+        net_port_info_list = result.get_child_by_name(
+            'attributes-list') or netapp_api.NaElement('none')
+
+        ports = []
+        for port_info in net_port_info_list.get_children():
+            # making it a net-qualified-port-name
+            # compatible with ports result from net-ipspaces-get-iter
+            ports.append(f"{port_info.get_child_content('node')}:"
+                         f"{port_info.get_child_content('port')}")
+
+        return ports
+
+    @na_utils.trace
+    def _get_valid_broadcast_domains(_self, broadcast_domains):
+        valid_domains = []
+        for broadcast_domain in broadcast_domains:
+            if (
+                broadcast_domain == 'OpenStack'
+                or broadcast_domain == DEFAULT_BROADCAST_DOMAIN
+                or broadcast_domain.startswith(BROADCAST_DOMAIN_PREFIX)
+            ):
+                valid_domains.append(broadcast_domain)
+        return valid_domains
+
+    @na_utils.trace
     def create_route(self, gateway, destination=None):
         if not gateway:
             return
@@ -1022,7 +1077,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
         # Derive the broadcast domain name from the IPspace name since they
         # need to be 1-1 and the default for both is the same name, 'Default'.
-        domain = re.sub(r'ipspace', 'domain', ipspace)
+        domain = re.sub(IPSPACE_PREFIX, BROADCAST_DOMAIN_PREFIX, ipspace)
 
         port_info = self._get_broadcast_domain_for_port(node, port)
 
@@ -1312,8 +1367,15 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         return ipspace_name
 
     @na_utils.trace
-    def get_ipspaces(self, ipspace_name=None):
-        """Gets one or more IPSpaces."""
+    def get_ipspaces(self, ipspace_name=None, vserver_name=None):
+        """Gets one or more IPSpaces.
+
+        parameters ipspace_name and vserver_name are mutually exclusive
+        """
+        if ipspace_name and vserver_name:
+            msg = ('The parameters "ipspace_name" and "vserver_name" cannot '
+                   'both be used at the same time.')
+            raise exception.InvalidInput(reason=msg)
 
         if not self.features.IPSPACES:
             return []
@@ -1323,6 +1385,14 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             api_args['query'] = {
                 'net-ipspaces-info': {
                     'ipspace': ipspace_name,
+                }
+            }
+        elif vserver_name:
+            api_args['query'] = {
+                'net-ipspaces-info': {
+                    'vservers': {
+                        'vserver_name': vserver_name,
+                    }
                 }
             }
 
@@ -1408,12 +1478,44 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
     @na_utils.trace
     def delete_ipspace(self, ipspace_name):
-        """Deletes an IPspace."""
+        """Deletes an IPspace.
 
-        self._delete_broadcast_domains_for_ipspace(ipspace_name)
+        Returns:
+            True if ipspace was deleted,
+            False if validation or error prevented deletion
+        """
+        if not self.features.IPSPACES:
+            return False
+
+        if not ipspace_name:
+            return False
+
+        if (
+            ipspace_name in CLUSTER_IPSPACES
+            or self.ipspace_has_data_vservers(ipspace_name)
+        ):
+            LOG.debug('IPspace %(ipspace)s not deleted: still in use.',
+                      {'ipspace': ipspace_name})
+            return False
+
+        try:
+            self._delete_broadcast_domains_for_ipspace(ipspace_name)
+        except netapp_api.NaApiError as e:
+            msg = _('Broadcast Domains of IPspace %s not deleted. '
+                    'Reason: %s') % (ipspace_name, e)
+            LOG.warning(msg)
+            return False
 
         api_args = {'ipspace': ipspace_name}
-        self.send_request('net-ipspaces-destroy', api_args)
+        try:
+            self.send_request('net-ipspaces-destroy', api_args)
+        except netapp_api.NaApiError as e:
+            msg = _('IPspace %s not deleted. '
+                    'Reason: %s') % (ipspace_name, e)
+            LOG.warning(msg)
+            return False
+
+        return True
 
     @na_utils.trace
     def add_vserver_to_ipspace(self, ipspace_name, vserver_name):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -53,7 +53,6 @@ LOG = log.getLogger(__name__)
 SUPPORTED_NETWORK_TYPES = (None, 'flat', 'vlan')
 SEGMENTED_NETWORK_TYPES = ('vlan',)
 DEFAULT_MTU = 1500
-CLUSTER_IPSPACES = ('Cluster', 'Default')
 SERVER_MIGRATE_SVM_DR = 'svm_dr'
 SERVER_MIGRATE_SVM_MIGRATE = 'svm_migrate'
 
@@ -266,7 +265,10 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         vlan = network_info['segmentation_id']
         ipspace_name = self._client.get_ipspace_name_for_vlan_port(
             node_name, port, vlan)
-        if ipspace_name is None or ipspace_name in CLUSTER_IPSPACES:
+        if (
+            ipspace_name is None
+            or ipspace_name in client_cmode.CLUSTER_IPSPACES
+        ):
             ipspace_name = self._create_ipspace(network_info)
 
         aggregate_names = self._find_matching_aggregates()
@@ -349,7 +351,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
 
     def _get_valid_ipspace_name(self, network_id):
         """Get IPspace name according to network id."""
-        return 'ipspace_' + network_id.replace('-', '_')
+        return client_cmode.IPSPACE_PREFIX + network_id.replace('-', '_')
 
     @na_utils.trace
     def _create_ipspace(self, network_info, client=None):
@@ -572,7 +574,12 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                         needs_lock=True):
         """Delete a Vserver plus IPspace and security services as needed."""
 
-        ipspace_name = self._client.get_vserver_ipspace(vserver)
+        ipspace_name = None
+
+        ipspaces = self._client.get_ipspaces(vserver_name=vserver)
+        if ipspaces:
+            ipspace = ipspaces[0]
+            ipspace_name = ipspace['ipspace']
 
         vserver_client = self._get_api_client(vserver=vserver)
         network_interfaces = vserver_client.get_network_interfaces()
@@ -611,17 +618,31 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             self._client.delete_vserver(vserver,
                                         vserver_client,
                                         security_services=security_services)
-            ipspace_deleted = False
-            if (ipspace_name and ipspace_name not in CLUSTER_IPSPACES
-                    and not self._client.ipspace_has_data_vservers(
-                        ipspace_name)):
-                self._client.delete_ipspace(ipspace_name)
-                ipspace_deleted = True
 
-            if not ipspace_name or ipspace_deleted:
-                # NOTE(dviroel): only delete vlans if they are not being used
-                # by any ipspaces and data vservers.
-                self._delete_vserver_vlans(interfaces_on_vlans)
+            if ipspace_name is None:
+                return
+
+            ipspace_deleted = self._client.delete_ipspace(ipspace_name)
+
+            ports = set()
+            if ipspace_deleted:
+                # we don't want to leave any ports behind, clean them all up
+                ports.update(ipspace['ports'])
+            # NOTE(dviroel): only delete vlans if they are not being used
+            # by any ipspaces and data vservers.
+            else:
+                broadcast_domains = ipspace['broadcast-domains']
+                # NOTE(carthaca): filter for degraded ports, those where
+                # reachability is down (e.g. because neutron port is gone)
+                ports.update(self._client.get_degraded_ports(broadcast_domains,
+                                                             ipspace_name))
+                # make sure to delete ports of the vserver we are currently
+                # deleting (may not be marked degraded, yet)
+                for interface in interfaces_on_vlans:
+                    port = f"{interface['home-node']}:{interface['home-port']}"
+                    ports.add(port)
+
+            self._delete_port_vlans(self._client, ports)
 
         @utils.synchronized('netapp-VLAN-%s' % vlan_id, external=True)
         def _delete_vserver_with_lock():
@@ -633,14 +654,16 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             return _delete_vserver_without_lock()
 
     @na_utils.trace
-    def _delete_vserver_vlans(self, network_interfaces_on_vlans):
-        """Delete Vserver's VLAN configuration from ports"""
-        for interface in network_interfaces_on_vlans:
+    def _delete_port_vlans(_self, client, ports):
+        """Delete Port's VLAN configuration
+
+        must be called with a cluster client
+        """
+        for port_name in ports:
             try:
-                home_port = interface['home-port']
-                port, vlan = home_port.split('-')
-                node = interface['home-node']
-                self._client.delete_vlan(node, port, vlan)
+                node, port = port_name.split(':')
+                port, vlan = port.split('-')
+                client.delete_vlan(node, port, vlan)
             except exception.NetAppException:
                 LOG.exception("Deleting Vserver VLAN failed.")
 
@@ -1179,19 +1202,16 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                                                network_info)
 
         def _cleanup_ipspace(ipspace):
-            try:
-                dest_client.delete_ipspace(ipspace)
-            except Exception:
+            if not dest_client.delete_ipspace(ipspace):
                 LOG.info(
                     'Did not delete ipspace used to check the compatibility '
                     'for SVM Migrate. It is possible that it was reused and '
                     'there are other entities consuming it.')
-            else:
-                if vlan:
-                    port = None
-                    for node in dest_client.list_cluster_nodes():
-                        port = port or self._get_node_data_port(node)
-                        dest_client.delete_vlan(node, port, vlan)
+            if vlan:
+                port = None
+                for node in dest_client.list_cluster_nodes():
+                    port = port or self._get_node_data_port(node)
+                    dest_client.delete_vlan(node, port, vlan)
 
         # 1. Sends the request to the backend.
         try:
@@ -1826,22 +1846,21 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 src_ipspace = src_cluster_client.get_ipspaces(
                     src_ipspace_name)[0]
                 ports = src_ipspace['ports']
+                broadcast_domains = src_ipspace['broadcast-domains']
 
-                src_cluster_client.delete_ipspace(src_ipspace_name)
-                for port_name in ports:
-                    node, port = port_name.split(':')
-                    port, vlan = port.split('-')
-                    src_cluster_client.delete_vlan(node, port, vlan)
+                ipspace_deleted = src_cluster_client.delete_ipspace(
+                    src_ipspace_name)
+                if not ipspace_deleted:
+                    ports = src_cluster_client.get_degraded_ports(
+                        broadcast_domains, src_ipspace_name)
+                self._delete_port_vlans(src_cluster_client, ports)
 
-            if (src_ipspace_name not in CLUSTER_IPSPACES
-                    and not src_cluster_client.ipspace_has_data_vservers(
-                        src_ipspace_name)):
-                try:
-                    _delete_ipspace_and_vlan()
-                except Exception as e:
-                    msg = _('Could not delete ipspace %s on SVM migration '
-                            'source. Reason: %s') % (src_ipspace_name, e)
-                    LOG.warning(msg)
+            try:
+                _delete_ipspace_and_vlan()
+            except Exception as e:
+                msg = _('Could not delete ipspace %s on SVM migration '
+                        'source. Reason: %s') % (src_ipspace_name, e)
+                LOG.warning(msg)
         else:
             self._share_server_migration_complete_svm_dr(
                 source_share_server, dest_share_server, src_vserver,
@@ -2003,21 +2022,17 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             msg = _("Failed to cancel the share server migration.")
             raise exception.NetAppException(message=msg)
 
-        # If there is need to, remove the ipspace.
-        if (dest_ipspace_name and dest_ipspace_name not in CLUSTER_IPSPACES
-                and not dest_client.ipspace_has_data_vservers(
-                    dest_ipspace_name)):
-            # TODO(chuan) Wait until the ipspace is not being used by vserver
-            # anymore, which is not deleted immediately after migration
-            # cancelled.
-            dest_client.delete_ipspace(dest_ipspace_name)
-            network_info = dest_share_server.get('network_allocations')
-            vlan = network_info[0]['segmentation_id'] if network_info else None
-            if vlan:
-                port = None
-                for node in dest_client.list_cluster_nodes():
-                    port = port or self._get_node_data_port(node)
-                    dest_client.delete_vlan(node, port, vlan)
+        # TODO(chuan) Wait until the ipspace is not being used by vserver
+        # anymore, which is not deleted immediately after migration
+        # cancelled.
+        dest_client.delete_ipspace(dest_ipspace_name)
+        network_info = dest_share_server.get('network_allocations')
+        vlan = network_info[0]['segmentation_id'] if network_info else None
+        if vlan:
+            port = None
+            for node in dest_client.list_cluster_nodes():
+                port = port or self._get_node_data_port(node)
+                dest_client.delete_vlan(node, port, vlan)
         return
 
     @na_utils.trace

--- a/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
@@ -38,7 +38,8 @@ VERSION = 'NetApp Release 8.2.1 Cluster-Mode: Fri Mar 21 14:25:07 PDT 2014'
 VERSION_NO_DARE = 'NetApp Release 9.1.0: Tue May 10 19:30:23 2016 <1no-DARE>'
 VERSION_TUPLE = (8, 2, 1)
 NODE_NAME = 'fake_node1'
-NODE_NAMES = ('fake_node1', 'fake_node2')
+NODE_NAME2 = 'fake_node2'
+NODE_NAMES = (NODE_NAME, NODE_NAME2)
 VSERVER_NAME = 'fake_vserver'
 VSERVER_NAME_2 = 'fake_vserver_2'
 VSERVER_PEER_NAME = 'fake_vserver_peer'
@@ -97,7 +98,7 @@ VOLUME_COMMENT = 'fake_comment'
 
 PORT = 'e0a'
 VLAN = '1001'
-VLAN_PORT = 'e0a-1001'
+VLAN_PORT = PORT + '-' + VLAN
 IP_ADDRESS = '10.10.10.10'
 NETMASK = '255.255.255.0'
 GATEWAY = '10.10.10.1'
@@ -105,8 +106,8 @@ SUBNET = '10.10.10.0/24'
 NET_ALLOCATION_ID = 'fake_allocation_id'
 LIF_NAME_TEMPLATE = 'os_%(net_allocation_id)s'
 LIF_NAME = LIF_NAME_TEMPLATE % {'net_allocation_id': NET_ALLOCATION_ID}
-IPSPACE_NAME = 'fake_ipspace'
-BROADCAST_DOMAIN = 'fake_domain'
+IPSPACE_NAME = 'ipspace_fake'
+BROADCAST_DOMAIN = 'domain_fake'
 MTU = 9000
 SM_SOURCE_VSERVER = 'fake_source_vserver'
 SM_SOURCE_VOLUME = 'fake_source_volume'
@@ -163,17 +164,22 @@ NETWORK_INTERFACES_MULTIPLE = [
         'vserver': VSERVER_NAME,
         'netmask': NETMASK,
         'role': 'data',
-        'home-node': NODE_NAME,
-        'home-port': PORT,
+        'home-node': NODE_NAME2,
+        'home-port': VLAN_PORT,
     }
 ]
+
+NETWORK_QUALIFIED_PORTS = [NODE_NAME + ':' + VLAN_PORT]
+NETWORK_QUALIFIED_PORTS2 = [NODE_NAME2 + ':' + VLAN_PORT]
+NETWORK_QUALIFIED_PORTS_ALL = (NETWORK_QUALIFIED_PORTS
+                               + NETWORK_QUALIFIED_PORTS2)
 
 IPSPACES = [{
     'uuid': 'fake_uuid',
     'ipspace': IPSPACE_NAME,
     'id': 'fake_id',
-    'broadcast-domains': ['OpenStack'],
-    'ports': [NODE_NAME + ':' + VLAN_PORT],
+    'broadcast-domains': [BROADCAST_DOMAIN],
+    'ports': NETWORK_QUALIFIED_PORTS2,
     'vservers': [
         IPSPACE_NAME,
         VSERVER_NAME,
@@ -825,7 +831,7 @@ NET_IPSPACES_GET_ITER_RESPONSE = etree.XML("""
     <attributes-list>
       <net-ipspaces-info>
         <broadcast-domains>
-          <broadcast-domain-name>OpenStack</broadcast-domain-name>
+          <broadcast-domain-name>%(domain)s</broadcast-domain-name>
         </broadcast-domains>
         <id>fake_id</id>
         <ipspace>%(ipspace)s</ipspace>
@@ -842,8 +848,9 @@ NET_IPSPACES_GET_ITER_RESPONSE = etree.XML("""
     <num-records>1</num-records>
   </results>
 """ % {
+    'domain': BROADCAST_DOMAIN,
     'ipspace': IPSPACE_NAME,
-    'node': NODE_NAME,
+    'node': NODE_NAME2,
     'port': VLAN_PORT,
     'vserver': VSERVER_NAME
 })

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -2004,6 +2004,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
 
     def test_delete_ipspace(self):
 
+        self.client.features.add_feature('IPSPACES')
+        mock_ipspace_has_data_vservers = self.mock_object(
+            self.client, 'ipspace_has_data_vservers',
+            mock.Mock(return_value=False))
         mock_delete_broadcast_domains_for_ipspace = self.mock_object(
             self.client, '_delete_broadcast_domains_for_ipspace')
         self.mock_object(self.client, 'send_request')
@@ -2011,6 +2015,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
         self.client.delete_ipspace(fake.IPSPACE_NAME)
 
         net_ipspaces_destroy_args = {'ipspace': fake.IPSPACE_NAME}
+        mock_ipspace_has_data_vservers.assert_called_once_with(
+            fake.IPSPACE_NAME)
         mock_delete_broadcast_domains_for_ipspace.assert_called_once_with(
             fake.IPSPACE_NAME)
         self.client.send_request.assert_has_calls([


### PR DESCRIPTION
We keep deleted volumes (and therefore share servers/vservers) for
a while to be able to restore.
Those entities live in an ipspace that is tied to a neutron subnet
and fixed vlan ID per NetApp storage backend as long as a port is bound
to that backend. Now during delete on manila side the port gets
released which also cleans the vlan ID in neutron if it is the last
one.

If then a new port in the same subnet is bound to that backend it gets
a new vlan ID, but ends up in the same ipspace.
This leads to two vlans in the same ipspace.

When the old volume is ready to be really deleted, vserver cleanup
on manila side tries to delete the ipspace, but won't because it is
still in use and wrongly also did not clean up the vlan.
It assumed wrongly, the vlan would be in use, too. This has been fixed.

The guard to not attempt to delete the cluster ipspace or ipspaces
that are still in use has moved to a central place in the cmode client.

Change-Id: I99152dd2d3e6dd1c37843615745a079dfb5dbf36
