### PR TITLE
SCI: add config for custom snapmirror policies

### DIFF
--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -138,7 +138,7 @@ class Detail(object):
           "security service to the share network."))
     DRIVER_FAILED_DELETE_SHARE_SNAPMIRROR = (
         '026',
-        _("Share Driver failed to delete the share. The EC2 backup SnapMirror "
+        _("Share Driver failed to delete the share. A backup SnapMirror "
           "configuration exist in the backend that has to be removed first in "
           "order to delete the share. Please contact Storage Team via SNOW "
           "ticket."))

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -2664,7 +2664,10 @@ class NetAppCmodeFileStorageLibrary(object):
 
         snapshot_attributes = vserver_client.get_volume_snapshot_attributes(
             share_name)
-        if snapshot_attributes['snapshot-policy'].lower() == 'ec2_backups':
+        if (
+            snapshot_attributes['snapshot-policy'].lower()
+            in self.configuration.netapp_snapmirror_policy_exceptions
+        ):
             provisioning_options['snapshot_policy'] = \
                 snapshot_attributes['snapshot-policy']
             if snapshot_attributes['snapdir-access-enabled'].lower() == 'true':

--- a/manila/share/drivers/netapp/options.py
+++ b/manila/share/drivers/netapp/options.py
@@ -120,6 +120,10 @@ netapp_provisioning_opts = [
                     "affect new shares, which will have their snapshot "
                     "directory always visible, unless toggled by the share "
                     "type extra spec 'netapp:hide_snapdir'."),
+    cfg.ListOpt('netapp_snapmirror_policy_exceptions',
+                help='NetApp SnapMirror policy names which will not be '
+                     'overriden by ensure.',
+                default=['ec2_backups', 'hxm_backups']),
     cfg.StrOpt('netapp_snapmirror_policy_name_svm_template',
                help='NetApp SnapMirror policy name template for Storage '
                     'Virtual Machines (Vservers).',


### PR DESCRIPTION
allows to set snapshot policy names that will be kept during ensure
instead of overwriting with the snapshot policy that is set via
share type extra specs.
Moving away from hard coded ec2_backups because new hxm_backups
scenario came up. To ease the setup we default to the known two
options.

Change-Id: I814980966a3ad873ee4e890a5237b336c0040383
