### PR TITLE
fix race in share network delete

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -4710,11 +4710,17 @@ class ShareManager(manager.SchedulerDependentManager):
                 share_net = None
                 share_net_subnet = None
                 if subnet_id:
+                    # we request a copy of the current context
+                    # that can read soft-deleted entries
+                    # because the subnet and network may already have been
+                    # deleted in the API layer
+                    soft_deleted_context = context.elevated(read_deleted='yes')
                     try:
                         share_net_subnet = self.db.share_network_subnet_get(
-                            context, subnet_id)
+                            soft_deleted_context, subnet_id)
                         share_net = self.db.share_network_get(
-                            context, share_net_subnet['share_network_id'])
+                            soft_deleted_context,
+                            share_net_subnet['share_network_id'])
                     except Exception:
                         LOG.warning('Share network subnet not found during '
                                     'deletion of share server.')


### PR DESCRIPTION
We iterate over the share network subnets, send rpc calls to delete
their share servers and then remove the share network subnet and the
share network from the db by using soft delete.

The info from those models is still required to deallocate the
network in the driver, e.g. the neutron plugin needs the neutron
net info.

We don't want the API layer of share network delete to be blocked
waiting for share server deletion, instead we look at the soft deleted
data in the manager handling the share server deletion.
This usually happens shortly after the soft deletion was done, so we
should still be able to find the entries.

Change-Id: I1f23b9e93316cabb7bd32be7bb9b63dbd4eb889f
