### PR TITLE
[gh-issue#80] Neuton Subnet Full Exception Handling

### DIFF
--- a/manila/exception.py
+++ b/manila/exception.py
@@ -510,7 +510,7 @@ class PortLimitExceeded(QuotaError):
     message = _("Maximum number of ports exceeded.")
 
 class IpAddressGenerationFailureClient(ManilaException):
-    message = _("No free IP's available in neutron subnet.")
+    message = _("No free IP addresses available in neutron subnet.")
 
 class ShareAccessExists(ManilaException):
     message = _("Share access %(access_type)s:%(access)s exists.")

--- a/manila/exception.py
+++ b/manila/exception.py
@@ -509,8 +509,10 @@ class UnmanageInvalidShare(InvalidShare):
 class PortLimitExceeded(QuotaError):
     message = _("Maximum number of ports exceeded.")
 
+
 class IpAddressGenerationFailureClient(ManilaException):
     message = _("No free IP addresses available in neutron subnet.")
+
 
 class ShareAccessExists(ManilaException):
     message = _("Share access %(access_type)s:%(access)s exists.")

--- a/manila/exception.py
+++ b/manila/exception.py
@@ -509,6 +509,8 @@ class UnmanageInvalidShare(InvalidShare):
 class PortLimitExceeded(QuotaError):
     message = _("Maximum number of ports exceeded.")
 
+class IpAddressGenerationFailureClient(ManilaException):
+    message = _("No free IP's available in neutron subnet.")
 
 class ShareAccessExists(ManilaException):
     message = _("Share access %(access_type)s:%(access)s exists.")

--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -153,8 +153,8 @@ class Detail(object):
     NEUTRON_SUBNET_CAPACITY_REACHED = (
         '030',
         _("Share Driver failed to create share server on share network "
-          "due no more free IP's in the neutorn subnet. You may free some "
-          "IP's in the subnet or create new subnet/share network. If this "
+          "due no more free IP addresses in the neutron subnet. You may free some "
+          "IP addresses in the subnet or create a new subnet/share network. If this "
           "doesn't work, contact your administrator to troubleshoot issues with your network."))
     
     ALL = (

--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -156,7 +156,8 @@ class Detail(object):
           "due no more free IP addresses in the neutron subnet."
           "You may free some IP addresses in the subnet "
           "or create a new subnet/share network. If this doesn't work, "
-          "contact your administrator to troubleshoot issues with your network."))
+          "contact your administrator to troubleshoot ",
+          "issues with your network."))
     ALL = (
         UNKNOWN_ERROR,
         NO_VALID_HOST,

--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -150,13 +150,13 @@ class Detail(object):
           "due to port limit exceeded. You may increase quota of network "
           "ports and retry your request. If this doesn't work, contact your "
           "administrator to troubleshoot issues with your network."))
-    NEUTRON_SUBNET_CAPACITY_REACHED = (
+    NEUTRON_SUBNET_CAPACITY_FULL = (
         '030',
         _("Share Driver failed to create share server on share network "
           "due no more free IP addresses in the neutron subnet. You may free some "
           "IP addresses in the subnet or create a new subnet/share network. If this "
-          "doesn't work, contact your administrator to troubleshoot issues with your network."))
-    
+          "doesn't work, contact your administrator to troubleshoot "
+          "issues with your network."))
     ALL = (
         UNKNOWN_ERROR,
         NO_VALID_HOST,
@@ -187,7 +187,7 @@ class Detail(object):
         FILTER_AFFINITY,
         FILTER_ANTI_AFFINITY,
         SHARE_NETWORK_PORT_QUOTA_LIMIT_EXCEEDED,
-        NEUTRON_SUBNET_CAPACITY_REACHED
+        NEUTRON_SUBNET_CAPACITY_FULL
     )
 
     # Exception and detail mappings

--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -150,13 +150,13 @@ class Detail(object):
           "due to port limit exceeded. You may increase quota of network "
           "ports and retry your request. If this doesn't work, contact your "
           "administrator to troubleshoot issues with your network."))
-    NEUTRON_SUBNET_CAPACITY_FULL = (
+    NEUTRON_SUBNET_FULL = (
         '030',
         _("Share Driver failed to create share server on share network "
-          "due no more free IP addresses in the neutron subnet. You may free some "
-          "IP addresses in the subnet or create a new subnet/share network. If this "
-          "doesn't work, contact your administrator to troubleshoot "
-          "issues with your network."))
+          "due no more free IP addresses in the neutron subnet."
+          "You may free some IP addresses in the subnet "
+          "or create a new subnet/share network. If this doesn't work, "
+          "contact your administrator to troubleshoot issues with your network."))
     ALL = (
         UNKNOWN_ERROR,
         NO_VALID_HOST,
@@ -187,7 +187,7 @@ class Detail(object):
         FILTER_AFFINITY,
         FILTER_ANTI_AFFINITY,
         SHARE_NETWORK_PORT_QUOTA_LIMIT_EXCEEDED,
-        NEUTRON_SUBNET_CAPACITY_FULL
+        NEUTRON_SUBNET_FULL
     )
 
     # Exception and detail mappings

--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -150,7 +150,13 @@ class Detail(object):
           "due to port limit exceeded. You may increase quota of network "
           "ports and retry your request. If this doesn't work, contact your "
           "administrator to troubleshoot issues with your network."))
-
+    NEUTRON_SUBNET_CAPACITY_REACHED = (
+        '030',
+        _("Share Driver failed to create share server on share network "
+          "due no more free IP's in the neutorn subnet. You may free some "
+          "IP's in the subnet or create new subnet/share network. If this "
+          "doesn't work, contact your administrator to troubleshoot issues with your network."))
+    
     ALL = (
         UNKNOWN_ERROR,
         NO_VALID_HOST,
@@ -180,7 +186,8 @@ class Detail(object):
         DRIVER_FAILED_DELETE_SHARE_SNAPMIRROR,
         FILTER_AFFINITY,
         FILTER_ANTI_AFFINITY,
-        SHARE_NETWORK_PORT_QUOTA_LIMIT_EXCEEDED
+        SHARE_NETWORK_PORT_QUOTA_LIMIT_EXCEEDED,
+        NEUTRON_SUBNET_CAPACITY_REACHED
     )
 
     # Exception and detail mappings

--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -156,7 +156,7 @@ class Detail(object):
           "due no more free IP addresses in the neutron subnet."
           "You may free some IP addresses in the subnet "
           "or create a new subnet/share network. If this doesn't work, "
-          "contact your administrator to troubleshoot ",
+          "contact your administrator to troubleshoot "
           "issues with your network."))
     ALL = (
         UNKNOWN_ERROR,

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -183,7 +183,7 @@ class API(object):
             port = self.client.create_port(port_req_body).get('port', {})
             return port
         except neutron_client_exc.IpAddressGenerationFailureClient as e:
-            LOG.warning('Neutron error no free IP\'s in neutron subnet')
+            LOG.warning('Neutron error no free IP\'s in neutron subnet %s', subnet_id)
             raise exception.IpAddressGenerationFailureClient()
         except neutron_client_exc.NeutronClientException as e:
             LOG.warning('Neutron error creating port on network %s',

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -183,7 +183,8 @@ class API(object):
             port = self.client.create_port(port_req_body).get('port', {})
             return port
         except neutron_client_exc.IpAddressGenerationFailureClient:
-            LOG.warning('Neutron error no free IP addresses in neutron subnet %s', subnet_id)
+            LOG.warning('Neutron error no free IP addresses in neutron subnet %s', 
+                        subnet_id)
             raise exception.IpAddressGenerationFailureClient()
         except neutron_client_exc.NeutronClientException as e:
             LOG.warning('Neutron error creating port on network %s',

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -182,6 +182,9 @@ class API(object):
                 port_req_body['port'].update(kwargs)
             port = self.client.create_port(port_req_body).get('port', {})
             return port
+        except neutron_client_exc.IpAddressGenerationFailureClient as e:
+            LOG.warning('Neutron error no free IP\'s in neutron subnet')
+            raise exception.IpAddressGenerationFailureClient()
         except neutron_client_exc.NeutronClientException as e:
             LOG.warning('Neutron error creating port on network %s',
                         network_id)

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -183,8 +183,7 @@ class API(object):
             port = self.client.create_port(port_req_body).get('port', {})
             return port
         except neutron_client_exc.IpAddressGenerationFailureClient:
-            LOG.warning('Neutron error no free IP addresses in neutron subnet %s', 
-                        subnet_id)
+            LOG.warning('No free IP addresses in neutron subnet %s', subnet_id)
             raise exception.IpAddressGenerationFailureClient()
         except neutron_client_exc.NeutronClientException as e:
             LOG.warning('Neutron error creating port on network %s',

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -182,8 +182,8 @@ class API(object):
                 port_req_body['port'].update(kwargs)
             port = self.client.create_port(port_req_body).get('port', {})
             return port
-        except neutron_client_exc.IpAddressGenerationFailureClient as e:
-            LOG.warning('Neutron error no free IP\'s in neutron subnet %s', subnet_id)
+        except neutron_client_exc.IpAddressGenerationFailureClient:
+            LOG.warning('Neutron error no free IP addresses in neutron subnet %s', subnet_id)
             raise exception.IpAddressGenerationFailureClient()
         except neutron_client_exc.NeutronClientException as e:
             LOG.warning('Neutron error creating port on network %s',

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2212,6 +2212,22 @@ class ShareManager(manager.SchedulerDependentManager):
                         resource_id=share_id,
                         detail=(message_field.Detail
                                 .SECURITY_SERVICE_FAILED_AUTH))
+            except exception.IpAddressGenerationFailureClient:
+                with excutils.save_and_reraise_exception():
+                    error = ("Creation of share instance %s failed: "
+                             "No Free IP's in neutron subnet.")
+                    LOG.warning(error, share_instance_id)
+                    self.db.share_instance_update(
+                        context, share_instance_id,
+                        {'status': constants.STATUS_ERROR}
+                    )
+                    self.message_api.create(
+                        context,
+                        message_field.Action.CREATE,
+                        share['project_id'],
+                        resource_type=message_field.Resource.SHARE,
+                        resource_id=share_id,
+                        detail=message_field.Detail.NEUTRON_SUBNET_CAPACITY_REACHED)
             except Exception:
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2227,7 +2227,7 @@ class ShareManager(manager.SchedulerDependentManager):
                         share['project_id'],
                         resource_type=message_field.Resource.SHARE,
                         resource_id=share_id,
-                        detail=message_field.Detail.NEUTRON_SUBNET_CAPACITY_FULL)
+                        detail=message_field.Detail.NEUTRON_SUBNET_FULL)
             except Exception:
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2227,7 +2227,7 @@ class ShareManager(manager.SchedulerDependentManager):
                         share['project_id'],
                         resource_type=message_field.Resource.SHARE,
                         resource_id=share_id,
-                        detail=message_field.Detail.NEUTRON_SUBNET_CAPACITY_REACHED)
+                        detail=message_field.Detail.NEUTRON_SUBNET_CAPACITY_FULL)
             except Exception:
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "


### PR DESCRIPTION
## Problem
if a neutron subnet is full, no more ports can be created, it raises `IpAddressGenerationFailureClient`

manila catches that exception and raises `PortLimitExceeded`
(Maximum number of ports exceeded.)
This is done in manila/network/neutron/api.py in _create_port() 

```python
        except neutron_client_exc.NeutronClientException as e:
            LOG.warning('Neutron error creating port on network %s',
                        network_id)
            if e.status_code == 409:
                raise exception.PortLimitExceeded()
```

which leads to user message `SHARE_NETWORK_PORT_QUOTA_LIMIT_EXCEEDED`
"Share Driver failed to create share server on share network due to port limit exceeded. You may increase quota of network ports and retry your request [...]"

this is misleading, the problem is not the port quota, but the subnet is out of free IPs

How to reproduce:

create a small subnet (think of /28), fill it up by creating ports, then use this as base for manila share network and try to create a share.