### PR TITLE
followup to share server list fix

### DIFF
--- a/manila/api/v1/share_servers.py
+++ b/manila/api/v1/share_servers.py
@@ -74,6 +74,7 @@ class ShareServerController(wsgi.Controller):
                 s.share_network_id = s.share_network_subnet['share_network_id']
                 sn = share_network_map.get(s.share_network_id)
             else:
+                s.share_network_id = None
                 sn = None
             if sn:
                 s.project_id = sn['project_id']


### PR DESCRIPTION
follows 081bf70e58e1011f44b35c2e686e01ed62b93fc5

fixes error when writing debug log
```
AttributeError
'ShareServer' object has no attribute 'share_network_id'
```

Change-Id: Ief2bc64c5365676e1e31a4e50582bb556de6b8c6
