### PR TITLE
neutron delete port: pass if not found

### DIFF
--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -207,6 +207,10 @@ class API(object):
     def delete_port(self, port_id):
         try:
             self.client.delete_port(port_id)
+        except neutron_client_exc.PortNotFoundClient:
+            LOG.warning('Neutron port not found: %s', port_id)
+            # we assume it has been deleted by something else
+            pass
         except neutron_client_exc.NeutronClientException as e:
             raise exception.NetworkException(code=e.status_code,
                                              message=e.message)


### PR DESCRIPTION
The goal is to get rid of the port, if it is not found, we reached the
goal. But since it is odd, we log a debug message.

Change-Id: I51e7f3b12643b33e0a44464569b820a37ad75508
