### PR TITLE
NetApp share server migration: re use existing ipspace

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -257,19 +257,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                     "subtype.")
             LOG.debug(msg)
 
-        # NOTE(lseki): If there's already an ipspace created for the same VLAN
-        # port, reuse it. It will be named after the previously created share
-        # server's neutron subnet id.
-        node_name = self._client.list_cluster_nodes()[0]
-        port = self._get_node_data_port(node_name)
-        vlan = network_info['segmentation_id']
-        ipspace_name = self._client.get_ipspace_name_for_vlan_port(
-            node_name, port, vlan)
-        if (
-            ipspace_name is None
-            or ipspace_name in client_cmode.CLUSTER_IPSPACES
-        ):
-            ipspace_name = self._create_ipspace(network_info)
+        ipspace_name = self._get_or_create_ipspace(network_info)
 
         aggregate_names = self._find_matching_aggregates()
         if is_dp_destination:
@@ -354,7 +342,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         return client_cmode.IPSPACE_PREFIX + network_id.replace('-', '_')
 
     @na_utils.trace
-    def _create_ipspace(self, network_info, client=None):
+    def _get_or_create_ipspace(self, network_info, client=None):
         """If supported, create an IPspace for a new Vserver."""
 
         desired_client = client if client else self._client
@@ -365,6 +353,17 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         if (network_info['network_allocations'][0]['network_type']
                 not in SEGMENTED_NETWORK_TYPES):
             return client_cmode.DEFAULT_IPSPACE
+
+        # NOTE(lseki): If there's already an ipspace created for the same VLAN
+        # port, reuse it. It will be named after the previously created share
+        # server's neutron subnet id.
+        node_name = desired_client.list_cluster_nodes()[0]
+        port = self._get_node_data_port(node_name, client=desired_client)
+        vlan = network_info['network_allocations'][0]['segmentation_id']
+        ipspace_name = desired_client.get_ipspace_name_for_vlan_port(
+            node_name, port, vlan)
+        if ipspace_name and ipspace_name not in client_cmode.CLUSTER_IPSPACES:
+            return ipspace_name
 
         # NOTE(cknight): Neutron needs cDOT IP spaces because it can provide
         # overlapping IP address ranges for different subnets.  That is not
@@ -1196,8 +1195,8 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         vlan = network_info['network_allocations'][0]['segmentation_id']
 
         # 2. Create new ipspace, port and broadcast domain.
-        destination_ipspace = self._create_ipspace(network_info,
-                                                   client=dest_client)
+        destination_ipspace = self._get_or_create_ipspace(network_info,
+                                                          client=dest_client)
         self._create_port_and_broadcast_domain(destination_ipspace,
                                                network_info)
 
@@ -1465,8 +1464,10 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         }
 
         # 2. Create new ipspace, port and broadcast domain.
-        destination_ipspace = self._create_ipspace(network_info,
-                                                   client=dest_client)
+        # NOTE(carthaca): since we execute this always on the share service of
+        # the dest host: dest_client equals self._client
+        destination_ipspace = self._get_or_create_ipspace(network_info,
+                                                          client=dest_client)
         self._create_port_and_broadcast_domain(destination_ipspace,
                                                network_info)
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -563,6 +563,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         versions = ['fake_v1', 'fake_v2']
         self.library.configuration.netapp_enabled_share_protocols = versions
+        ipspace_name = ('ipspace_'
+                        + fake.NETWORK_INFO['neutron_subnet_id'].replace(
+                            '-', '_'))
         vserver_id = fake.NETWORK_INFO['server_id']
         vserver_name = fake.VSERVER_NAME_TEMPLATE % vserver_id
         vserver_client = mock.Mock()
@@ -588,9 +591,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_get_flexgroup_aggr_set',
                          mock.Mock(return_value=fake.AGGREGATES))
-        self.mock_object(self.library,
-                         '_create_ipspace',
-                         mock.Mock(return_value=fake.IPSPACE))
+        self.mock_object(self.library._client, 'create_ipspace')
         get_ipspace_name_for_vlan_port = self.mock_object(
             self.library._client,
             'get_ipspace_name_for_vlan_port',
@@ -607,19 +608,21 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             fake.CLUSTER_NODES[0],
             'fake_port',
             fake.NETWORK_INFO['segmentation_id'])
-        if not existing_ipspace:
-            self.library._create_ipspace.assert_called_once_with(
-                fake.NETWORK_INFO)
+        if existing_ipspace:
+            ipspace_name = existing_ipspace
+        else:
+            self.library._client.create_ipspace.assert_called_once_with(
+                ipspace_name)
         self.library._client.create_vserver.assert_called_once_with(
             vserver_name, fake.ROOT_VOLUME_AGGREGATE, fake.ROOT_VOLUME,
-            set(fake.AGGREGATES), fake.IPSPACE, 12, False,
+            set(fake.AGGREGATES), ipspace_name, 12, False,
             fake.SECURITY_CERT_EXPIRE_DAYS)
         self.library._get_api_client.assert_called_once_with(
             vserver=vserver_name)
         self.library._create_vserver_lifs.assert_called_once_with(
-            vserver_name, vserver_client, fake.NETWORK_INFO, fake.IPSPACE)
+            vserver_name, vserver_client, fake.NETWORK_INFO, ipspace_name)
         self.library._create_vserver_admin_lif.assert_called_once_with(
-            vserver_name, vserver_client, fake.NETWORK_INFO, fake.IPSPACE)
+            vserver_name, vserver_client, fake.NETWORK_INFO, ipspace_name)
         self.library._create_vserver_routes.assert_called_once_with(
             vserver_client, fake.NETWORK_INFO)
         vserver_client.enable_nfs.assert_called_once_with(
@@ -633,6 +636,10 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
     def test_create_vserver_dp_destination(self, existing_ipspace):
         versions = ['fake_v1', 'fake_v2']
         self.library.configuration.netapp_enabled_share_protocols = versions
+        ipspace_name = ('ipspace_'
+                        + fake.NETWORK_INFO['neutron_subnet_id'].replace(
+                            '-', '_'))
+
         vserver_id = fake.NETWORK_INFO['server_id']
         vserver_name = fake.VSERVER_NAME_TEMPLATE % vserver_id
 
@@ -654,9 +661,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library,
                          '_get_flexgroup_aggr_set',
                          mock.Mock(return_value=fake.AGGREGATES))
-        self.mock_object(self.library,
-                         '_create_ipspace',
-                         mock.Mock(return_value=fake.IPSPACE))
+        self.mock_object(self.library._client, 'create_ipspace')
 
         get_ipspace_name_for_vlan_port = self.mock_object(
             self.library._client,
@@ -671,14 +676,16 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             fake.CLUSTER_NODES[0],
             'fake_port',
             fake.NETWORK_INFO['segmentation_id'])
-        if not existing_ipspace:
-            self.library._create_ipspace.assert_called_once_with(
-                fake.NETWORK_INFO)
+        if existing_ipspace:
+            ipspace_name = existing_ipspace
+        else:
+            self.library._client.create_ipspace.assert_called_once_with(
+                ipspace_name)
         create_server_mock = self.library._client.create_vserver_dp_destination
         create_server_mock.assert_called_once_with(
-            vserver_name, fake.AGGREGATES, fake.IPSPACE, 12, False)
+            vserver_name, fake.AGGREGATES, ipspace_name, 12, False)
         self.library._create_port_and_broadcast_domain.assert_called_once_with(
-            fake.IPSPACE, fake.NETWORK_INFO)
+            ipspace_name, fake.NETWORK_INFO)
         self.library._get_flexgroup_aggr_set.assert_not_called()
 
     def test_create_vserver_already_present(self):
@@ -743,7 +750,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          'get_ipspace_name_for_vlan_port',
                          mock.Mock(return_value=existing_ipspace))
         self.mock_object(self.library,
-                         '_create_ipspace',
+                         '_get_or_create_ipspace',
                          mock.Mock(return_value=fake.IPSPACE))
         self.mock_object(self.library,
                          '_setup_network_for_vserver',
@@ -790,34 +797,43 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         expected = 'ipspace_' + fake.IPSPACE_ID.replace('-', '_')
         self.assertEqual(expected, result)
 
-    def test_create_ipspace_not_supported(self):
+    def test_get_or_create_ipspace_not_supported(self):
 
         self.library._client.features.IPSPACES = False
 
-        result = self.library._create_ipspace(fake.NETWORK_INFO)
+        result = self.library._get_or_create_ipspace(fake.NETWORK_INFO)
 
         self.assertIsNone(result)
 
     @ddt.data(None, 'flat')
-    def test_create_ipspace_not_vlan(self, network_type):
+    def test_get_or_create_ipspace_not_vlan(self, network_type):
 
         self.library._client.features.IPSPACES = True
         network_info = copy.deepcopy(fake.NETWORK_INFO)
         network_info['network_allocations'][0]['segmentation_id'] = None
         network_info['network_allocations'][0]['network_type'] = network_type
 
-        result = self.library._create_ipspace(network_info)
+        result = self.library._get_or_create_ipspace(network_info)
 
         self.assertEqual('Default', result)
 
-    def test_create_ipspace(self):
+    def test_get_or_create_ipspace(self):
 
         self.library._client.features.IPSPACES = True
+        self.mock_object(self.library._client,
+                         'list_cluster_nodes',
+                         mock.Mock(return_value=fake.CLUSTER_NODES))
+        self.mock_object(self.library,
+                         '_get_node_data_port',
+                         mock.Mock(return_value='fake_port'))
+        self.mock_object(self.library._client,
+                         'get_ipspace_name_for_vlan_port',
+                         mock.Mock(return_value=None))
         self.mock_object(self.library._client,
                          'create_ipspace',
                          mock.Mock(return_value=False))
 
-        result = self.library._create_ipspace(fake.NETWORK_INFO)
+        result = self.library._get_or_create_ipspace(fake.NETWORK_INFO)
 
         expected = self.library._get_valid_ipspace_name(
             fake.NETWORK_INFO['neutron_subnet_id'])
@@ -2154,13 +2170,14 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                     'neutron_subnet_id')
         }
 
-        dest_ipspace = 'ipspace_' + network_info['neutron_subnet_id']
+        dest_ipspace = ('ipspace_'
+                        + network_info['neutron_subnet_id'].replace('-', '_'))
 
         self.mock_object(self.library, '_get_node_data_port',
                          mock.Mock(return_value=fake.NODE_DATA_PORT))
         self.mock_object(
-            self.library._client, 'get_ipspace_name_for_vlan_port',
-            mock.Mock(return_value=fake.IPSPACE))
+            self.mock_dest_client, 'get_ipspace_name_for_vlan_port',
+            mock.Mock(return_value=dest_ipspace))
         self.mock_object(self.library, '_create_port_and_broadcast_domain')
         self.mock_object(self.mock_dest_client, 'get_ipspaces',
                          mock.Mock(return_value=[{'uuid': fake.IPSPACE_ID}]))
@@ -2184,8 +2201,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             dest_ipspace=dest_ipspace)
         self.library._get_job_uuid.assert_called_once_with(
             c_fake.FAKE_MIGRATION_RESPONSE_WITH_JOB)
-        self.mock_dest_client.list_cluster_nodes.assert_called_once()
-        self.library._get_node_data_port.assert_called_once_with(
+        self.mock_dest_client.list_cluster_nodes.assert_called()
+        self.library._get_node_data_port.assert_called_with(
             fake.CLUSTER_NODES[0])
         self.library._create_port_and_broadcast_domain.assert_called_once_with(
             dest_ipspace, network_info)
@@ -2199,13 +2216,14 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                     'neutron_subnet_id')
         }
 
-        dest_ipspace = 'ipspace_' + network_info['neutron_subnet_id']
+        dest_ipspace = ('ipspace_'
+                        + network_info['neutron_subnet_id'].replace('-', '_'))
 
         self.mock_object(self.library, '_get_node_data_port',
                          mock.Mock(return_value=fake.NODE_DATA_PORT))
         self.mock_object(self.library, '_create_port_and_broadcast_domain')
-        self.mock_object(self.mock_dest_client, 'get_ipspaces',
-                         mock.Mock(return_value=[{'uuid': fake.IPSPACE_ID}]))
+        self.mock_object(self.library, '_get_or_create_ipspace',
+                         mock.Mock(return_value=dest_ipspace))
         self.mock_object(self.mock_dest_client, 'list_cluster_nodes',
                          mock.Mock(return_value=fake.CLUSTER_NODES))
         self.mock_object(
@@ -2222,8 +2240,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             fake.AGGREGATES,
             self.mock_dest_client)
 
-        self.mock_dest_client.list_cluster_nodes.assert_called_once()
-        self.library._get_node_data_port.assert_called_once_with(
+        self.mock_dest_client.list_cluster_nodes.assert_called()
+        self.library._get_node_data_port.assert_called_with(
             fake.CLUSTER_NODES[0])
         self.library._create_port_and_broadcast_domain.assert_called_once_with(
             dest_ipspace, network_info)
@@ -2477,7 +2495,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                     'neutron_subnet_id']
         }
 
-        dest_ipspace = 'ipspace_' + network_info['neutron_subnet_id']
+        dest_ipspace = ('ipspace_'
+                        + network_info['neutron_subnet_id'].replace('-', '_'))
 
         mock_create_port = self.mock_object(
             self.library, '_create_port_and_broadcast_domain')
@@ -2490,6 +2509,13 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         mock_get_aggregates = self.mock_object(
             self.library, '_find_matching_aggregates',
             mock.Mock(return_value=fake.AGGREGATES))
+        self.mock_object(self.mock_dest_client, 'list_cluster_nodes',
+                         mock.Mock(return_value=fake.CLUSTER_NODES))
+        self.mock_object(self.library, '_get_node_data_port',
+                         mock.Mock(return_value=fake.NODE_DATA_PORT))
+        mock_get_ipspace_name_for_vlan_port = self.mock_object(
+            self.mock_dest_client, 'get_ipspace_name_for_vlan_port',
+            mock.Mock(return_value=None))
         mock_create_ipspace = self.mock_object(
             self.mock_dest_client, 'create_ipspace')
         mock_svm_migration_start = self.mock_object(
@@ -2503,6 +2529,10 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             None, self.fake_src_share_server, self.fake_dest_share_server,
             self.mock_src_client, self.mock_dest_client)
 
+        mock_get_ipspace_name_for_vlan_port.assert_called_once_with(
+            fake.CLUSTER_NODE, fake.NODE_DATA_PORT,
+            network_info['network_allocations'][0]['segmentation_id']
+        )
         mock_create_ipspace.assert_called_once_with(
             dest_ipspace)
         mock_create_port.assert_called_once_with(
@@ -2532,7 +2562,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                     'neutron_subnet_id']
         }
 
-        dest_ipspace = 'ipspace_' + network_info['neutron_subnet_id']
+        dest_ipspace = ('ipspace_'
+                        + network_info['neutron_subnet_id'].replace('-', '_'))
 
         mock_create_port = self.mock_object(
             self.library, '_create_port_and_broadcast_domain')
@@ -2548,6 +2579,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         mock_get_node_data_port = self.mock_object(
             self.library, '_get_node_data_port',
             mock.Mock(return_value=fake.NODE_DATA_PORT))
+        self.mock_object(self.mock_dest_client,
+                         'get_ipspace_name_for_vlan_port',
+                         mock.Mock(return_value=dest_ipspace))
         mock_create_ipspace = self.mock_object(
             self.mock_dest_client, 'create_ipspace')
         mock_svm_migration_start = self.mock_object(
@@ -2566,8 +2600,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.fake_src_share_server, self.fake_dest_share_server,
             self.mock_src_client, self.mock_dest_client)
 
-        mock_create_ipspace.assert_called_once_with(
-            dest_ipspace)
+        mock_create_ipspace.assert_not_called()
         mock_create_port.assert_called_once_with(
             dest_ipspace, network_info)
         mock_get_vserver_name.assert_called_once_with(


### PR DESCRIPTION
It works currently, if the existing ipspace name has the same name
that we would try to create, because create_ipspace in the client
accepts that.

But if the existing ipspace name is different, because we have
multiple neutron subnets, server migration fails.

In the future, once all ipspaces are based on neutron network name
instead of subnet name, this will be needed only on edge cases.

Change-Id: If220727ded0bc796645eb29852d18c23e0a9e8b2
