### PR TITLE
NetApp disable nfs v4.0 for new share servers

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1827,13 +1827,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                               extra_config=None):
         """Set the enabled NFS protocol versions."""
         nfs3 = 'true' if 'nfs3' in versions else 'false'
-        # SAPCC absence of 'nfs4.0' should not equal 'false'
-        # instead it should mean:
-        #   don't touch existing value for existing vservers
-        #   and set the default value ('false' for ONTAP 9.7 and newer)
-        #   for new vservers
-        # Change back to upstream once all vservers have nfs4.0 disabled!
-        # nfs40 = 'true' if 'nfs4.0' in versions else 'false'
+        nfs40 = 'true' if 'nfs4.0' in versions else 'false'
         nfs41 = 'true' if 'nfs4.1' in versions else 'false'
 
         nfs_service_modify_args = {
@@ -1845,15 +1839,21 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'enable-ejukebox': 'false',
             'is-vstorage-enabled': 'true',
         }
+        # below options are dangerous to change on existing vservers:
+        # e.g. clients may lose connections or remount is required.
+        # absence of those options on method 'update' means to not touch them
+        # e.g. during ensure runs
         if method == 'create':
             flexgroup_opts = {
                 'is-nfsv3-64bit-identifiers-enabled': 'true',   # default false
                 'is-nfsv4-64bit-identifiers-enabled': 'true',   # default true
             }
             nfs_service_modify_args.update(flexgroup_opts)
+            version_opts = {
+                'is-nfsv40-enabled': nfs40,
+            }
+            nfs_service_modify_args.update(version_opts)
 
-        if 'nfs4.0' in versions:
-            nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
         if 'nfs4.1' in versions:
             nfs41_opts = {
                 # 'is-nfsv41-pnfs-enabled': 'false',               # default false, use default on new vservers, don't touch old vservers  # noqa: E501

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -2647,8 +2647,6 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'is-vstorage-enabled': 'true',
         }
 
-        if v40:
-            nfs_service_modify_args['is-nfsv40-enabled'] = 'true'
         if v41:
             nfs41_opts = {
                 'is-nfsv41-acl-enabled': 'false',
@@ -2664,6 +2662,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
                 'is-nfsv4-64bit-identifiers-enabled': 'true',
             }
             nfs_service_modify_args.update(flexgroup_opts)
+            v40_enabled = 'true' if v40 else 'false'
+            nfs_service_modify_args['is-nfsv40-enabled'] = v40_enabled
 
         if extra:
             nfs_service_modify_args.update(extra)


### PR DESCRIPTION
this has been the default for ONTAP 9.7 and 9.8 and we mistakenly
relied on that it would stay that way in
https://github.com/sapcc/manila/commit/3503a199a00cef176c398b98a4187808f5d521ad

But since ONTAP 9.9.1 the default is to enable nfsv40 again.

Now making the disablement explicit, since we now have a proper way to
distinguish between options that should be set on create and those
that should be set on update, too.

Change-Id: I39e2da2c3393ec95312c09a608a997a29981a471
