### PR TITLE
svm migrate: fix allocation cleanup

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5718,10 +5718,11 @@ class ShareManager(manager.SchedulerDependentManager):
                 context, constants.STATUS_AVAILABLE,
                 share_instance_ids=share_instance_ids,
                 snapshot_instance_ids=snapshot_instance_ids)
-            # Rollback port bindings on destination host
+            # Rollback port bindings on destination host,
+            # those are still associated to source share server in this phase
             if extended_allocs:
                 self.driver.network_api.delete_extended_allocations(
-                    context, source_share_server, dest_share_server)
+                    context, source_share_server)
             # Rollback read only access rules
             self._reset_read_only_access_rules_for_server(
                 context, share_instances, source_share_server,


### PR DESCRIPTION
followup to 9189ac305057fa2b9e6f28615ba67a695cff1d00

fixes TypeError
'delete_extended_allocations() takes 3 positional arguments but 4 were given'

Change-Id: I2c659d118d7b156259943e23e61913886768e481
