### PR TITLE
Fix export location for readable type replica promote

### DIFF
--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -2313,7 +2313,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         self.assertEqual(fake.NFS_EXPORTS, result)
         mock_get_export_addresses_with_metadata.assert_called_once_with(
-            fake.SHARE, fake.SHARE_SERVER, fake.LIFS, expected_host)
+            fake.SHARE, fake.SHARE_SERVER, fake.LIFS, expected_host,
+            vserver_client)
         protocol_helper.create_share.assert_called_once_with(
             fake.SHARE, fake.SHARE_NAME, clear_current_export_policy=True,
             ensure_share_already_exists=False, replica=False,
@@ -2356,9 +2357,11 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             fake.SHARE_SERVER)
         if is_flexgroup:
             mock_get_aggr_flexgroup.assert_called_once_with(fake.POOL_NAME)
-            mock_get_aggregate_node.assert_called_once_with(fake.AGGREGATE)
+            mock_get_aggregate_node.assert_called_once_with(
+                fake.AGGREGATE, None)
         else:
-            mock_get_aggregate_node.assert_called_once_with(fake.POOL_NAME)
+            mock_get_aggregate_node.assert_called_once_with(
+                fake.POOL_NAME, None)
 
     def test_get_export_addresses_with_metadata_node_unknown(self):
 
@@ -2379,7 +2382,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             value['preferred'] = False
 
         self.assertEqual(expected, result)
-        mock_get_aggregate_node.assert_called_once_with(fake.POOL_NAME)
+        mock_get_aggregate_node.assert_called_once_with(
+            fake.POOL_NAME, None)
         mock_get_admin_addresses_for_share_server.assert_called_once_with(
             fake.SHARE_SERVER)
 


### PR DESCRIPTION
During replica promotion, the export location retrieved using the replica used for promotion where invalid vserver_client is used causing NetApp API error.

Change-Id: I6b809e093413a9a5d574023db73bbb01023f0e9f