### PR TITLE
Fix 'server_migrating' status of non-active replica

### DIFF
--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -2879,14 +2879,16 @@ class API(base.Base):
             {'task_state': constants.TASK_STATE_MIGRATION_STARTING,
              'status': constants.STATUS_SERVER_MIGRATING})
 
-        share_snapshots = [
-            self.db.share_snapshot_get_all_for_share(context, share['id'])
-            for share in shares]
+        share_instances = self.db.share_instances_get_all_by_share_server(
+            context, share_server['id'])
+        share_instance_ids = [
+            share_instance['id'] for share_instance in share_instances]
+
         snapshot_instance_ids = []
-        for snapshot_list in share_snapshots:
-            for snapshot in snapshot_list:
-                snapshot_instance_ids.append(snapshot['instance']['id'])
-        share_instance_ids = [share['instance']['id'] for share in shares]
+        snap_instances = self.db.share_snapshot_instance_get_all_with_filters(
+            context, {'share_instance_ids': share_instance_ids})
+        snapshot_instance_ids = [
+            snap_instance['id'] for snap_instance in snap_instances]
 
         # Updates all shares and snapshot instances
         self.db.share_and_snapshot_instances_status_update(

--- a/manila/tests/share/test_api.py
+++ b/manila/tests/share/test_api.py
@@ -5652,13 +5652,16 @@ class ShareAPITestCase(test.TestCase):
         share_type = db_api.share_type_get(self.context, share_type['id'])
         fake_shares = [db_utils.create_share(
             host='fake@backend#pool', status=constants.STATUS_AVAILABLE,
-            share_type_id=share_type['id']) for x in range(4)]
+            share_type_id=share_type['id'],
+            share_server_id=fake_share_server['id']) for x in range(4)]
         fake_snapshots = [
             db_utils.create_snapshot(share_id=fake_shares[0]['id'])]
         instance_ids = [share['instance']['id'] for share in fake_shares]
+        snap_instances = []
         snap_instance_ids = []
         for fake_share in fake_shares:
             for snapshot in fake_snapshots:
+                snap_instances.append({'id': snapshot['instance']['id']})
                 snap_instance_ids.append(snapshot['instance']['id'])
         fake_types = [share_type]
         fake_share_network = db_utils.create_share_network()
@@ -5677,8 +5680,6 @@ class ShareAPITestCase(test.TestCase):
         share_expected_update = {
             'status': constants.STATUS_SERVER_MIGRATING
         }
-        snapshot_get_calls = [
-            mock.call(self.context, share['id']) for share in fake_shares]
 
         mock_initial_checks = self.mock_object(
             self.api, '_migration_initial_checks',
@@ -5688,8 +5689,8 @@ class ShareAPITestCase(test.TestCase):
             self.share_rpcapi, 'share_server_migration_start')
         mock_server_update = self.mock_object(db_api, 'share_server_update')
         mock_snapshots_get = self.mock_object(
-            db_api, 'share_snapshot_get_all_for_share',
-            mock.Mock(return_value=fake_snapshots))
+            db_api, 'share_snapshot_instance_get_all_with_filters',
+            mock.Mock(return_value=snap_instances))
         mock_update_instances = self.mock_object(
             db_api, 'share_and_snapshot_instances_status_update')
 
@@ -5706,8 +5707,7 @@ class ShareAPITestCase(test.TestCase):
         )
         mock_server_update.assert_called_once_with(
             self.context, fake_share_server['id'], server_expected_update)
-        mock_snapshots_get.assert_has_calls(
-            snapshot_get_calls)
+        mock_snapshots_get.assert_called()
         mock_update_instances.assert_called_once_with(
             self.context, share_expected_update,
             current_expected_status=constants.STATUS_AVAILABLE,


### PR DESCRIPTION
Since we allow share server migration with share replica, we need to make sure correct share and snapshot instances updated to 'server_migrating' status i.e. instances belonging to share server under migration. Fixed this.

Change-Id: I498700367752f2effc8c7a1e50a233579607a9fc