### PR TITLE
Pass comment for flexgroup volume

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -1208,6 +1208,7 @@ class NetAppCmodeFileStorageLibrary(object):
                 vserver_client, aggr_list, share_name,
                 share['size'],
                 self.configuration.netapp_volume_snapshot_reserve_percent,
+                comment=share_comment,
                 **provisioning_options)
         else:
             vserver_client.create_volume(
@@ -1241,6 +1242,7 @@ class NetAppCmodeFileStorageLibrary(object):
     def _create_flexgroup_share(self, vserver_client, aggr_list, share_name,
                                 size, snapshot_reserve, dedup_enabled=False,
                                 compression_enabled=False, max_files=None,
+                                comment=None,
                                 **provisioning_options):
         """Create a FlexGroup share using async API with job."""
 
@@ -1248,7 +1250,7 @@ class NetAppCmodeFileStorageLibrary(object):
             self.configuration.netapp_flexgroup_aggregate_not_busy_timeout)
         job_info = self.wait_for_start_create_flexgroup(
             start_timeout, vserver_client, aggr_list, share_name, size,
-            snapshot_reserve, **provisioning_options)
+            snapshot_reserve, comment=comment, **provisioning_options)
 
         if not job_info['jobid'] or job_info['error-code']:
             msg = "Error creating FlexGroup share: %s."
@@ -1275,6 +1277,7 @@ class NetAppCmodeFileStorageLibrary(object):
     def wait_for_start_create_flexgroup(self, start_timeout, vserver_client,
                                         aggr_list, share_name, size,
                                         snapshot_reserve,
+                                        comment=None,
                                         **provisioning_options):
         """Wait for starting create FlexGroup volume succeed.
 
@@ -1302,6 +1305,7 @@ class NetAppCmodeFileStorageLibrary(object):
                     aggr_list, share_name, size,
                     snapshot_reserve=snapshot_reserve,
                     auto_provisioned=self._is_flexgroup_auto,
+                    comment=comment,
                     **provisioning_options)
             except netapp_api.NaApiError as e:
                 with excutils.save_and_reraise_exception() as raise_ctxt:

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -1537,7 +1537,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             mock_get_aggr_flexgroup.assert_called_once_with(fake.POOL_NAME)
             mock_create_flexgroup.assert_called_once_with(
                 vserver_client, [fake.AGGREGATE], fake.SHARE_NAME,
-                fake.SHARE['size'], 8, **provisioning_options)
+                fake.SHARE['size'], 8, comment=fake.VOLUME_COMMENT,
+                **provisioning_options)
         else:
             mock_get_aggr_flexgroup.assert_not_called()
             vserver_client.create_volume.assert_called_once_with(
@@ -1634,7 +1635,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         start_timeout = (self.library.configuration.
                          netapp_flexgroup_aggregate_not_busy_timeout)
         mock_wait_for_start.assert_called_once_with(
-            start_timeout, vserver_client, aggr_list, fake.SHARE_NAME, 100, 10)
+            start_timeout, vserver_client, aggr_list, fake.SHARE_NAME, 100,
+            10, comment=None)
         mock_wait_for_flexgroup_deployment.assert_called_once_with(
             vserver_client, fake.JOB_ID, 2)
         (vserver_client.update_volume_efficiency_attributes.
@@ -1671,7 +1673,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.assertEqual(job, result)
         vserver_client.create_volume_async.assert_called_once_with(
             aggr_list, fake.SHARE_NAME, 1, snapshot_reserve=10,
-            auto_provisioned=self.library._is_flexgroup_auto)
+            auto_provisioned=self.library._is_flexgroup_auto,
+            comment=None)
 
     def test_wait_for_start_create_flexgroup_timeout(self):
         vserver_client = mock.Mock()


### PR DESCRIPTION
_create_flexgroup_share() in lib_base needs to use the comment option during creation of flexgroup volumes.

Change-Id: I0f2a14fdd483cb54c9b92548c5f8d1938417bd4b