### PR TITLE
NetApp - Preserve custom snapshot policies.

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -2214,6 +2214,19 @@ class NetAppCmodeFileStorageLibrary(object):
         if qos_policy_group_name:
             provisioning_options['qos_policy_group'] = qos_policy_group_name
 
+        snapshot_attributes = vserver_client.get_volume_snapshot_attributes(
+            share_name)
+        if (
+            snapshot_attributes['snapshot-policy'].lower()
+            in self.configuration.netapp_snapmirror_policy_exceptions
+        ):
+            provisioning_options['snapshot_policy'] = \
+                snapshot_attributes['snapshot-policy']
+            if snapshot_attributes['snapdir-access-enabled'].lower() == 'true':
+                provisioning_options['hide_snapdir'] = False
+            else:
+                provisioning_options['hide_snapdir'] = True
+
         # Modify volume to match extra specs.
         vserver_client.modify_volume(aggregate_name, share_name,
                                      **provisioning_options)
@@ -4042,6 +4055,19 @@ class NetAppCmodeFileStorageLibrary(object):
                 source_share['id'])
             self._client.mark_qos_policy_group_for_deletion(
                 qos_policy_of_src_share)
+
+        snapshot_attributes = vserver_client.get_volume_snapshot_attributes(
+            new_share_volume_name)
+        if (
+            snapshot_attributes['snapshot-policy'].lower()
+            in self.configuration.netapp_snapmirror_policy_exceptions
+        ):
+            provisioning_options['snapshot_policy'] = \
+                snapshot_attributes['snapshot-policy']
+            if snapshot_attributes['snapdir-access-enabled'].lower() == 'true':
+                provisioning_options['hide_snapdir'] = False
+            else:
+                provisioning_options['hide_snapdir'] = True
 
         destination_aggregate = share_utils.extract_host(
             destination_share['host'], level='pool')

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -2800,6 +2800,10 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         mock_modify_or_create_qos_policy = self.mock_object(
             self.library, '_modify_or_create_qos_for_existing_share',
             mock.Mock(return_value=qos_policy_group_name))
+        mock_get_volume_snapshot_attributes = self.mock_object(
+            vserver_client, 'get_volume_snapshot_attributes',
+            mock.Mock(return_value={'snapshot-policy': 'fake_policy'}))
+
         fake_fpolicy_scope = {
             'policy-name': fake.FPOLICY_POLICY_NAME,
             'shares-to-include': [fake.FLEXVOL_NAME]
@@ -2838,6 +2842,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             fake_aggr, fake.SHARE_NAME, **provisioning_opts)
         mock_modify_or_create_qos_policy.assert_called_once_with(
             share_to_manage, extra_specs, fake.VSERVER1, vserver_client)
+        mock_get_volume_snapshot_attributes.assert_called_once_with(
+            fake.SHARE_NAME)
         mock_validate_volume_for_manage.assert_called()
         if fpolicy:
             mock_find_scope.assert_called_once_with(
@@ -6815,6 +6821,10 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(
             self.library, '_modify_or_create_qos_for_existing_share',
             mock.Mock(return_value=policy_group_name))
+        mock_get_volume_snapshot_attributes = self.mock_object(
+            vserver_client, 'get_volume_snapshot_attributes',
+            mock.Mock(return_value={'snapshot-policy': 'fake_policy'}))
+
         self.mock_object(vserver_client, 'modify_volume')
         mock_create_new_fpolicy = self.mock_object(
             self.library, '_create_fpolicy_for_share')
@@ -6843,6 +6853,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.library._create_export.assert_called_once_with(
             dest_share, fake.SHARE_SERVER, fake.VSERVER1, vserver_client,
             clear_current_export_policy=False)
+        mock_get_volume_snapshot_attributes.assert_called_once_with(
+            'new_share_name')
         vserver_client.modify_volume.assert_called_once_with(
             dest_aggr, 'new_share_name', **provisioning_options)
         mock_info_log.assert_called_once()


### PR DESCRIPTION
During share migration and share manage, we use provisioning options from extra-specs. This over-writes the custome snapshot policies associated with volume, so retrieve and apply them again during volume modify API call.

Change-Id: If7421dae4c9de25041bd543648ceb82d2b9db2d4