### PR TITLE
sapcc: add request_id if we already have any in the header

### DIFF
--- a/manila/api/middleware/auth.py
+++ b/manila/api/middleware/auth.py
@@ -96,6 +96,9 @@ class ManilaKeystoneContext(base_wsgi.Middleware):
             LOG.debug("Neither X_USER_ID nor X_USER found in request")
             return webob.exc.HTTPUnauthorized()
 
+        if req.headers.get('X-Openstack-Request-ID'):
+            ctx.request_id = req.headers.get('X-Openstack-Request-ID')
+
         if req.environ.get('X_PROJECT_DOMAIN_ID'):
             ctx.project_domain_id = req.environ['X_PROJECT_DOMAIN_ID']
 


### PR DESCRIPTION
This is only a quick-fix for the problem that the request id
changes in-between the same request.

The proper way would be to do a similar
refactoring like https://github.com/openstack/cinder/commit/18b8033b6bd1945bd27b03b779a32a883df5fb10
because doing this in the auth middleware here is actually too late
in the stack.

Change-Id: I4183757e02c7c6446911ace898499af303d711e5
