### PR TITLE
Consider share metadata snapshot_policy

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -2660,6 +2660,12 @@ class NetAppCmodeFileStorageLibrary(object):
             else:
                 provisioning_options['hide_snapdir'] = True
 
+        metadata = share.get('metadata')
+        if metadata:
+            snapshot_policy = metadata.get('snapshot_policy')
+            if snapshot_policy:
+                provisioning_options['snapshot_policy'] = snapshot_policy
+
         modify_args = {
             'share': share_name,
             'aggr': aggregate_name,

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -592,6 +592,8 @@ class ShareManager(manager.SchedulerDependentManager):
                 ctxt, share_instance['id'], with_share_data=True)
             share_instance_dict = self._get_share_instance_dict(
                 ctxt, share_instance)
+            if metadata:
+                share_instance_dict.update({'metadata': metadata})
             update_share_instances.append(share_instance_dict)
 
         if update_share_instances:


### PR DESCRIPTION
The snapshot_policy if set in share metadata would be given higher preference over share type extra-spec provided snapshot_policy. Also this will override the snapshot_policy exceptions.

Change-Id: I7731cb7a32e0bd5418a8158350d56eefa69a5db4