### PR TITLE
NetApp: Add min-throughput for QoS policy group create/modify

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -5942,6 +5942,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                     'policy-group': None,
                     'vserver': None,
                     'max-throughput': None,
+                    'min-throughput': None,
                     'num-workloads': None
                 },
             },
@@ -5975,6 +5976,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'vserver': qos_policy_group_info.get_child_content('vserver'),
             'max-throughput': qos_policy_group_info.get_child_content(
                 'max-throughput'),
+            'min-throughput': qos_policy_group_info.get_child_content(
+                'min-throughput'),
             'num-workloads': int(qos_policy_group_info.get_child_content(
                 'num-workloads')),
         }
@@ -5982,7 +5985,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
     @na_utils.trace
     def qos_policy_group_create(self, qos_policy_group_name, vserver,
-                                max_throughput=None):
+                                max_throughput=None, min_throughput=None):
         """Creates a QoS policy group."""
         api_args = {
             'policy-group': qos_policy_group_name,
@@ -5990,15 +5993,21 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         }
         if max_throughput:
             api_args['max-throughput'] = max_throughput
+        if min_throughput:
+            api_args['min-throughput'] = min_throughput
         return self.send_request('qos-policy-group-create', api_args, False)
 
     @na_utils.trace
-    def qos_policy_group_modify(self, qos_policy_group_name, max_throughput):
+    def qos_policy_group_modify(self, qos_policy_group_name, max_throughput,
+                                min_throughput):
         """Modifies a QoS policy group."""
         api_args = {
             'policy-group': qos_policy_group_name,
-            'max-throughput': max_throughput,
         }
+        if max_throughput:
+            api_args['max-throughput'] = max_throughput
+        if min_throughput:
+            api_args['min-throughput'] = min_throughput
         return self.send_request('qos-policy-group-modify', api_args, False)
 
     @na_utils.trace

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -702,7 +702,7 @@ class NetAppRestClient(object):
 
     @na_utils.trace
     def qos_policy_group_create(self, qos_policy_group_name, vserver,
-                                max_throughput=None):
+                                max_throughput=None, min_throughput=None):
         """Creates a QoS policy group."""
 
         body = {
@@ -719,6 +719,17 @@ class NetAppRestClient(object):
                 value = value.replace('b/s', '')
                 value = int(value)
                 body['fixed.max_throughput_mbps'] = math.ceil(value /
+                                                              units.Mi)
+        if min_throughput:
+            value = min_throughput.lower()
+            if 'iops' in min_throughput:
+                value = value.replace('iops', '')
+                value = int(value)
+                body['fixed.min_throughput_iops'] = value
+            else:
+                value = value.replace('b/s', '')
+                value = int(value)
+                body['fixed.min_throughput_mbps'] = math.ceil(value /
                                                               units.Mi)
         return self.send_request('/storage/qos/policies', 'post',
                                  body=body)
@@ -1683,7 +1694,8 @@ class NetAppRestClient(object):
         query = {
             'name': qos_policy_group_name,
             'fields': 'name,object_count,fixed.max_throughput_iops,'
-                      'fixed.max_throughput_mbps,svm.name',
+                      'fixed.max_throughput_mbps,svm.name,'
+                      'fixed.min_throughput_iops,fixed.min_throughput_mbps',
         }
         try:
             res = self.send_request('/storage/qos/policies', 'get',
@@ -1708,18 +1720,29 @@ class NetAppRestClient(object):
             'num-workloads': int(qos_policy_group_info.get('object_count')),
         }
 
-        iops = qos_policy_group_info.get('fixed', {}).get(
+        max_iops = qos_policy_group_info.get('fixed', {}).get(
             'max_throughput_iops')
-        mbps = qos_policy_group_info.get('fixed', {}).get(
+        max_mbps = qos_policy_group_info.get('fixed', {}).get(
             'max_throughput_mbps')
 
-        if iops:
-            policy_info['max-throughput'] = f'{iops}iops'
-        elif mbps:
-            policy_info['max-throughput'] = f'{mbps * 1024 * 1024}b/s'
+        if max_iops:
+            policy_info['max-throughput'] = f'{max_iops}iops'
+        elif max_mbps:
+            policy_info['max-throughput'] = f'{max_mbps * 1024 * 1024}b/s'
         else:
             policy_info['max-throughput'] = None
 
+        min_iops = qos_policy_group_info.get('fixed', {}).get(
+            'min_throughput_iops')
+        min_mbps = qos_policy_group_info.get('fixed', {}).get(
+            'min_throughput_mbps')
+
+        if min_iops:
+            policy_info['min-throughput'] = f'{min_iops}iops'
+        elif min_mbps:
+            policy_info['min-throughput'] = f'{min_mbps * 1024 * 1024}b/s'
+        else:
+            policy_info['min-throughput'] = None
         return policy_info
 
     @na_utils.trace

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -128,11 +128,18 @@ class NetAppCmodeFileStorageLibrary(object):
         'compression': 'netapp:compression',
     }
 
-    QOS_SPECS = {
+    MAX_QOS_SPECS = {
         'netapp:maxiops': 'maxiops',
         'netapp:maxiopspergib': 'maxiopspergib',
         'netapp:maxbps': 'maxbps',
         'netapp:maxbpspergib': 'maxbpspergib',
+    }
+
+    MIN_QOS_SPECS = {
+        'netapp:miniops': 'miniops',
+        'netapp:miniopspergib': 'miniopspergib',
+        'netapp:minbps': 'minbps',
+        'netapp:minbpspergib': 'minxbpspergib',
     }
 
     HIDE_SNAPDIR_CFG_MAP = {
@@ -141,7 +148,9 @@ class NetAppCmodeFileStorageLibrary(object):
         'default': None,
     }
 
-    SIZE_DEPENDENT_QOS_SPECS = {'maxiopspergib', 'maxbpspergib'}
+    SIZE_DEPENDENT_QOS_SPECS = {
+        'maxiopspergib', 'maxbpspergib', 'miniopspergib', 'minbpspergib'
+    }
 
     # Maps the NFS config used by share-servers
     NFS_CONFIG_EXTRA_SPECS_MAP = {
@@ -1543,25 +1552,41 @@ class NetAppCmodeFileStorageLibrary(object):
         if not extra_specs.get('qos'):
             return {}
 
-        normalized_qos_specs = {
-            self.QOS_SPECS[key.lower()]: value
+        normalized_max_qos_specs = {
+            self.MAX_QOS_SPECS[key.lower()]: value
             for key, value in extra_specs.items()
-            if self.QOS_SPECS.get(key.lower())
+            if self.MAX_QOS_SPECS.get(key.lower())
         }
-        if not normalized_qos_specs:
+
+        normalized_min_qos_specs = {
+            self.MIN_QOS_SPECS[key.lower()]: value
+            for key, value in extra_specs.items()
+            if self.MIN_QOS_SPECS.get(key.lower())
+        }
+
+        if not (normalized_max_qos_specs or normalized_min_qos_specs):
             msg = _("The extra-spec 'qos' is set to True, but no netapp "
                     "supported qos-specs have been specified in the share "
                     "type. Cannot provision a QoS policy. Specify any of the "
-                    "following extra-specs and try again: %s")
-            raise exception.NetAppException(msg % list(self.QOS_SPECS))
+                    "following max-throughput extra-specs and/or any of the "
+                    "following min-throughput extras-specs and try again: %s")
+            specs = self.MAX_QOS_SPECS.copy()
+            specs.update(self.MIN_QOS_SPECS)
+            raise exception.NetAppException(msg % list(specs))
 
         # TODO(gouthamr): Modify check when throughput floors are allowed
-        if len(normalized_qos_specs) > 1:
-            msg = _('Only one NetApp QoS spec can be set at a time. '
-                    'Specified QoS limits: %s')
-            raise exception.NetAppException(msg % normalized_qos_specs)
+        if len(normalized_max_qos_specs) > 1:
+            msg = _('Only one NetApp max-throughput QoS spec can be set at a '
+                    'time. Specified QoS limits: %s')
+            raise exception.NetAppException(msg % normalized_max_qos_specs)
 
-        return normalized_qos_specs
+        if len(normalized_min_qos_specs) > 1:
+            msg = _('Only one NetApp min-throughput QoS spec can be set at a '
+                    'time. Specified QoS limits: %s')
+            raise exception.NetAppException(msg % normalized_min_qos_specs)
+
+        normalized_max_qos_specs.update(normalized_min_qos_specs)
+        return normalized_max_qos_specs
 
     def _get_max_throughput(self, share_size, qos_specs):
         # QoS limits are exclusive of one another.
@@ -1576,15 +1601,30 @@ class NetAppCmodeFileStorageLibrary(object):
             return '%sB/s' % str(
                 int(qos_specs['maxbpspergib']) * int(share_size))
 
+    def _get_min_throughput(self, share_size, qos_specs):
+        # QoS limits are exclusive of one another.
+        if 'miniops' in qos_specs:
+            return '%siops' % qos_specs['miniops']
+        elif 'miniopspergib' in qos_specs:
+            return '%siops' % str(
+                int(qos_specs['miniopspergib']) * int(share_size))
+        elif 'minbps' in qos_specs:
+            return '%sB/s' % qos_specs['minbps']
+        elif 'minbpspergib' in qos_specs:
+            return '%sB/s' % str(
+                int(qos_specs['minbpspergib']) * int(share_size))
+
     @na_utils.trace
     def _create_qos_policy_group(self, share, vserver, qos_specs,
                                  vserver_client=None):
         max_throughput = self._get_max_throughput(share['size'], qos_specs)
+        min_throughput = self._get_min_throughput(share['size'], qos_specs)
         qos_policy_group_name = self._get_backend_qos_policy_group_name(
             share['id'])
         client = vserver_client or self._client
         client.qos_policy_group_create(qos_policy_group_name, vserver,
-                                       max_throughput=max_throughput)
+                                       max_throughput=max_throughput,
+                                       min_throughput=min_throughput)
         return qos_policy_group_name
 
     @na_utils.trace
@@ -2506,8 +2546,10 @@ class NetAppCmodeFileStorageLibrary(object):
             if size_dependent_specs:
                 max_throughput = self._get_max_throughput(
                     new_size, size_dependent_specs)
+                min_throughput = self._get_min_throughput(
+                    new_size, size_dependent_specs)
                 self._client.qos_policy_group_modify(
-                    qos_policy_on_share, max_throughput)
+                    qos_policy_on_share, max_throughput, min_throughput)
 
     @na_utils.trace
     def extend_share(self, share, new_size, share_server=None):
@@ -3283,8 +3325,11 @@ class NetAppCmodeFileStorageLibrary(object):
                 else:
                     max_throughput = self._get_max_throughput(
                         new_active_replica['size'], qos_specs)
+                    min_throughput = self._get_min_throughput(
+                        new_active_replica['size'], qos_specs)
                     self._client.qos_policy_group_modify(
-                        new_active_replica_qos_policy, max_throughput)
+                        new_active_replica_qos_policy, max_throughput,
+                        min_throughput)
                 vserver_client.set_qos_policy_group_for_volume(
                     volume_name_on_backend, new_active_replica_qos_policy)
 
@@ -4119,11 +4164,15 @@ class NetAppCmodeFileStorageLibrary(object):
 
                 max_throughput = self._get_max_throughput(
                     backend_volume_size, qos_specs)
+                min_throughput = self._get_min_throughput(
+                    backend_volume_size, qos_specs)
                 if (existing_qos_policy_group['max-throughput']
-                        != max_throughput):
+                        != max_throughput or
+                    existing_qos_policy_group['min-throughput']
+                        != min_throughput):
                     self._client.qos_policy_group_modify(
                         backend_volume['qos-policy-group-name'],
-                        max_throughput)
+                        max_throughput, min_throughput)
                 self._client.qos_policy_group_rename(
                     backend_volume['qos-policy-group-name'],
                     qos_policy_group_name)

--- a/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
@@ -87,9 +87,13 @@ DELETED_EXPORT_POLICIES = {
 }
 QOS_POLICY_GROUP_NAME = 'fake_qos_policy_group_name'
 QOS_MAX_THROUGHPUT = '5000B/s'
+QOS_MIN_THROUGHPUT = '50B/s'
 QOS_MAX_THROUGHPUT_IOPS = '5000iops'
+QOS_MIN_THROUGHPUT_IOPS = '50iops'
 QOS_MAX_THROUGHPUT_NO_UNIT = 5000
+QOS_MIX_THROUGHPUT_NO_UNIT = 50
 QOS_MAX_THROUGHPUT_IOPS_NO_UNIT = 5000
+QOS_MIN_THROUGHPUT_IOPS_NO_UNIT = 50
 ADAPTIVE_QOS_POLICY_GROUP_NAME = 'fake_adaptive_qos_policy_group_name'
 VSERVER_TYPE_DEFAULT = 'default'
 VSERVER_TYPE_DP_DEST = 'dp_destination'
@@ -207,6 +211,7 @@ QOS_POLICY_GROUP = {
     'policy-group': QOS_POLICY_GROUP_NAME,
     'vserver': VSERVER_NAME,
     'max-throughput': QOS_MAX_THROUGHPUT,
+    'min-throughput': QOS_MIN_THROUGHPUT,
     'num-workloads': 1,
 }
 
@@ -2900,6 +2905,7 @@ QOS_POLICY_GROUP_GET_ITER_RESPONSE = etree.XML("""
     <attributes-list>
       <qos-policy-group-info>
         <max-throughput>%(max_throughput)s</max-throughput>
+        <min-throughput>%(min_throughput)s</min-throughput>
         <num-workloads>1</num-workloads>
         <policy-group>%(qos_policy_group_name)s</policy-group>
         <vserver>%(vserver)s</vserver>
@@ -2910,6 +2916,7 @@ QOS_POLICY_GROUP_GET_ITER_RESPONSE = etree.XML("""
     'qos_policy_group_name': QOS_POLICY_GROUP_NAME,
     'vserver': VSERVER_NAME,
     'max_throughput': QOS_MAX_THROUGHPUT,
+    'min_throughput': QOS_MIN_THROUGHPUT,
 })
 
 SNAPMIRROR_POLICY_GET_ITER_RESPONSE = etree.XML("""

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -7675,6 +7675,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
                     'policy-group': None,
                     'vserver': None,
                     'max-throughput': None,
+                    'min-throughput': None,
                     'num-workloads': None
                 },
             },
@@ -7702,6 +7703,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
                     'policy-group': None,
                     'vserver': None,
                     'max-throughput': None,
+                    'min-throughput': None,
                     'num-workloads': None
                 },
             },
@@ -7710,14 +7712,21 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'qos-policy-group-get-iter', qos_policy_group_get_iter_args, False)
         self.assertDictEqual(fake.QOS_POLICY_GROUP, qos_info)
 
-    @ddt.data(None, fake.QOS_MAX_THROUGHPUT)
-    def test_qos_policy_group_create(self, max_throughput):
+    @ddt.data(
+        {'max_throughput': None, 'min_throughput': None},
+        {'max_throughput': fake.QOS_MAX_THROUGHPUT, 'min_throughput': None},
+        {'max_throughput': None, 'min_throughput': fake.QOS_MIN_THROUGHPUT},
+        {'max_throughput': fake.QOS_MAX_THROUGHPUT,
+         'min_throughput': fake.QOS_MIN_THROUGHPUT})
+    @ddt.unpack
+    def test_qos_policy_group_create(self, max_throughput, min_throughput):
         self.mock_object(self.client, 'send_request',
                          mock.Mock(return_value=fake.PASSED_RESPONSE))
 
         self.client.qos_policy_group_create(
             fake.QOS_POLICY_GROUP_NAME, fake.VSERVER_NAME,
-            max_throughput=max_throughput)
+            max_throughput=max_throughput,
+            min_throughput=min_throughput)
 
         qos_policy_group_create_args = {
             'policy-group': fake.QOS_POLICY_GROUP_NAME,
@@ -7726,6 +7735,9 @@ class NetAppClientCmodeTestCase(test.TestCase):
         if max_throughput:
             qos_policy_group_create_args.update(
                 {'max-throughput': max_throughput})
+        if min_throughput:
+            qos_policy_group_create_args.update(
+                {'min-throughput': min_throughput})
 
         self.client.send_request.assert_called_once_with(
             'qos-policy-group-create', qos_policy_group_create_args, False)
@@ -7735,11 +7747,12 @@ class NetAppClientCmodeTestCase(test.TestCase):
                          mock.Mock(return_value=fake.PASSED_RESPONSE))
 
         self.client.qos_policy_group_modify(fake.QOS_POLICY_GROUP_NAME,
-                                            '3000iops')
+                                            '3000iops', '20iops')
 
         qos_policy_group_modify_args = {
             'policy-group': fake.QOS_POLICY_GROUP_NAME,
             'max-throughput': '3000iops',
+            'min-throughput': '20iops'
         }
 
         self.client.send_request.assert_called_once_with(

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -1587,18 +1587,22 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
         qos_policy = qos_policy_group.get('records')[0]
         max_throughput = qos_policy.get('fixed',
                                         {}).get('max_throughput_iops')
+        min_throughput = qos_policy.get('fixed',
+                                        {}).get('min_throughput_iops')
 
         expected = {
             'policy-group': qos_policy.get('name'),
             'vserver': qos_policy.get('svm', {}).get('name'),
             'max-throughput': max_throughput if max_throughput else None,
+            'min-throughput': min_throughput if min_throughput else None,
             'num-workloads': int(qos_policy.get('object_count')),
         }
 
         query = {
             'name': qos_policy_group_name,
             'fields': 'name,object_count,fixed.max_throughput_iops,' +
-                      'fixed.max_throughput_mbps,svm.name'
+                      'fixed.max_throughput_mbps,svm.name,' +
+                      'fixed.min_throughput_iops,fixed.min_throughput_mbps'
         }
 
         mock_sr = self.mock_object(self.client, 'send_request',

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -2001,7 +2001,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         expected_policy_name = 'qos_share_' + fake.SHARE['id'].replace(
             '-', '_')
         mock_qos_policy_create.assert_called_once_with(
-            expected_policy_name, fake.VSERVER1, max_throughput='3000iops')
+            expected_policy_name, fake.VSERVER1, max_throughput='3000iops',
+            min_throughput=None)
 
     def test_check_if_max_files_is_valid_with_negative_integer(self):
         self.assertRaises(exception.NetAppException,
@@ -3496,7 +3497,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         share_types.get_extra_specs_from_share.assert_called_once_with(
             fake.SHARE)
         self.library._client.qos_policy_group_modify.assert_called_once_with(
-            fake.QOS_POLICY_GROUP_NAME, expected_max_throughput)
+            fake.QOS_POLICY_GROUP_NAME, expected_max_throughput, None)
 
     def test_extend_share(self):
 
@@ -4843,7 +4844,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             (self.mock_dm_session.remove_qos_on_old_active_replica.
                 assert_not_called())
         self.library._client.qos_policy_group_modify.assert_called_once_with(
-            'qos_' + volume_name_on_backend, '3000iops')
+            'qos_' + volume_name_on_backend, '3000iops', None)
         vserver_client.set_qos_policy_group_for_volume.assert_called_once_with(
             volume_name_on_backend, 'qos_' + volume_name_on_backend)
         self.library._create_qos_policy_group.assert_not_called()
@@ -6927,11 +6928,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.assertEqual(new_qos_policy_name, retval)
         if num_workloads == 1:
             mock_create_qos_policy.assert_not_called()
-            if qos_iops_change:
-                mock_qos_policy_modify.assert_called_once_with(
-                    fake.QOS_POLICY_GROUP_NAME, expected_iops + 'iops')
-            else:
-                mock_qos_policy_modify.assert_not_called()
+            mock_qos_policy_modify.assert_called_once_with(
+                fake.QOS_POLICY_GROUP_NAME, expected_iops + 'iops', None)
 
             mock_qos_policy_rename.assert_called_once_with(
                 fake.QOS_POLICY_GROUP_NAME, new_qos_policy_name)

--- a/manila/tests/share/drivers/netapp/dataontap/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/fakes.py
@@ -248,6 +248,7 @@ QOS_POLICY_GROUP = {
     'policy-group': QOS_POLICY_GROUP_NAME,
     'vserver': VSERVER1,
     'max-throughput': '3000iops',
+    'min-throughput': '20iops',
     'num-workloads': 1,
 }
 

--- a/releasenotes/notes/Add-min-throughput-for-QoS-policy-group-create-and-modify-c03ca15b5b53bd24.yaml
+++ b/releasenotes/notes/Add-min-throughput-for-QoS-policy-group-create-and-modify-c03ca15b5b53bd24.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    NetApp ONTAP driver is updated to consider min-throughput while creating
+    and modifying QoS policy. This parameter is considered only when admin has
+    configured it via share-type extra-specs. The extra-specs should have only
+    any single key from the list of ['netapp:miniops', 'netapp:miniopspergib',
+    'netapp:minbps', 'netapp:minbpspergib'].


### PR DESCRIPTION
With QoS policy, admin can control a certain quality (minimum and maximum level) to be sureto know what to expect. Similar to max_throughput, share-type extra-spec needs to update to consider min_throughput. It can be specified using any single key from list of ['netapp:miniops', 'netapp:miniopspergib', 'netapp:minbps', 'netapp:minbpspergib'].

Closes-bug: #2111273
Change-Id: Iae14f7948629e7b77a93fc62d95b6cfd7346cb6e