### PR TITLE
Skip snapmirror schedule if set in share metadata

### DIFF
--- a/manila/share/driver.py
+++ b/manila/share/driver.py
@@ -2173,7 +2173,8 @@ class ShareDriver(object):
 
     def update_replica_state(self, context, replica_list, replica,
                              access_rules, replica_snapshots,
-                             share_server=None):
+                             share_server=None,
+                             skip_conf_snapmirror_schedule=False):
         """Update the replica_state of a replica.
 
         .. note::
@@ -2300,6 +2301,9 @@ class ShareDriver(object):
              ]
 
         :param share_server: <models.ShareServer> or None
+        :param: skip_conf_snapmirror_schedule: True or False
+            Default to False, Setting to True, the driver will skip the
+            snapmirror schedule defined in conf file.
         :return: replica_state: a str value denoting the replica_state.
             Valid values are 'in_sync' and 'out_of_sync' or None (to leave the
             current replica_state unchanged).

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/drv_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/drv_multi_svm.py
@@ -160,11 +160,14 @@ class NetAppCmodeMultiSvmShareDriver(driver.ShareDriver):
 
     def update_replica_state(self, context, replica_list, replica,
                              access_rules, replica_snapshots,
-                             share_server=None):
-        return self.library.update_replica_state(context, replica_list,
-                                                 replica, access_rules,
-                                                 replica_snapshots,
-                                                 share_server)
+                             share_server=None,
+                             skip_conf_snapmirror_schedule=False):
+        return self.library.update_replica_state(
+            context, replica_list,
+            replica, access_rules,
+            replica_snapshots,
+            share_server,
+            skip_conf_snapmirror_schedule=skip_conf_snapmirror_schedule)
 
     def create_replicated_snapshot(self, context, replica_list,
                                    replica_snapshots, share_server=None):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/drv_single_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/drv_single_svm.py
@@ -151,13 +151,16 @@ class NetAppCmodeSingleSvmShareDriver(driver.ShareDriver):
 
     def update_replica_state(self, context, replica_list, replica,
                              access_rules, replica_snapshots,
-                             share_server=None):
-        return self.library.update_replica_state(context,
-                                                 replica_list,
-                                                 replica,
-                                                 access_rules,
-                                                 replica_snapshots,
-                                                 share_server=share_server)
+                             share_server=None,
+                             skip_conf_snapmirror_schedule=False):
+        return self.library.update_replica_state(
+            context,
+            replica_list,
+            replica,
+            access_rules,
+            replica_snapshots,
+            share_server=share_server,
+            skip_conf_snapmirror_schedule=skip_conf_snapmirror_schedule)
 
     def create_replicated_snapshot(self, context, replica_list,
                                    replica_snapshots, share_server=None):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -1094,6 +1094,7 @@ class NetAppCmodeFileStorageLibrary(object):
                 [],  # access_rules
                 [],  # snapshot list
                 share_server,
+                skip_conf_snapmirror_schedule=False,
                 replication=False)
             if replica_state in [None, constants.STATUS_ERROR]:
                 msg = _("Destination share has failed on replicating data "
@@ -2997,6 +2998,7 @@ class NetAppCmodeFileStorageLibrary(object):
 
     def update_replica_state(self, context, replica_list, replica,
                              access_rules, share_snapshots, share_server=None,
+                             skip_conf_snapmirror_schedule=False,
                              replication=True):
         """Returns the status of the given replica on this backend."""
         active_replica = self.find_active_replica(replica_list)
@@ -3067,19 +3069,20 @@ class NetAppCmodeFileStorageLibrary(object):
                 LOG.exception("Could not resync snapmirror.")
                 return constants.STATUS_ERROR
 
-        # Enforce the SnapMirror schedule to match the configuration
-        current_schedule = snapmirror.get('schedule')
-        target_schedule = self.configuration.netapp_snapmirror_schedule
-        if current_schedule != target_schedule:
-            LOG.debug(
-                'Modify snapmirror schedule for replica: '
-                '%(replica)s from %(from)s to %(to)s', {
-                    'replica': replica['id'],
-                    'from': current_schedule,
-                    'to': target_schedule
-                })
-            dm_session.modify_snapmirror(active_replica, replica,
-                                         schedule=target_schedule)
+        if skip_conf_snapmirror_schedule is False:
+            # Enforce the SnapMirror schedule to match the configuration
+            current_schedule = snapmirror.get('schedule')
+            target_schedule = self.configuration.netapp_snapmirror_schedule
+            if current_schedule != target_schedule:
+                LOG.debug(
+                    'Modify snapmirror schedule for replica: '
+                    '%(replica)s from %(from)s to %(to)s', {
+                        'replica': replica['id'],
+                        'from': current_schedule,
+                        'to': target_schedule
+                        })
+                dm_session.modify_snapmirror(active_replica, replica,
+                                             schedule=target_schedule)
 
         last_update_timestamp = float(
             snapmirror.get('last-transfer-end-timestamp', 0))

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2950,9 +2950,15 @@ class ShareManager(manager.SchedulerDependentManager):
         share_replica = self._get_share_instance_dict(context, share_replica)
 
         try:
+            metadata = self.db.share_metadata_get(
+                context, share_replica['share_id'])
+            skip_conf_snapmirror_schedule = False
+            if 'snapmirror_schedule' in metadata:
+                skip_conf_snapmirror_schedule = True
             replica_state = self.driver.update_replica_state(
                 context, replica_list, share_replica, access_rules,
-                available_share_snapshots, share_server=share_server)
+                available_share_snapshots, share_server=share_server,
+                skip_conf_snapmirror_schedule=skip_conf_snapmirror_schedule)
         except Exception as excep:
             msg = ("Driver error when updating replica "
                    "state for replica %s.")

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -1438,6 +1438,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         self.mock_update_rep_state.assert_called_once_with(
             None, [self.fake_src_share], fake.SHARE, [], [], fake.SHARE_SERVER,
+            skip_conf_snapmirror_schedule=False,
             replication=False
         )
         self.assertEqual(is_flexgroup,

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -1795,6 +1795,7 @@ class ShareManagerTestCase(test.TestCase):
                          mock.Mock(return_value=[replica, active_replica]))
         self.mock_object(db, 'share_server_get',
                          mock.Mock(return_value=fakes.fake_share_server_get()))
+        self.mock_object(db, 'share_metadata_get', mock.Mock(return_value=[]))
         mock_db_update_calls = []
         self.mock_object(self.share_manager.db, 'share_replica_get',
                          mock.Mock(return_value=replica))


### PR DESCRIPTION
if key 'snapmirror_schedule' exist in share metadata, then during replica update/resync, the conf option of netapp snamirror schedule will be ignored. Thus Manila will prevent the schedule from revert.

Note - The value of key 'snapmirror_schedule' will be ignored for now.

Change-Id: I9dc21b9a8ca89644bf9f89e65e8d54f8e142d2dc