### PR TITLE
Implement external scheduler call to cortex

### DIFF
--- a/manila/scheduler/drivers/external.py
+++ b/manila/scheduler/drivers/external.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2025 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+This module provides functionality to interact with an external scheduler API
+to reorder and filter hosts based on additional criteria.
+
+The external scheduler API is expected to take a list of weighed hosts and
+their weights, along with the request specification, and return a reordered
+and filtered list of host names.
+"""
+import jsonschema
+from oslo_config import cfg
+from oslo_log import log as logging
+import requests
+
+LOG = logging.getLogger(__name__)
+
+CONF = cfg.CONF
+CONF.register_opts([
+    cfg.StrOpt(
+        "external_scheduler_api_url",
+        default="",
+        help="""
+The API URL of the external scheduler.
+
+If this URL is provided, Manila will call an external service after filters
+and weighers have been applied. This service can reorder and filter the
+list of hosts before Manila attempts to place the share.
+
+If not provided, this step will be skipped.
+"""),
+    cfg.IntOpt(
+        "external_scheduler_timeout",
+        default=10,
+        min=1,
+        help="""
+The timeout in seconds for the external scheduler.
+
+If external_scheduler_api_url is configured, Manila will call and wait for the
+external scheduler to respond for this long. If the external scheduler does not
+respond within this time, the request will be aborted. In this case, the
+scheduler will continue with the original host selection and weights.
+""")
+])
+
+# The expected response schema from the external scheduler api.
+# The response should contain a list of ordered host names.
+RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "hosts": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": ["hosts"],
+    "additionalProperties": False,
+}
+
+
+def call_external_scheduler_api(context, weighed_hosts, spec_dict):
+    """Reorder and filter hosts using an external scheduler service.
+
+    :param context: The RequestContext object containing request id, user, etc.
+    :param weighed_hosts: List of w. hosts to send to the external scheduler.
+    :param spec_dict: The RequestSpec object with the vm specification.
+    """
+    if not weighed_hosts:
+        return weighed_hosts
+    if not (url := CONF.external_scheduler_api_url):
+        LOG.debug("External scheduler API is not enabled.")
+        return weighed_hosts
+    timeout = CONF.external_scheduler_timeout
+
+    json_data = {
+        "spec": spec_dict,
+        # Also serialize the request context, which contains the global request
+        # id and other information helpful for logging and request tracing.
+        "context": context.to_dict(),
+        # Only provide basic information for the hosts for now.
+        # The external scheduler is expected to fetch statistics
+        # about the hosts separately, so we don't need to pass
+        # them here.
+        "hosts": [
+            {
+                "host": h.obj.host,
+            } for h in weighed_hosts
+        ],
+        # Also pass previous weights from the Manila weigher pipeline.
+        # The external scheduler api is expected to take these weights
+        # into account if provided.
+        "weights": [
+            {
+                "host": h.obj.host,
+                "weight": h.weight,
+            } for h in weighed_hosts
+        ],
+    }
+    LOG.debug("Calling external scheduler API with %s", json_data)
+    try:
+        response = requests.post(url, json=json_data, timeout=timeout)
+        response.raise_for_status()
+        # If the JSON parsing fails, this will also raise a RequestException.
+        response_json = response.json()
+    except requests.RequestException as e:
+        LOG.error("Failed to call external scheduler API: %s", e)
+        return weighed_hosts
+
+    # The external scheduler api is expected to return a json with
+    # a sorted list of host names. Note that no weights are returned.
+    try:
+        jsonschema.validate(response_json, RESPONSE_SCHEMA)
+    except jsonschema.ValidationError as e:
+        LOG.error("External scheduler response is invalid: %s", e)
+        return weighed_hosts
+
+    # The list of host names can also be empty. In this case, we trust
+    # the external scheduler decision and return an empty list.
+    if not (host_names := response_json["hosts"]):
+        # If this case happens often, it may indicate an issue.
+        LOG.warning("External scheduler filtered out all hosts.")
+
+    # Reorder the weighed hosts based on the list of host names returned
+    # by the external scheduler api.
+    weighed_hosts_dict = {h.obj.host: h for h in weighed_hosts}
+    return [weighed_hosts_dict[h] for h in host_names]

--- a/manila/scheduler/drivers/external.py
+++ b/manila/scheduler/drivers/external.py
@@ -103,12 +103,7 @@ def call_external_scheduler_api(context, weighed_hosts, spec_dict):
         # Also pass previous weights from the Manila weigher pipeline.
         # The external scheduler api is expected to take these weights
         # into account if provided.
-        "weights": [
-            {
-                "host": h.obj.host,
-                "weight": h.weight,
-            } for h in weighed_hosts
-        ],
+        "weights": {h.obj.host: h.weight for h in weighed_hosts},
     }
     LOG.debug("Calling external scheduler API with %s", json_data)
     try:

--- a/manila/scheduler/drivers/external.py
+++ b/manila/scheduler/drivers/external.py
@@ -43,7 +43,7 @@ If not provided, this step will be skipped.
 """),
     cfg.IntOpt(
         "external_scheduler_timeout",
-        default=10,
+        default=5,
         min=1,
         help="""
 The timeout in seconds for the external scheduler.
@@ -77,7 +77,7 @@ def call_external_scheduler_api(context, weighed_hosts, spec_dict):
 
     :param context: The RequestContext object containing request id, user, etc.
     :param weighed_hosts: List of w. hosts to send to the external scheduler.
-    :param spec_dict: The RequestSpec object with the vm specification.
+    :param spec_dict: The RequestSpec object with the share specification.
     """
     if not weighed_hosts:
         return weighed_hosts
@@ -85,12 +85,15 @@ def call_external_scheduler_api(context, weighed_hosts, spec_dict):
         LOG.debug("External scheduler API is not enabled.")
         return weighed_hosts
     timeout = CONF.external_scheduler_timeout
-
+    # We shouldn't pass and log the auth token. Thus, we delete it here.
+    ctx_dict = context.to_dict()
+    if "auth_token" in ctx_dict:
+        del ctx_dict["auth_token"]
     json_data = {
         "spec": spec_dict,
         # Also serialize the request context, which contains the global request
         # id and other information helpful for logging and request tracing.
-        "context": context.to_dict(),
+        "context": ctx_dict,
         # Only provide basic information for the hosts for now.
         # The external scheduler is expected to fetch statistics
         # about the hosts separately, so we don't need to pass

--- a/manila/scheduler/drivers/filter.py
+++ b/manila/scheduler/drivers/filter.py
@@ -267,7 +267,8 @@ class FilterScheduler(base.Scheduler):
             context, weighed_hosts, request_spec)
         if not weighed_hosts:
             msg = "No valid hosts found after calling external scheduler API."
-            raise exception.NoValidHost(reason=msg)
+            detail_data = {'last_filter': 'call_external_scheduler_api'}
+            raise exception.NoValidHost(reason=msg, detail_data=detail_data)
 
         best_host = weighed_hosts[0]
         LOG.debug("Choosing for share: %(best_host)s",

--- a/manila/scheduler/drivers/filter.py
+++ b/manila/scheduler/drivers/filter.py
@@ -29,6 +29,7 @@ from manila.i18n import _
 from manila.message import api as message_api
 from manila.message import message_field
 from manila.scheduler.drivers import base
+from manila.scheduler.drivers.external import call_external_scheduler_api
 from manila.scheduler import scheduler_options
 from manila.share import share_types
 
@@ -259,6 +260,15 @@ class FilterScheduler(base.Scheduler):
         # host for the job.
         weighed_hosts = self.host_manager.get_weighed_hosts(hosts,
                                                             filter_properties)
+
+        # Call an external service that can modify `weighed_hosts` once more.
+        # This service may filter out some hosts, or it may re-order them.
+        weighed_hosts = call_external_scheduler_api(
+            context, weighed_hosts, request_spec)
+        if not weighed_hosts:
+            msg = "No valid hosts found after calling external scheduler API."
+            raise exception.NoValidHost(reason=msg)
+
         best_host = weighed_hosts[0]
         LOG.debug("Choosing for share: %(best_host)s",
                   {"best_host": best_host})

--- a/manila/tests/scheduler/drivers/test_external.py
+++ b/manila/tests/scheduler/drivers/test_external.py
@@ -44,17 +44,7 @@ REQUEST_SCHEMA = {
                 "required": ["host"],
             },
         },
-        "weights": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "host": {"type": "string"},
-                    "weight": {"type": "number"},
-                },
-                "required": ["host", "weight"],
-            },
-        },
+        "weights": {"type": "object"},
     },
     "required": ["spec", "context", "hosts", "weights"],
     "additionalProperties": False,

--- a/manila/tests/scheduler/drivers/test_external.py
+++ b/manila/tests/scheduler/drivers/test_external.py
@@ -55,10 +55,10 @@ class ExternalSchedulerAPITestCase(test_base.SchedulerTestCase):
     def setUp(self):
         super(ExternalSchedulerAPITestCase, self).setUp()
         self.flags(external_scheduler_api_url='http://127.0.0.1:1234')
-        self.flags(external_scheduler_timeout=10)
-        self.h1 = fakes.FakeHostState('host1', {'cell_uuid': 'i-dont-matter'})
-        self.h2 = fakes.FakeHostState('host2', {'cell_uuid': 'i-dont-matter'})
-        self.h3 = fakes.FakeHostState('host3', {'cell_uuid': 'i-dont-matter'})
+        self.flags(external_scheduler_timeout=5)
+        self.h1 = fakes.FakeHostState('host1', {})
+        self.h2 = fakes.FakeHostState('host2', {})
+        self.h3 = fakes.FakeHostState('host3', {})
         self.example_weighed_hosts = [
             WeighedObject(self.h1, 1.0),
             WeighedObject(self.h2, 0.5),
@@ -80,7 +80,7 @@ class ExternalSchedulerAPITestCase(test_base.SchedulerTestCase):
     def _check_request(self, response=None):
         """Utility to check the request for validity."""
         def wrapped(url, json, timeout):
-            self.assertEqual(timeout, 10)  # should be the default timeout
+            self.assertEqual(timeout, 5)  # should be the default timeout
             self.assertEqual(url, 'http://127.0.0.1:1234')
             try:
                 jsonschema.validate(json, REQUEST_SCHEMA)

--- a/manila/tests/scheduler/drivers/test_external.py
+++ b/manila/tests/scheduler/drivers/test_external.py
@@ -113,8 +113,16 @@ class ExternalSchedulerAPITestCase(test_base.SchedulerTestCase):
             'global_request_id', kwargs['json']['context'],
             'Global request ID should be included in the context'
         )
+        # The auth_token should be excluded from the context
+        self.assertNotIn(
+            'auth_token', kwargs['json']['context'],
+            'Auth token should not be included in the context'
+        )
+        expected_dict = self.example_ctx.to_dict()
+        del expected_dict['auth_token']
+        # Check that the context is serialized correctly
         self.assertEqual(
-            self.example_ctx.to_dict(),
+            expected_dict,
             kwargs['json']['context'],
             'Context should be serialized correctly'
         )

--- a/manila/tests/scheduler/drivers/test_external.py
+++ b/manila/tests/scheduler/drivers/test_external.py
@@ -1,0 +1,285 @@
+# Copyright 2025 SAP SE or an SAP affiliate company.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Tests for the external scheduler api call.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import jsonschema
+import requests
+
+from manila import context
+from manila.scheduler.drivers.external import call_external_scheduler_api
+from manila.scheduler.weighers.base import WeighedObject
+from manila.tests.scheduler.drivers import test_base
+from manila.tests.scheduler import fakes
+
+# The expected request schema for the external scheduler API.
+# It should contain the spec, hosts, and weights.
+REQUEST_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "spec": {"type": "object"},
+        "context": {"type": "object"},
+        "hosts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "host": {"type": "string"},
+                },
+                "required": ["host"],
+            },
+        },
+        "weights": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "host": {"type": "string"},
+                    "weight": {"type": "number"},
+                },
+                "required": ["host", "weight"],
+            },
+        },
+    },
+    "required": ["spec", "context", "hosts", "weights"],
+    "additionalProperties": False,
+}
+
+
+class ExternalSchedulerAPITestCase(test_base.SchedulerTestCase):
+    def setUp(self):
+        super(ExternalSchedulerAPITestCase, self).setUp()
+        self.flags(external_scheduler_api_url='http://127.0.0.1:1234')
+        self.flags(external_scheduler_timeout=10)
+        self.h1 = fakes.FakeHostState('host1', {'cell_uuid': 'i-dont-matter'})
+        self.h2 = fakes.FakeHostState('host2', {'cell_uuid': 'i-dont-matter'})
+        self.h3 = fakes.FakeHostState('host3', {'cell_uuid': 'i-dont-matter'})
+        self.example_weighed_hosts = [
+            WeighedObject(self.h1, 1.0),
+            WeighedObject(self.h2, 0.5),
+            WeighedObject(self.h3, 0.0),
+        ]
+        self.example_spec = {
+            'share_type': {'name': 'NFS'},
+            'share_properties': {'project_id': 1, 'size': 1},
+            'share_instance_properties': {},
+        }
+        self.example_ctx = context.RequestContext(
+            user_id='fake_user',
+            project_id='fake_project',
+            is_admin=True,
+            read_deleted='no',
+            global_request_id='fake_global_request_id',
+        )
+
+    def _check_request(self, response=None):
+        """Utility to check the request for validity."""
+        def wrapped(url, json, timeout):
+            self.assertEqual(timeout, 10)  # should be the default timeout
+            self.assertEqual(url, 'http://127.0.0.1:1234')
+            try:
+                jsonschema.validate(json, REQUEST_SCHEMA)
+            except jsonschema.ValidationError as e:
+                msg = f"Request JSON schema validation failed: {e.message}"
+                self.fail(msg)
+            return response or MagicMock()
+        return wrapped
+
+    @patch('requests.post')
+    def test_context_included_in_request(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': ['host1', 'host3']}
+        mock_post.side_effect = self._check_request(mock_response)
+
+        call_external_scheduler_api(
+            self.example_ctx,
+            self.example_weighed_hosts,
+            self.example_spec,
+        )
+
+        # Check that the context is serialized and included in the request
+        _, kwargs = mock_post.call_args
+        self.assertIn(
+            'context', kwargs['json'],
+            'Context should be included in the request'
+        )
+        self.assertIn(
+            'global_request_id', kwargs['json']['context'],
+            'Global request ID should be included in the context'
+        )
+        self.assertEqual(
+            self.example_ctx.to_dict(),
+            kwargs['json']['context'],
+            'Context should be serialized correctly'
+        )
+
+    @patch('requests.post')
+    @patch('manila.scheduler.drivers.external.LOG.debug')
+    def test_enabled_api_success(self, mock_debug_log, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': ['host1', 'host3']}
+        mock_post.side_effect = self._check_request(mock_response)
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_debug_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_weighed_hosts,
+            self.example_spec,
+        )
+        self.assertEqual(
+            ['host1', 'host3'],
+            [h.obj.host for h in hosts]
+        )
+        self.assertIn('Calling external scheduler API with ', log)
+
+    @patch('requests.post')
+    @patch('manila.scheduler.drivers.external.LOG.warning')
+    def test_enabled_api_empty_response(self, mock_warn_log, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': []}
+        mock_post.side_effect = self._check_request(mock_response)
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_weighed_hosts,
+            self.example_spec,
+        )
+        self.assertEqual([], hosts)
+        mock_warn_log.assert_called_with(
+            'External scheduler filtered out all hosts.'
+        )
+
+    @patch('requests.post')
+    @patch('manila.scheduler.drivers.external.LOG.error')
+    def test_enabled_api_timeout(self, mock_err_log, mock_post):
+        mock_post.side_effect = requests.exceptions.Timeout
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_weighed_hosts,
+            self.example_spec,
+        )
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.obj.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API: ', log)
+
+    @patch('requests.post')
+    @patch('manila.scheduler.drivers.external.LOG.error')
+    def test_enabled_api_invalid_response(self, mock_err_log, mock_post):
+        invalid_response_dicts = [
+            {},
+            {"hosts": "not a list"},
+            {"hosts": [1, 2, "host1"]},
+            {"hosts": [{"name": "host1", "status": "up"}]},
+        ]
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        for response_dict in invalid_response_dicts:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = response_dict
+            mock_post.side_effect = self._check_request(mock_response)
+
+            hosts = call_external_scheduler_api(
+                self.example_ctx,
+                self.example_weighed_hosts,
+                self.example_spec,
+            )
+            # Should fallback to the original host list.
+            self.assertEqual(
+                ['host1', 'host2', 'host3'],
+                [h.obj.host for h in hosts]
+            )
+            self.assertIn('External scheduler response is invalid: ', log)
+
+    @patch('requests.post')
+    @patch('manila.scheduler.drivers.external.LOG.error')
+    def test_enabled_api_json_decode_err(self, mock_err_log, mock_post):
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        # Note: requests.exceptions.InvalidJSONError is also a RequestException
+        mock_response.json.side_effect = requests.exceptions.InvalidJSONError
+        mock_post.side_effect = self._check_request(mock_response)
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_weighed_hosts,
+            self.example_spec,
+        )
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.obj.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API: ', log)
+
+    @patch('requests.post')
+    @patch('manila.scheduler.drivers.external.LOG.error')
+    def test_enabled_api_error_reply(self, mock_err_log, mock_post):
+        mock_post.side_effect = requests.exceptions.HTTPError
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_weighed_hosts,
+            self.example_spec,
+        )
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.obj.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API: ', log)

--- a/manila/tests/scheduler/drivers/test_filter.py
+++ b/manila/tests/scheduler/drivers/test_filter.py
@@ -188,8 +188,8 @@ class FilterSchedulerTestCase(test_base.SchedulerTestCase):
     def test__schedule_share_external_scheduler_disabled(self, mock_post):
         """Tests that the external scheduler is not called when disabled."""
         sched = fakes.FakeFilterScheduler()
-        h1 = fakes.FakeHostState('host1', {'cell_uuid': 'i-dont-matter'})
-        h2 = fakes.FakeHostState('host2', {'cell_uuid': 'i-dont-matter'})
+        h1 = fakes.FakeHostState('host1', {})
+        h2 = fakes.FakeHostState('host2', {})
         for h in (h1, h2):
             m = mock.Mock(return_value=None)
             self.mock_object(h, 'consume_from_share', m)

--- a/manila/tests/scheduler/drivers/test_filter.py
+++ b/manila/tests/scheduler/drivers/test_filter.py
@@ -28,6 +28,7 @@ from manila.message import message_field
 from manila.scheduler.drivers import base
 from manila.scheduler.drivers import filter
 from manila.scheduler import host_manager
+from manila.scheduler.weighers.base import WeighedObject
 from manila.tests.scheduler.drivers import test_base
 from manila.tests.scheduler import fakes
 
@@ -182,6 +183,35 @@ class FilterSchedulerTestCase(test_base.SchedulerTestCase):
         self.assertRaises(exception.NoValidHost, sched.schedule_create_share,
                           fake_context, request_spec, {})
         self.assertTrue(self.was_admin)
+
+    @mock.patch('requests.post')
+    def test__schedule_share_external_scheduler_disabled(self, mock_post):
+        """Tests that the external scheduler is not called when disabled."""
+        sched = fakes.FakeFilterScheduler()
+        h1 = fakes.FakeHostState('host1', {'cell_uuid': 'i-dont-matter'})
+        h2 = fakes.FakeHostState('host2', {'cell_uuid': 'i-dont-matter'})
+        for h in (h1, h2):
+            m = mock.Mock(return_value=None)
+            self.mock_object(h, 'consume_from_share', m)
+        self.mock_object(
+            sched.host_manager, 'get_filtered_hosts',
+            mock.Mock(return_value=[h1, h2]),
+        )
+        wh1 = WeighedObject(h1, 1.0)
+        wh2 = WeighedObject(h2, 1.0)
+        self.mock_object(
+            sched.host_manager, 'get_weighed_hosts',
+            mock.Mock(return_value=[wh1, wh2]),
+        )
+        ctx = context.RequestContext('user', 'project', is_admin=True)
+        spec = {
+            'share_type': {'name': 'NFS'},
+            'share_properties': {'project_id': 1, 'size': 1},
+            'share_instance_properties': {},
+        }
+        self.flags(external_scheduler_api_url='')
+        _ = sched._schedule_share(ctx, spec, {})
+        mock_post.assert_not_called()
 
     @ddt.data(
         {'name': 'foo'},


### PR DESCRIPTION
Provides support for an external service that can perform advanced scheduling
decisions. FilterScheduler now calls a function call_external_scheduler_api
after executing filters and weighers. This function sends the hosts and their
current weights to an external scheduling service. This service then performs
advanced scheduling decisions and returns the sorted list of host names, from
highest priority to lowest priority. To toggle this feature, provide
external_scheduler_api_url to Manila's configuration.

See also: https://github.com/sapcc/nova/pull/502