### PR TITLE
Enable all_squash for nfs

### DIFF
--- a/manila/share/access.py
+++ b/manila/share/access.py
@@ -347,6 +347,12 @@ class ShareInstanceAccess(ShareInstanceAccessDatabaseMixin):
             update_rules = []
 
         try:
+            share_instance = share_instance.to_dict()
+            metadata = self.db.share_metadata_get(
+                context, share_instance['share_id'])
+            if metadata:
+                share_instance.update({'metadata': metadata})
+
             driver_rule_updates = self._update_rules_through_share_driver(
                 context, share_instance, access_rules_on_share,
                 add_rules, delete_rules, update_rules,

--- a/manila/share/drivers/netapp/dataontap/protocols/nfs_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/protocols/nfs_cmode.py
@@ -125,11 +125,20 @@ class NetAppCmodeNFSHelper(base.NetAppBaseHelper):
         # Get authentication methods, based on Vserver configuration
         auth_methods = self._get_auth_methods()
 
+        metadata = share.get('metadata', None)
+        all_squash = (
+            (metadata.get('all_squash', 'false').lower() == 'true') if
+            metadata else False)
+
         # Add new rules to new policy
         for address in addresses:
-            self._client.add_nfs_export_rule(
-                temp_new_export_policy_name, address,
-                self._is_readonly(new_rules[address]), auth_methods)
+            if all_squash:
+                self._client.add_nfs_export_rule(
+                    temp_new_export_policy_name, address, False, ['none'])
+            else:
+                self._client.add_nfs_export_rule(
+                    temp_new_export_policy_name, address,
+                    self._is_readonly(new_rules[address]), auth_methods)
 
         # Rename policy currently in force
         LOG.info('Renaming NFS export policy for share %(share)s to '


### PR DESCRIPTION
Pass share metadata in share_instance object during update_access method. This metadata will be parsed to check 'all_squash' key having value 'true'. In such case clientmatch will be given access with 'none' security method.

Change-Id: I2903ab681a9528effaa0583482385a64d1f43896