### PR TITLE
Fix share migration error: destination is an NAE aggregate

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -6197,18 +6197,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'cutover-action': CUTOVER_ACTION_MAP[cutover_action],
         }
 
-        if self.features.FLEXVOL_ENCRYPTION:
-            if encrypt_destination:
-                api_args['encrypt-destination'] = 'true'
-            else:
-                api_args['encrypt-destination'] = 'false'
+        if self.features.FLEXVOL_ENCRYPTION and encrypt_destination:
+            api_args['encrypt-destination'] = 'true'
         elif encrypt_destination:
             msg = 'Flexvol encryption is not supported on this backend.'
             raise exception.NetAppException(msg)
+        else:
+            api_args['encrypt-destination'] = 'false'
 
         if validation_only:
             api_args['perform-validation-only'] = 'true'
-
         self.send_request('volume-move-start', api_args)
 
     @na_utils.trace

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -6197,13 +6197,14 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'cutover-action': CUTOVER_ACTION_MAP[cutover_action],
         }
 
-        if self.features.FLEXVOL_ENCRYPTION and encrypt_destination:
-            api_args['encrypt-destination'] = 'true'
-        elif encrypt_destination:
-            msg = 'Flexvol encryption is not supported on this backend.'
-            raise exception.NetAppException(msg)
-        else:
-            api_args['encrypt-destination'] = 'false'
+        if encrypt_destination is not None:
+            if encrypt_destination:
+                if not self.features.FLEXVOL_ENCRYPTION:
+                    s = 'Flexvol encryption is not supported on this backend.'
+                    raise exception.NetAppException(s)
+                api_args['encrypt-destination'] = 'true'
+            else:
+                api_args['encrypt-destination'] = 'false'
 
         if validation_only:
             api_args['perform-validation-only'] = 'true'

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -7580,7 +7580,6 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'vserver': fake.VSERVER_NAME,
             'dest-aggr': fake.SHARE_AGGREGATE_NAME,
             'cutover-action': 'wait',
-            'encrypt-destination': 'false'
         }
         if method_name.startswith('check'):
             expected_api_args['perform-validation-only'] = 'true'

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -7566,19 +7566,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
         expected = [fake.SNAPSHOT_NAME]
         self.assertEqual(expected, result)
 
-    @ddt.data(
-        {'method_name': 'start_volume_move', 'ontapi_version': (1, 20)},
-        {'method_name': 'start_volume_move', 'ontapi_version': (1, 110)},
-        {'method_name': 'check_volume_move', 'ontapi_version': (1, 20)},
-        {'method_name': 'check_volume_move', 'ontapi_version': (1, 110)}
-    )
-    @ddt.unpack
-    def test_volume_move_method(self, method_name, ontapi_version):
-        self.mock_object(client_base.NetAppBaseClient,
-                         'get_ontapi_version',
-                         mock.Mock(return_value=ontapi_version))
-
-        self.client._init_features()
+    @ddt.data('start_volume_move', 'check_volume_move')
+    def test_volume_move_method(self, method_name):
 
         method = getattr(self.client, method_name)
         self.mock_object(self.client, 'send_request')
@@ -7591,14 +7580,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
             'vserver': fake.VSERVER_NAME,
             'dest-aggr': fake.SHARE_AGGREGATE_NAME,
             'cutover-action': 'wait',
+            'encrypt-destination': 'false'
         }
-
-        if ontapi_version >= (1, 110):
-            expected_api_args['encrypt-destination'] = 'false'
-            self.assertTrue(self.client.features.FLEXVOL_ENCRYPTION)
-        else:
-            self.assertFalse(self.client.features.FLEXVOL_ENCRYPTION)
-
         if method_name.startswith('check'):
             expected_api_args['perform-validation-only'] = 'true'
 

--- a/releasenotes/notes/bug-1915237-netapp-fix-encrypt-check-on-migrate-1e39bd7f19651972.yaml
+++ b/releasenotes/notes/bug-1915237-netapp-fix-encrypt-check-on-migrate-1e39bd7f19651972.yaml
@@ -1,6 +1,0 @@
----
-fixes:
-  - |
-    NetApp OnTap driver `Bug #1915237
-    <https://bugs.launchpad.net/manila/+bug/1915237>`_:
-    Fixed encryption compatibility check on manila share migrate.


### PR DESCRIPTION
Upstream change in "NetApp OnTap: Fix compatibility check for share migrate" is not compatible with
"NetApp encrypt option differentiate between not present and false". Revert it and apply fix.