### PR TITLE
fix server migration after introducing multiple subnets

### DIFF
--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -701,14 +701,12 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
         return ports
 
     @utils.retry(retry_param=exception.NetworkException, retries=20)
-    def _wait_for_network_segment(self, share_server, host):
-        network_id = share_server['share_network_subnet']['neutron_net_id']
+    def _wait_for_network_segment(self, network_id, physnet):
         network = self.neutron_api.get_network(network_id)
         for segment in network['segments']:
-            if segment['provider:physical_network'] == (
-                    self.config.neutron_physical_net_name):
+            if segment['provider:physical_network'] == physnet:
                 return segment['provider:segmentation_id']
-        msg = _('Network segment not found on host %s') % host
+        msg = _('Network segment not found on physical network %s') % physnet
         raise exception.NetworkException(msg)
 
     def extend_network_allocations(self, context, share_server):
@@ -737,7 +735,11 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
                                                vnic_type)
 
         # Wait for network segment to be created on destination host.
-        vlan = self._wait_for_network_segment(share_server, host_id)
+        share_subnet = self.db.share_network_subnet_get(
+            context, active_port_bindings[0]['share_network_subnet_id'])
+        network_id = share_subnet['neutron_net_id']
+        physnet = self.config.neutron_physical_net_name
+        vlan = self._wait_for_network_segment(network_id, physnet)
         for port in active_port_bindings:
             port['segmentation_id'] = vlan
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -1339,7 +1339,7 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             'network_allocations':
                 source_share_server['network_allocations'],
             'neutron_subnet_id':
-                source_share_server['share_network_subnet'].get(
+                source_share_server['share_network_subnets'][0].get(
                     'neutron_subnet_id')
         }
 
@@ -1477,6 +1477,15 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
             LOG.error(msg)
             return not_compatible
 
+        # Blocking multiple subnets
+        new_subnets = new_share_network.get('share_network_subnets', [])
+        old_subnets = old_share_network.get('share_network_subnets', [])
+        if (len(new_subnets) != 1) or (len(old_subnets) != 1):
+            msg = _("Cannot perform server migration for share network"
+                    "with multiple subnets.")
+            LOG.error(msg)
+            return not_compatible
+
         pools = self._get_pools()
 
         # NOTE(dviroel): These clients can only be used for non-tunneling
@@ -1606,17 +1615,17 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         # Manila haven't made new allocations, we can just get allocation data
         # from the source share server.
         if not dest_share_server['network_allocations']:
-            share_server_to_get_network_info = source_share_server
+            share_server_network_info = source_share_server
         else:
-            share_server_to_get_network_info = dest_share_server
+            share_server_network_info = dest_share_server
 
         # Reuse network information from the source share server in the SVM
         # Migrate if the there was no share network changes.
         network_info = {
             'network_allocations':
-                share_server_to_get_network_info['network_allocations'],
+                share_server_network_info['network_allocations'],
             'neutron_subnet_id':
-                share_server_to_get_network_info['share_network_subnet'].get(
+                share_server_network_info['share_network_subnets'][0].get(
                     'neutron_subnet_id')
         }
 

--- a/manila/tests/network/neutron/test_neutron_plugin.py
+++ b/manila/tests/network/neutron/test_neutron_plugin.py
@@ -1149,6 +1149,11 @@ class NeutronBindNetworkPluginTest(test.TestCase):
             "network_allocations_get_for_share_server",
             mock.Mock(side_effect=get_nalloc_side_effect),
         )
+        self.mock_object(
+            self.bind_plugin.db,
+            'share_network_subnet_get',
+            mock.Mock(return_value=fake_share_network_subnet),
+        )
 
         # calling the extend_network_allocations method
         self.bind_plugin.extend_network_allocations(self.fake_context, fake_ss)

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -2402,7 +2402,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             'network_allocations':
                 self.fake_src_share_server['network_allocations'],
             'neutron_subnet_id':
-                self.fake_src_share_server['share_network_subnet'].get(
+                self.fake_src_share_server['share_network_subnets'][0].get(
                     'neutron_subnet_id')
         }
 
@@ -2456,7 +2456,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             'network_allocations':
                 self.fake_src_share_server['network_allocations'],
             'neutron_subnet_id':
-                self.fake_src_share_server['share_network_subnet'].get(
+                self.fake_src_share_server['share_network_subnets'][0].get(
                     'neutron_subnet_id')
         }
 
@@ -2735,8 +2735,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             'network_allocations':
                 server_to_get_network_info['network_allocations'],
             'neutron_subnet_id':
-                server_to_get_network_info['share_network_subnet'][
-                    'neutron_subnet_id']
+                server_to_get_network_info['share_network_subnets'][0].get(
+                    'neutron_subnet_id')
         }
 
         dest_ipspace = ('ipspace_'
@@ -2802,8 +2802,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             'network_allocations':
                 server_to_get_network_info['network_allocations'],
             'neutron_subnet_id':
-                server_to_get_network_info['share_network_subnet'][
-                    'neutron_subnet_id']
+                server_to_get_network_info['share_network_subnets'][0].get(
+                    'neutron_subnet_id')
         }
 
         dest_ipspace = ('ipspace_'

--- a/manila/tests/share/drivers/netapp/dataontap/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/fakes.py
@@ -586,10 +586,10 @@ SHARE_SERVER = {
     'network_allocations': (USER_NETWORK_ALLOCATIONS +
                             ADMIN_NETWORK_ALLOCATIONS),
     'host': SERVER_HOST,
-    'share_network_subnet': {
+    'share_network_subnets': [{
         'neutron_net_id': 'fake_neutron_net_id',
         'neutron_subnet_id': 'fake_neutron_subnet_id'
-    }
+    }]
 }
 
 SHARE_SERVER_2 = {
@@ -601,10 +601,10 @@ SHARE_SERVER_2 = {
     'network_allocations': (USER_NETWORK_ALLOCATIONS +
                             ADMIN_NETWORK_ALLOCATIONS),
     'host': SERVER_HOST_2,
-    'share_network_subnet': {
+    'share_network_subnets': [{
         'neutron_net_id': 'fake_neutron_net_id_2',
         'neutron_subnet_id': 'fake_neutron_subnet_id_2'
-    }
+    }]
 }
 
 VSERVER_INFO = {
@@ -1805,7 +1805,7 @@ SHARE_NETWORK = {
     'name': 'fake_name',
     'description': 'fake_description',
     'security_services': [CIFS_SECURITY_SERVICE],
-    'subnets': [SHARE_NETWORK_SUBNET],
+    'share_network_subnets': [SHARE_NETWORK_SUBNET],
 }
 
 SHARE_TYPE_2 = copy.deepcopy(SHARE_TYPE)

--- a/releasenotes/notes/fix-netApp-drivers-share-server-migration-is-failing-eee991ccbab4cd5a.yaml
+++ b/releasenotes/notes/fix-netApp-drivers-share-server-migration-is-failing-eee991ccbab4cd5a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Netapp driver: Fix Netapp share server migration with multiple subnets.
+    For more details please refer to
+    `launchpad bug #2018300 <https://bugs.launchpad.net/manila/+bug/2018300>`


### PR DESCRIPTION
Because of the new feature of multiple share network subnets, introduced
in antelope, Share server model has changed. Server migration driver
needs to be adjusted accordingly.

Should also be fixed upstream.

Change-Id: If94dbe7d4cf7b9a892b827cabe6edf019357c615
