### PR TITLE
[NetApp] fix resetting autosize attributes while replica promotion

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -3275,6 +3275,42 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 is_flexgroup=is_flexgroup)
 
     @na_utils.trace
+    def reset_autosize_attributes(self, aggr, volume):
+        '''Reset autosize attributes according to Volume type (RW or DP)
+
+        :param aggr: aggregate name where FlexVol volume is.
+        :param volume: name of the modified volume.
+        '''
+        api_args = {
+            'query': {
+                'volume-attributes': {
+                    'volume-id-attributes': {
+                        'containing-aggregate-name': aggr,
+                        'name': volume,
+                    },
+                },
+            },
+            'attributes': {
+                'volume-attributes': {
+                    'volume-autosize-attributes': {
+                        'reset': 'true',
+                    },
+                },
+            },
+        }
+
+        result = self.send_request('volume-modify-iter', api_args)
+        failures = result.get_child_content('num-failed')
+        if failures and int(failures) > 0:
+            failure_list = result.get_child_by_name(
+                'failure-list') or netapp_api.NaElement('none')
+            errors = failure_list.get_children()
+            if errors:
+                raise netapp_api.NaApiError(
+                    errors[0].get_child_content('error-code'),
+                    errors[0].get_child_content('error-message'))
+
+    @na_utils.trace
     def update_volume_efficiency_attributes(
             self, volume_name, dedup_enabled, compression_enabled,
             cross_dedup_disabled=False, is_flexgroup=False):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -3244,6 +3244,9 @@ class NetAppCmodeFileStorageLibrary(object):
                                                is_dr,
                                                share_server=share_server)
 
+        self._update_autosize_attributes_after_promote_replica(
+            orig_active_replica, new_active_replica, dm_session)
+
         extra_specs = share_types.get_extra_specs_from_share(
             new_active_replica)
         provisioning_options = self._get_provisioning_options(extra_specs)
@@ -3288,8 +3291,6 @@ class NetAppCmodeFileStorageLibrary(object):
                     f"With efficiency options '{effi_opts}'"
                     f"could not apply cross_dedup_disabled to the promoted "
                     f"replica. {e}")
-        self._update_autosize_attributes_after_promote_replica(
-            orig_active_replica, new_active_replica, dm_session)
 
         return new_replica_list
 
@@ -3362,36 +3363,16 @@ class NetAppCmodeFileStorageLibrary(object):
             new_active_replica, dm_session)
 
         # 3. Set autosize attributes for orig_active_replica
-
-        # Reset the autosize attributes according to the volume type (RW or DP)
-        orig_active_replica_autosize_attributes = {'reset': 'true'}
-
-        orig_provisioning_opts = (
-            orig_active_replica_info['provisioning_options'])
-
-        orig_provisioning_opts['autosize_attributes'] = (
-            orig_active_replica_autosize_attributes)
-
-        orig_active_replica_info['client'].modify_volume(
+        orig_active_replica_info['client'].reset_autosize_attributes(
             orig_active_replica_info['aggregate'],
             orig_active_replica_info['name'],
-            **orig_provisioning_opts)
+        )
 
         # 4. Set autosize attributes for new_active_replica
-
-        # Reset the autosize attributes according to the volume type (RW or DP)
-        new_active_replica_autosize_attributes = {'reset': 'true'}
-
-        new_provisioning_opts = (
-            new_active_replica_info['provisioning_options'])
-
-        new_provisioning_opts['autosize_attributes'] = (
-            new_active_replica_autosize_attributes)
-
-        new_active_replica_info['client'].modify_volume(
+        new_active_replica_info['client'].reset_autosize_attributes(
             new_active_replica_info['aggregate'],
             new_active_replica_info['name'],
-            **new_provisioning_opts)
+        )
 
     def _handle_qos_on_replication_change(self, dm_session, new_active_replica,
                                           orig_active_replica, is_dr,


### PR DESCRIPTION
Instead of calling NetApp API via the modify_volume() function, create a
new function in the NetApp client to reset the autosize attributes
alone. The former touches various attributes, such as `snapshot-policy`,
which are not allowed to be modified in the stage of promoting replica.

Todo: Submit this change to upstream.
Change-Id: Ie69b08c8555d42d425db86b9ef55c76fe50b0376
