### PR TITLE
Allow list values for same_host/different_host hint

### DIFF
--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -2602,7 +2602,8 @@ class API(base.Base):
                 raise exception.ShareNotFound(share_id=uuid)
 
     def _save_scheduler_hints(self, context, share, share_uuids, key):
-        share_uuids = share_uuids.split(",")
+        if not isinstance(share_uuids, list):
+            share_uuids = share_uuids.split(",")
 
         self._validate_scheduler_hints(context, share, share_uuids)
         val_uuids = None


### PR DESCRIPTION
When setting the scheduler hints same_host/different_host, upstream
allows only string values. However, we had a patch that allows list
values as well. The patch was hidden in the giant squash commit during
Xena upgrade. We need to bring this change back when upgrading to newer
release to stay consistent with previous behavior.

Change-Id: If63f2755b8c6d4a059921f4d13e4f687c8b2b2a2
