### PR TITLE
(SCI) allow share migration when resizing

### DIFF
--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -2692,6 +2692,18 @@ class API(base.Base):
             }
             raise exception.ShareBusyException(reason=msg)
 
+    def _is_share_in_migration(self, share):
+        if share.task_state in [
+            constants.TASK_STATE_MIGRATION_STARTING,
+            constants.TASK_STATE_MIGRATION_IN_PROGRESS,
+            constants.TASK_STATE_MIGRATION_COMPLETING,
+            constants.TASK_STATE_MIGRATION_DRIVER_STARTING,
+            constants.TASK_STATE_MIGRATION_DRIVER_IN_PROGRESS,
+            constants.TASK_STATE_MIGRATION_DRIVER_PHASE1_DONE,
+        ]:
+            return True
+        return False
+
     @staticmethod
     def check_is_share_size_within_per_share_quota_limit(context, size):
         """Raises an exception if share size above per share quota limit."""
@@ -2728,6 +2740,8 @@ class API(base.Base):
 
         if force:
             valid_statuses.append(constants.STATUS_EXTENDING_ERROR)
+            valid_statuses.append(constants.STATUS_MIGRATING)
+            valid_statuses.append(constants.STATUS_SERVER_MIGRATING)
 
         if share['status'] not in valid_statuses:
             msg_params = {
@@ -2740,7 +2754,8 @@ class API(base.Base):
                     "%(status)s.") % msg_params
             raise exception.InvalidShare(reason=msg)
 
-        self._check_is_share_busy(share)
+        if not self._is_share_in_migration(share):
+            self._check_is_share_busy(share)
 
         size_increase = int(new_size) - share['size']
         if size_increase <= 0:
@@ -2854,7 +2869,8 @@ class API(base.Base):
                     "%(status)s.") % msg_params
             raise exception.InvalidShare(reason=msg)
 
-        self._check_is_share_busy(share)
+        if not self._is_share_in_migration(share):
+            self._check_is_share_busy(share)
 
         size_decrease = int(share['size']) - int(new_size)
         if size_decrease <= 0 or new_size <= 0:

--- a/manila/tests/share/test_api.py
+++ b/manila/tests/share/test_api.py
@@ -3252,7 +3252,7 @@ class ShareAPITestCase(test.TestCase):
     def test_extend_invalid_task_state(self):
         share = db_utils.create_share(
             status=constants.STATUS_AVAILABLE,
-            task_state=constants.TASK_STATE_MIGRATION_IN_PROGRESS)
+            task_state=constants.TASK_STATE_DATA_COPYING_IN_PROGRESS)
         new_size = 123
 
         self.assertRaises(exception.ShareBusyException,
@@ -3410,7 +3410,7 @@ class ShareAPITestCase(test.TestCase):
     def test_shrink_invalid_task_state(self):
         share = db_utils.create_share(
             status=constants.STATUS_AVAILABLE,
-            task_state=constants.TASK_STATE_MIGRATION_IN_PROGRESS)
+            task_state=constants.TASK_STATE_DATA_COPYING_IN_PROGRESS)
 
         self.assertRaises(exception.ShareBusyException,
                           self.api.shrink, self.context, share, 123)


### PR DESCRIPTION
This is a quick patch to allow share resizing while it is in either
migration or server migration. Not a general solution.