### PR TITLE
SCI: update share server according to driver capabilities

### DIFF
--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -541,6 +541,14 @@ class ShareManager(manager.SchedulerDependentManager):
                 self.db.share_server_backend_details_set(
                     ctxt, share_server['id'], server_info)
 
+            # update share server by driver capabilities
+            server_specs = {
+                'share_replicas_migration_support': (
+                    self.driver.share_replicas_migration_support
+                ),
+            }
+            self.db.share_server_update(ctxt, share_server['id'], server_specs)
+
         share_instances = self.db.share_instances_get_all_by_host(
             ctxt, self.host)
         LOG.debug("Re-exporting %s shares", len(share_instances))


### PR DESCRIPTION
This patch updates the ensure logic to update share servers in DB,
setting share_replicas_migration_support field according to the
driver capabilities.

Change-Id: I6fc1d832510abe446953b99f0df6568279bb94f6
