### PR TITLE
SCI: handle cifs type access rules for multi protocol

### DIFF
--- a/manila/share/drivers/netapp/dataontap/protocols/cifs_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/protocols/cifs_cmode.py
@@ -188,6 +188,9 @@ class NetAppCmodeCIFSHelper(base.NetAppBaseHelper):
     @na_utils.trace
     def _get_export_location(self, share):
         """Returns host ip and share name for a given CIFS share."""
+        if share['share_proto'].lower() == 'multi':
+            return self._get_multi_export_location(share)
+
         export_location = self._get_share_export_location(share) or '\\\\\\'
         regex = r'^(?:\\\\|//)(?P<host_ip>.*)(?:\\|/)(?P<share_name>.*)$'
         match = re.match(regex, export_location)
@@ -195,6 +198,24 @@ class NetAppCmodeCIFSHelper(base.NetAppBaseHelper):
             return match.group('host_ip'), match.group('share_name')
         else:
             return '', ''
+
+    @na_utils.trace
+    def _get_multi_export_location(self, share):
+        """Returns host ip and share name for a given MULTI share.
+
+        Duplicates few lines of _get_export_location(), but is easier to
+        carry forward in coming release upgrades that way.
+
+        Need to look at all export locations, because the first one may
+        not match the CIFS style.
+        """
+        for export_location in share.get('export_locations'):
+            regex = r'^(?:\\\\|//)(?P<host_ip>.*)(?:\\|/)(?P<share_name>.*)$'
+            match = re.match(regex, export_location['path'])
+            if match:
+                return match.group('host_ip'), match.group('share_name')
+
+        return '', ''
 
     @na_utils.trace
     def cleanup_demoted_replica(self, share, share_name):

--- a/manila/tests/share/drivers/netapp/dataontap/protocols/test_cifs_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/protocols/test_cifs_cmode.py
@@ -211,7 +211,10 @@ class NetAppClusteredCIFSHelperTestCase(test.TestCase):
 
     def test_get_target_missing_location(self):
 
-        target = self.helper.get_target({'export_location': ''})
+        target = self.helper.get_target({
+            'export_location': '',
+            'share_proto': 'CIFS'
+        })
         self.assertEqual('', target)
 
     def test_get_share_name_for_share(self):
@@ -261,6 +264,27 @@ class NetAppClusteredCIFSHelperTestCase(test.TestCase):
         self.assertEqual(ip, result_ip)
         self.assertEqual(share_name, result_share_name)
         self.helper._get_share_export_location.assert_called_once_with(share)
+
+    @ddt.data('MULTI', 'NOT_MULTI')
+    def test_get_multi_export_location(self, protocol):
+
+        share = {'id': fake.SHARE_ID}
+        share['export_location'] = None
+        nfs_path = r'%s:/%s' % (fake.SHARE_ADDRESS_1, fake.SHARE_NAME + '_0')
+        cifs_path = r'\\%s\%s' % (fake.SHARE_ADDRESS_2, fake.SHARE_NAME)
+        # keep order, we want to test that it would also take the 2nd path
+        share['export_locations'] = [{'path': nfs_path}, {'path': cifs_path}]
+        share['share_proto'] = protocol
+
+        result_ip, result_share_name = self.helper._get_export_location(share)
+        expected_ip = ''
+        expected_name = ''
+        if protocol == 'MULTI':
+            expected_ip = fake.SHARE_ADDRESS_2
+            expected_name = fake.SHARE_NAME
+
+        self.assertEqual(expected_ip, result_ip)
+        self.assertEqual(expected_name, result_share_name)
 
     def test_cleanup_demoted_replica(self):
         self.helper.cleanup_demoted_replica(fake.CIFS_SHARE, fake.SHARE_NAME)


### PR DESCRIPTION
Usually it is sufficient to look at the first export location
to get the share details, but in multi setup we need to look at all
export locations to find the right pattern in case of cifs.

Change-Id: I16da2452c8977fb550822dcebaba194a1618d7a6
