### PR TITLE
prevent empty pool list

### DIFF
--- a/manila/scheduler/host_manager.py
+++ b/manila/scheduler/host_manager.py
@@ -709,7 +709,12 @@ class HostManager(object):
 
     def get_pools(self, context, filters=None, cached=False):
         """Returns a dict of all pools on all hosts HostManager knows about."""
-        if not cached or not self.host_state_map:
+        map_has_all_pools = False
+        if self.host_state_map:
+            map_has_all_pools = all(
+                h_state.pools for h_state in self.host_state_map.values())
+
+        if not cached or not self.host_state_map or not map_has_all_pools:
             self._update_host_state_map(context)
 
         all_pools = []

--- a/manila/tests/scheduler/test_host_manager.py
+++ b/manila/tests/scheduler/test_host_manager.py
@@ -499,12 +499,20 @@ class HostManagerTestCase(test.TestCase):
             for pool in expected:
                 self.assertIn(pool, res)
 
-    def test_get_pools_host_down(self):
+    @ddt.data({'cached': True, 'missing_pools': True},
+              {'cached': True, 'missing_pools': False},
+              {'cached': False, 'missing_pools': True},
+              {'cached': False, 'missing_pools': False})
+    @ddt.unpack
+    def test_get_pools_host_down(self, cached, missing_pools):
         fake_context = context.RequestContext('user', 'project')
         mock_service_is_up = self.mock_object(utils, 'service_is_up')
         self.mock_object(
             db, 'service_get_all_by_topic',
             mock.Mock(return_value=fakes.SHARE_SERVICES_NO_POOLS))
+        map_update_mock = self.mock_object(
+            self.host_manager, '_update_host_state_map',
+            mock.Mock(wraps=self.host_manager._update_host_state_map))
         host_manager.LOG.warning = mock.Mock()
 
         with mock.patch.dict(self.host_manager.service_states,
@@ -515,14 +523,26 @@ class HostManagerTestCase(test.TestCase):
 
             # Call once to update the host state map
             self.host_manager.get_pools(fake_context)
+            host_state_map_update_calls = 1
 
             self.assertEqual(len(fakes.SHARE_SERVICES_NO_POOLS),
                              len(self.host_manager.host_state_map))
 
             # Then mock one host as down
             mock_service_is_up.side_effect = [True, True, False]
+            if missing_pools:
+                self.host_manager.host_state_map = {
+                    'host1@back1': host_manager.HostState('host1'),
+                    'host2@back2': host_manager.HostState('host2',
+                                                          {'pools': []}),
+                }
 
-            res = self.host_manager.get_pools(fake_context)
+            res = self.host_manager.get_pools(fake_context, cached=cached)
+            if not cached or missing_pools:
+                host_state_map_update_calls += 1
+
+            self.assertEqual(map_update_mock.call_count,
+                             host_state_map_update_calls)
 
             expected = [
                 {
@@ -599,11 +619,12 @@ class HostManagerTestCase(test.TestCase):
             ]
             self.assertIsInstance(res, list)
             self.assertIsInstance(self.host_manager.host_state_map, dict)
-            self.assertEqual(len(expected), len(res))
-            self.assertEqual(len(expected),
-                             len(self.host_manager.host_state_map))
-            for pool in expected:
-                self.assertIn(pool, res)
+            if not cached or missing_pools:
+                self.assertEqual(len(expected), len(res))
+                self.assertEqual(len(expected),
+                                 len(self.host_manager.host_state_map))
+                for pool in expected:
+                    self.assertIn(pool, res)
 
     def test_get_pools_with_filters(self):
         fake_context = context.RequestContext('user', 'project')


### PR DESCRIPTION
We need to refresh the scheduler's host state map, if it does not
have info about all the pools.
Checking just for existance of one pool is not enough, because this
one may be out of capacity.

Change-Id: Id3a6e59674dfed2ee09f05aebffa0faa5a1396d0
