### PR TITLE
[NetApp] ensure export policy can take desired name

### DIFF
--- a/manila/share/drivers/netapp/dataontap/protocols/nfs_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/protocols/nfs_cmode.py
@@ -226,6 +226,7 @@ class NetAppCmodeNFSHelper(base.NetAppBaseHelper):
             self._client.set_nfs_export_policy_for_volume(
                 share_name, expected_export_policy)
         else:
+            self._client.soft_delete_nfs_export_policy(expected_export_policy)
             self._client.rename_nfs_export_policy(actual_export_policy,
                                                   expected_export_policy)
 


### PR DESCRIPTION
If the name we want to give is already taken (because an earlier
access update was interrupted), we need to get rid of the unused
export policy holding that name.
This is safe, because we enter this condition only if the actual
export policy that is in use by the volume has a different name.

Fixes the error 'Failed to rename ruleset: duplicate entry'.

Change-Id: Idaf82e730c97f5559b477f07c88ecd76a0c65fce
Closes-bug: #1966176
