### PR TITLE
Pin setuptools

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,7 @@ commands =
   stestr slowest
 
 [testenv:releasenotes]
-deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
-  -r{toxinidir}/doc/requirements.txt
+deps = {[testenv:docs]deps}
 commands =
   rm -rf releasenotes/build
   sphinx-build -a -E -W -d releasenotes/build/doctrees \
@@ -33,9 +31,8 @@ commands =
 allowlist_externals = rm
 
 [testenv:newnote]
-deps =
--c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
-  -r{toxinidir}/doc/requirements.txt
+allowlist_externals = reno
+deps = {[testenv:docs]deps}
 commands = reno new {posargs}
 
 [testenv:debug]
@@ -82,9 +79,11 @@ commands = {posargs}
 # dependencies are installed during 'develop-inst' tox phase without
 # constraints which could cause failures in stable branches.
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
-  -r{toxinidir}/requirements.txt
-  -r{toxinidir}/doc/requirements.txt
+    -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/doc/requirements.txt
+    # NOTE(stephenfin): pin setuptools to the last version to support pkg_resources
+    setuptools<82.0.0
 commands =
   rm -rf doc/build
   sphinx-build -W -b html doc/source doc/build/html
@@ -115,7 +114,7 @@ usedevelop = False
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run --source manila --parallel-mode
-allowlist_externals = 
+allowlist_externals =
   {toxinidir}/tools/cover.sh
 commands =
   {toxinidir}/tools/cover.sh {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 minversion = 3.18.0
 envlist = py3,pep8
+requires = virtualenv<=20.36
 # Automatic envs (pyXX) will only use the python version appropriate to that
 # env and ignore basepython inherited from [testenv] if we set
 # ignore_basepython_conflict.


### PR DESCRIPTION
setuptools 82.0.0 dropped support for the legacy 'pkg_resources'
library.
