### PR TITLE
NetApp: improve error logging for replica promotion failure

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -853,7 +853,7 @@ class DataMotionSession(object):
                 vserver_client.mount_volume(share_name)
             except netapp_api.NaApiError as e:
                 undergoing_snap_init = 'snapmirror initialize'
-                msg_args = {'name': share_name}
+                msg_args = {'name': share_name, 'err_msg': e.message}
                 if (e.code == netapp_api.EAPIERROR and
                         undergoing_snap_init in e.message):
                     msg = _('The share %(name)s is undergoing a snapmirror '
@@ -863,7 +863,8 @@ class DataMotionSession(object):
                 else:
                     msg = _("Unable to perform mount operation for the share "
                             "%(name)s. Caught an unexpected error. Not "
-                            "retrying.") % msg_args
+                            "retrying. %(err_msg)s") % msg_args
+                    LOG.exception(msg)
                     raise exception.NetAppException(message=msg)
 
         try:


### PR DESCRIPTION
Log unexpected errors when unable to perform mount operation.

Change-Id: I1932ffb294a500721ffe8110721fb2f4bd08443f
Signed-off-by: Maurice Escher <maurice.escher@sap.com>
