### PR TITLE
Share server migration complete should adjust device id on ports

### DIFF
--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -352,9 +352,9 @@ class API(object):
             raise exception.NetworkException(code=e.status_code,
                                              message=e.message)
 
-    def update_port_fixed_ips(self, port_id, fixed_ips):
+    def update_port(self, port_id, port_data):
         try:
-            port_req_body = {'port': fixed_ips}
+            port_req_body = {'port': port_data}
             port = self.client.update_port(
                 port_id, port_req_body).get('port', {})
             return port

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -756,7 +756,8 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
                 msg = 'Failed to delete port binding on port %{port}s: %{err}s'
                 LOG.warning(msg, {'port': port['id'], 'err': e})
 
-    def cutover_network_allocations(self, context, src_share_server):
+    def cutover_network_allocations(self, context, src_share_server,
+                                    dest_share_server=None):
         src_host = share_utils.extract_host(src_share_server['host'], 'host')
         dest_host = self.config.neutron_host_id
         ports = self.db.network_allocations_get_for_share_server(
@@ -764,6 +765,9 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
         for port in ports:
             self.neutron_api.activate_port_binding(port['id'], dest_host)
             self.neutron_api.delete_port_binding(port['id'], src_host)
+            if dest_share_server:
+                self.neutron_api.update_port(
+                    port['id'], {'device_id': dest_share_server['id']})
         return ports
 
 

--- a/manila/share/drivers/service_instance.py
+++ b/manila/share/drivers/service_instance.py
@@ -1052,7 +1052,7 @@ class NeutronNetworkHelper(BaseNetworkhelper):
         # we need to add those to the port and call update.
         if subnets:
             port_fixed_ips.extend([dict(subnet_id=s) for s in subnets])
-            port = self.neutron_api.update_port_fixed_ips(
+            port = self.neutron_api.update_port(
                 port['id'], {'fixed_ips': port_fixed_ips})
 
         return port

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -6562,7 +6562,7 @@ class ShareManager(manager.SchedulerDependentManager):
         # be deleted.
         if migration_extended_network_allocations:
             allocs = self.driver.network_api.cutover_network_allocations(
-                context, source_share_server)
+                context, source_share_server, dest_share_server)
             segmentation_id = self.db.share_server_backend_details_get(
                 context, dest_share_server['id'], 'segmentation_id')
             alloc_update = {

--- a/manila/tests/fake_network.py
+++ b/manila/tests/fake_network.py
@@ -181,7 +181,7 @@ class API(object):
     def show_router(self, *args, **kwargs):
         pass
 
-    def update_port_fixed_ips(self, *args, **kwargs):
+    def update_port(self, *args, **kwargs):
         pass
 
     def router_remove_interface(self, *args, **kwargs):

--- a/manila/tests/network/neutron/test_neutron_api.py
+++ b/manila/tests/network/neutron/test_neutron_api.py
@@ -505,19 +505,19 @@ class NeutronApiTest(test.TestCase):
             {'router': router_args})
         self.assertTrue(clientv20.Client.called)
 
-    def test_update_port_fixed_ips(self):
+    def test_update_port(self):
         # Set up test data
         port_id = 'test_port'
         fixed_ips = {'fixed_ips': [{'subnet_id': 'test subnet'}]}
 
-        # Execute method 'update_port_fixed_ips'
-        port = self.neutron_api.update_port_fixed_ips(port_id, fixed_ips)
+        # Execute method 'update_port'
+        port = self.neutron_api.update_port(port_id, fixed_ips)
 
         # Verify results
         self.assertEqual(fixed_ips, port)
         self.assertTrue(clientv20.Client.called)
 
-    def test_update_port_fixed_ips_exception(self):
+    def test_update_port_exception(self):
         # Set up test data
         port_id = 'test_port'
         fixed_ips = {'fixed_ips': [{'subnet_id': 'test subnet'}]}
@@ -525,10 +525,10 @@ class NeutronApiTest(test.TestCase):
             self.neutron_api.client, 'update_port',
             mock.Mock(side_effect=neutron_client_exc.NeutronClientException))
 
-        # Execute method 'update_port_fixed_ips'
+        # Execute method 'update_port'
         self.assertRaises(
             exception.NetworkException,
-            self.neutron_api.update_port_fixed_ips,
+            self.neutron_api.update_port,
             port_id, fixed_ips)
 
         # Verify results

--- a/manila/tests/share/drivers/test_service_instance.py
+++ b/manila/tests/share/drivers/test_service_instance.py
@@ -2172,7 +2172,7 @@ class NeutronNetworkHelperTestCase(test.TestCase):
                          mock.Mock(return_value='fake_host'))
         self.mock_object(instance.neutron_api, 'create_port',
                          mock.Mock(return_value=fake_service_port))
-        self.mock_object(instance.neutron_api, 'update_port_fixed_ips',
+        self.mock_object(instance.neutron_api, 'update_port',
                          mock.Mock(return_value=fake_service_port))
 
         result = instance._get_service_port(instance.service_network_id,
@@ -2185,7 +2185,7 @@ class NeutronNetworkHelperTestCase(test.TestCase):
             device_id='manila-share', device_owner='manila:share',
             host_id='fake_host', subnet_id=None, port_security_enabled=False)
         service_instance.socket.gethostname.assert_called_once_with()
-        self.assertFalse(instance.neutron_api.update_port_fixed_ips.called)
+        self.assertFalse(instance.neutron_api.update_port.called)
         self.assertEqual(fake_service_port, result)
 
     def test__get_service_port_one_exist_on_same_host(self):
@@ -2199,7 +2199,7 @@ class NeutronNetworkHelperTestCase(test.TestCase):
                          mock.Mock(return_value=[fake_service_port]))
         self.mock_object(instance.neutron_api, 'create_port',
                          mock.Mock(return_value=fake_service_port))
-        self.mock_object(instance.neutron_api, 'update_port_fixed_ips',
+        self.mock_object(instance.neutron_api, 'update_port',
                          mock.Mock(return_value=fake_service_port))
 
         result = instance._get_service_port(instance.service_network_id,
@@ -2208,7 +2208,7 @@ class NeutronNetworkHelperTestCase(test.TestCase):
         instance.neutron_api.list_ports.assert_called_once_with(
             **fake_port_values)
         self.assertFalse(instance.neutron_api.create_port.called)
-        self.assertFalse(instance.neutron_api.update_port_fixed_ips.called)
+        self.assertFalse(instance.neutron_api.update_port.called)
         self.assertEqual(fake_service_port, result)
 
     def test__get_service_port_one_exist_on_different_host(self):
@@ -2226,7 +2226,7 @@ class NeutronNetworkHelperTestCase(test.TestCase):
                          mock.Mock(return_value='fake_host'))
         self.mock_object(instance.neutron_api, 'create_port',
                          mock.Mock(return_value=fake_service_port))
-        self.mock_object(instance.neutron_api, 'update_port_fixed_ips',
+        self.mock_object(instance.neutron_api, 'update_port',
                          mock.Mock(return_value=fake_service_port))
 
         result = instance._get_service_port(instance.service_network_id,
@@ -2239,7 +2239,7 @@ class NeutronNetworkHelperTestCase(test.TestCase):
             device_id='manila-share', device_owner='manila:share',
             host_id='fake_host', subnet_id=None, port_security_enabled=False)
         service_instance.socket.gethostname.assert_called_once_with()
-        self.assertFalse(instance.neutron_api.update_port_fixed_ips.called)
+        self.assertFalse(instance.neutron_api.update_port.called)
         self.assertEqual(fake_service_port, result)
 
     def test__get_service_port_two_exist_on_same_host(self):
@@ -2269,7 +2269,7 @@ class NeutronNetworkHelperTestCase(test.TestCase):
         instance = self._init_neutron_network_plugin()
         self.mock_object(instance.neutron_api, 'get_network',
                          mock.Mock(return_value=network))
-        self.mock_object(instance.neutron_api, 'update_port_fixed_ips',
+        self.mock_object(instance.neutron_api, 'update_port',
                          mock.Mock(return_value=expected))
 
         result = instance._add_fixed_ips_to_service_port(port)
@@ -2277,7 +2277,7 @@ class NeutronNetworkHelperTestCase(test.TestCase):
         self.assertEqual(expected, result)
         instance.neutron_api.get_network.assert_called_once_with(
             instance.service_network_id)
-        instance.neutron_api.update_port_fixed_ips.assert_called_once_with(
+        instance.neutron_api.update_port.assert_called_once_with(
             port['id'], dict(fixed_ips=[
                 dict(subnet_id=subnet_id1, ip_address=ip_address1),
                 dict(subnet_id=subnet_id2)]))


### PR DESCRIPTION
- rename update_port_fixed_ips() to more generic update_port()
- update device_id on ports during cutover. This ensures ports are correctly associated with the new share server and won't be mistakenly deleted.

Change-Id: Id9af9866c591e68f3f08a6a76ebae060ca1a1f5a