### PR TITLE
NetApp error in get_performance_counters when node is down

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1491,7 +1491,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
     @na_utils.trace
     def get_node_for_aggregate(self, aggregate_name):
-        """Get home node for the specified aggregate.
+        """Get home and owner node for the specified aggregate.
 
         This API could return None, most notably if it was sent
         to a Vserver LIF, so the caller must be able to handle that case.
@@ -1505,6 +1505,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 'aggregate-name': None,
                 'aggr-ownership-attributes': {
                     'home-name': None,
+                    'owner-name': None,
                 },
             },
         }
@@ -1523,7 +1524,13 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
         aggr_ownership_attrs = aggrs[0].get_child_by_name(
             'aggr-ownership-attributes') or netapp_api.NaElement('none')
-        return aggr_ownership_attrs.get_child_content('home-name')
+        home_name = aggr_ownership_attrs.get_child_content('home-name')
+        owner_name = aggr_ownership_attrs.get_child_content('owner-name')
+
+        return {
+            'home_node': home_name,
+            'owner_node': owner_name,
+        }
 
     @na_utils.trace
     def get_cluster_aggregate_capacities(self, aggregate_names):

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1516,6 +1516,40 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             'aggr-ownership-attributes') or netapp_api.NaElement('none')
         return aggr_ownership_attrs.get_child_content('home-name')
 
+    def get_owner_node_for_aggregate(self, aggregate_name):
+        """Get owner node for the specified aggregate."""
+
+        if not aggregate_name:
+            return None
+
+        desired_attributes = {
+            'aggr-attributes': {
+                'aggregate-name': None,
+                'aggr-ownership-attributes': {
+                    'owner-name': None
+                },
+            },
+        }
+
+        try:
+            aggrs = self._get_aggregates(aggregate_names=[aggregate_name],
+                                         desired_attributes=desired_attributes)
+        except netapp_api.NaApiError as e:
+            if e.code == netapp_api.EAPINOTFOUND:
+                return None
+            else:
+                raise
+
+        if len(aggrs) < 1:
+            return None
+
+        aggr_ownership_attrs = aggrs[0].get_child_by_name(
+            'aggr-ownership-attributes') or netapp_api.NaElement('none')
+        owner_name = aggr_ownership_attrs.get_child_content('owner-name')
+        if not owner_name:
+            return None
+        return owner_name
+
     @na_utils.trace
     def get_cluster_aggregate_capacities(self, aggregate_names):
         """Calculates capacity of one or more aggregates.

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -587,7 +587,7 @@ class NetAppRestClient(object):
 
     @na_utils.trace
     def get_node_for_aggregate(self, aggregate_name):
-        """Get home node for the specified aggregate.
+        """Get home and owner node for the specified aggregate.
 
         This API could return None, most notably if it was sent
         to a Vserver LIF, so the caller must be able to handle that case.
@@ -596,20 +596,30 @@ class NetAppRestClient(object):
         if not aggregate_name:
             return None
 
-        fields = 'name,home_node.name'
+        fields = 'name,home_node.name,node.name'
 
         try:
             aggrs = self._get_aggregates(aggregate_names=[aggregate_name],
                                          fields=fields)
         except netapp_api.api.NaApiError as e:
             if e.code == netapp_api.EREST_NOT_AUTHORIZED:
-                LOG.debug("Could not get the home node of aggregate %s: "
+                LOG.debug("Could not get the nodes of aggregate %s: "
                           "command not authorized.", aggregate_name)
                 return None
             else:
                 raise
 
-        return aggrs[0]['home_node']['name'] if aggrs else None
+        if not aggrs:
+            return None
+        aggr = aggrs[0]
+
+        home_node = aggr.get('home_node', {}).get('name')
+        owner_node = aggr.get('node', {}).get('name')
+
+        return {
+            'home_node': home_node,
+            'owner_node': owner_node,
+        }
 
     @na_utils.trace
     def get_aggregate_disk_types(self, aggregate_name):

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -601,6 +601,35 @@ class NetAppRestClient(object):
         return aggrs[0]['home_node']['name'] if aggrs else None
 
     @na_utils.trace
+    def get_owner_node_for_aggregate(self, aggregate_name):
+        """Get current owner node for the specified aggregate."""
+
+        if not aggregate_name:
+            return None
+
+        fields = 'name,node.name'
+
+        try:
+            aggrs = self._get_aggregates(
+                aggregate_names=[aggregate_name],
+                fields=fields
+            )
+        except netapp_api.api.NaApiError as e:
+            if e.code == netapp_api.EREST_NOT_AUTHORIZED:
+                LOG.debug("Could not get the owner node of aggregate %s: "
+                          "command not authorized.", aggregate_name)
+                return None
+            else:
+                raise
+
+        if not aggrs:
+            return None
+        aggr = aggrs[0]
+        if aggr.get('node') and aggr['node'].get('name'):
+            return aggr['node']['name']
+        return None
+
+    @na_utils.trace
     def get_aggregate_disk_types(self, aggregate_name):
         """Get the disk type(s) of an aggregate."""
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -480,11 +480,14 @@ class NetAppCmodeFileStorageLibrary(object):
     def _get_aggregate_node(self, aggregate_name, cluster_client=None):
         """Get home node for the specified aggregate, or None."""
         if cluster_client:
-            return cluster_client.get_node_for_aggregate(aggregate_name)
+            node_info = cluster_client.get_node_for_aggregate(aggregate_name)
         elif self._have_cluster_creds:
-            return self._client.get_node_for_aggregate(aggregate_name)
+            node_info = self._client.get_node_for_aggregate(aggregate_name)
         else:
             return None
+        if node_info:
+            return node_info.get('home_node')
+        return None
 
     def get_default_filter_function(self, pool=None):
         """Get the default filter_function string."""

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/performance.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/performance.py
@@ -149,10 +149,11 @@ class PerformanceLibrary(object):
         aggr_node_map = {}
 
         for aggr_name in aggr_names:
-            node_name = self.zapi_client.get_node_for_aggregate(aggr_name)
-            if node_name:
-                node_names.add(node_name)
-                aggr_node_map[aggr_name] = node_name
+            node_info = (
+                self.zapi_client.get_node_for_aggregate(aggr_name))
+            if node_info and node_info.get('owner_node'):
+                node_names.add(node_info['owner_node'])
+                aggr_node_map[aggr_name] = node_info['owner_node']
 
         return list(node_names), aggr_node_map
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/performance.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/performance.py
@@ -149,7 +149,8 @@ class PerformanceLibrary(object):
         aggr_node_map = {}
 
         for aggr_name in aggr_names:
-            node_name = self.zapi_client.get_node_for_aggregate(aggr_name)
+            node_name = (
+                self.zapi_client.get_owner_node_for_aggregate(aggr_name))
             if node_name:
                 node_names.add(node_name)
                 aggr_node_map[aggr_name] = node_name

--- a/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
@@ -1271,6 +1271,42 @@ AGGR_GET_NODE_RESPONSE = etree.XML("""
     'node': NODE_NAME
 })
 
+AGGR_GET_OWNER_NODE_RESPONSE = etree.XML("""
+  <results status="passed">
+    <attributes-list>
+      <aggr-attributes>
+        <aggr-ownership-attributes>
+          <owner-name>%(node)s</owner-name>
+        </aggr-ownership-attributes>
+        <aggregate-name>%(aggr)s</aggregate-name>
+      </aggr-attributes>
+    </attributes-list>
+    <num-records>1</num-records>
+  </results>
+""" % {
+    'aggr': SHARE_AGGREGATE_NAME,
+    'node': NODE_NAME
+})
+
+AGGR_GET_OWNER_NODE_FAILOVER_RESPONSE = etree.XML("""
+  <results status="passed">
+    <attributes-list>
+      <aggr-attributes>
+        <aggr-ownership-attributes>
+          <owner-name>%(owner_node)s</owner-name>
+          <home-name>%(home_node)s</home-name>
+        </aggr-ownership-attributes>
+        <aggregate-name>%(aggr)s</aggregate-name>
+      </aggr-attributes>
+    </attributes-list>
+    <num-records>1</num-records>
+  </results>
+""" % {
+    'aggr': SHARE_AGGREGATE_NAME,
+    'owner_node': NODE_NAME2,
+    'home_node': NODE_NAME
+})
+
 AGGR_GET_ITER_RESPONSE = etree.XML("""
   <results status="passed">
     <attributes-list>
@@ -3776,6 +3812,9 @@ AGGR_GET_ITER_RESPONSE_REST = {
         {
             "uuid": "fake_uuid_1",
             "name": "fake_aggr1",
+            "node": {
+                "name": "fake_owner_node_name"
+            },
             "home_node": {
                 "name": "fake_home_node_name"
             },
@@ -3871,6 +3910,22 @@ AGGR_GET_ITER_RESPONSE_REST = {
         }
     ],
     "num_records": 2,
+}
+
+AGGR_GET_OWNER_NODE_FAILOVER_RESPONSE_REST = {
+    "records": [
+        {
+            "uuid": "fake_uuid_1",
+            "name": "fake_aggr1",
+            "node": {
+                "name": NODE_NAME2
+            },
+            "home_node": {
+                "name": NODE_NAME
+            },
+        }
+    ],
+    "num_records": 1,
 }
 
 EFFECTIVE_TYPE = 'fake_effective_type1'

--- a/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
@@ -1214,6 +1214,42 @@ AGGR_GET_NODE_RESPONSE = etree.XML("""
     'node': NODE_NAME
 })
 
+AGGR_GET_OWNER_NODE_RESPONSE = etree.XML("""
+  <results status="passed">
+    <attributes-list>
+      <aggr-attributes>
+        <aggr-ownership-attributes>
+          <owner-name>%(node)s</owner-name>
+        </aggr-ownership-attributes>
+        <aggregate-name>%(aggr)s</aggregate-name>
+      </aggr-attributes>
+    </attributes-list>
+    <num-records>1</num-records>
+  </results>
+""" % {
+    'aggr': SHARE_AGGREGATE_NAME,
+    'node': NODE_NAME
+})
+
+AGGR_GET_OWNER_NODE_FAILOVER_RESPONSE = etree.XML("""
+  <results status="passed">
+    <attributes-list>
+      <aggr-attributes>
+        <aggr-ownership-attributes>
+          <owner-name>%(owner_node)s</owner-name>
+          <home-name>%(home_node)s</home-name>
+        </aggr-ownership-attributes>
+        <aggregate-name>%(aggr)s</aggregate-name>
+      </aggr-attributes>
+    </attributes-list>
+    <num-records>1</num-records>
+  </results>
+""" % {
+    'aggr': SHARE_AGGREGATE_NAME,
+    'owner_node': NODE_NAME2,
+    'home_node': NODE_NAME
+})
+
 AGGR_GET_ITER_RESPONSE = etree.XML("""
   <results status="passed">
     <attributes-list>
@@ -3709,6 +3745,35 @@ AGGR_GET_ITER_RESPONSE_REST = {
         }
     ],
     "num_records": 2,
+}
+
+AGGR_GET_OWNER_NODE_RESPONSE_REST = {
+    "records": [
+        {
+            "uuid": "fake_uuid_1",
+            "name": "fake_aggr1",
+            "node": {
+                "name": NODE_NAME
+            },
+        }
+    ],
+    "num_records": 1,
+}
+
+AGGR_GET_OWNER_NODE_FAILOVER_RESPONSE_REST = {
+    "records": [
+        {
+            "uuid": "fake_uuid_1",
+            "name": "fake_aggr1",
+            "node": {
+                "name": NODE_NAME2
+            },
+            "home_node": {
+                "name": NODE_NAME
+            },
+        }
+    ],
+    "num_records": 1,
 }
 
 EFFECTIVE_TYPE = 'fake_effective_type1'

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -2256,6 +2256,81 @@ class NetAppClientCmodeTestCase(test.TestCase):
             mock.call('vserver-get', vserver_args)])
         self.assertDictEqual(fake.VSERVER_AGGREGATES, result)
 
+    def test_get_owner_node_for_aggregate(self):
+
+        api_response = netapp_api.NaElement(
+            fake.AGGR_GET_OWNER_NODE_RESPONSE).get_child_by_name(
+            'attributes-list').get_children()
+        self.mock_object(self.client,
+                         '_get_aggregates',
+                         mock.Mock(return_value=api_response))
+
+        result = self.client.get_owner_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+
+        desired_attributes = {
+            'aggr-attributes': {
+                'aggregate-name': None,
+                'aggr-ownership-attributes': {
+                    'owner-name': None,
+                },
+            },
+        }
+
+        self.client._get_aggregates.assert_has_calls([
+            mock.call(
+                aggregate_names=[fake.SHARE_AGGREGATE_NAME],
+                desired_attributes=desired_attributes)])
+
+        self.assertEqual(fake.NODE_NAME, result)
+
+    def test_get_owner_node_for_aggregate_failover(self):
+
+        api_response = netapp_api.NaElement(
+            fake.AGGR_GET_OWNER_NODE_FAILOVER_RESPONSE).get_child_by_name(
+            'attributes-list').get_children()
+        self.mock_object(self.client,
+                         '_get_aggregates',
+                         mock.Mock(return_value=api_response))
+
+        result = self.client.get_owner_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+
+        self.assertEqual(fake.NODE_NAME2, result)
+
+    def test_get_owner_node_for_aggregate_none_requested(self):
+        result = self.client.get_owner_node_for_aggregate(None)
+        self.assertIsNone(result)
+
+    def test_get_owner_node_for_aggregate_api_not_found(self):
+        self.mock_object(self.client,
+                         'send_iter_request',
+                         mock.Mock(side_effect=self._mock_api_error(
+                             netapp_api.EAPINOTFOUND)))
+
+        result = self.client.get_owner_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+        self.assertIsNone(result)
+
+    def test_get_owner_node_for_aggregate_api_error(self):
+        self.mock_object(self.client,
+                         'send_iter_request',
+                         self._mock_api_error())
+
+        self.assertRaises(netapp_api.NaApiError,
+                          self.client.get_owner_node_for_aggregate,
+                          fake.SHARE_AGGREGATE_NAME)
+
+    def test_get_owner_node_for_aggregate_not_found(self):
+        api_response = netapp_api.NaElement(fake.NO_RECORDS_RESPONSE)
+        self.mock_object(self.client,
+                         'send_iter_request',
+                         mock.Mock(return_value=api_response))
+
+        result = self.client.get_owner_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+        self.assertIsNone(result)
+
     def test_get_vserver_aggregate_capacities_partial_request(self):
 
         api_response = netapp_api.NaElement(fake.VSERVER_GET_RESPONSE)

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -2143,6 +2143,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
                 'aggregate-name': None,
                 'aggr-ownership-attributes': {
                     'home-name': None,
+                    'owner-name': None,
                 },
             },
         }
@@ -2152,7 +2153,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
                 aggregate_names=[fake.SHARE_AGGREGATE_NAME],
                 desired_attributes=desired_attributes)])
 
-        self.assertEqual(fake.NODE_NAME, result)
+        self.assertEqual({
+            'home_node': fake.NODE_NAME,
+            'owner_node': None,
+        }, result)
 
     def test_get_node_for_aggregate_none_requested(self):
 

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -649,6 +649,58 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
         expected = 'fake_home_node_name'
         self.assertEqual(expected, result)
 
+    def test_get_owner_node_for_aggregate(self):
+        response = fake.AGGR_GET_OWNER_NODE_RESPONSE_REST['records']
+        self.mock_object(self.client,
+                         '_get_aggregates',
+                         mock.Mock(return_value=response))
+
+        result = self.client.get_owner_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+
+        self.assertEqual('fake_node1', result)
+
+    def test_get_owner_node_for_aggregate_failover(self):
+        response = fake.AGGR_GET_OWNER_NODE_FAILOVER_RESPONSE_REST['records']
+        self.mock_object(self.client,
+                         '_get_aggregates',
+                         mock.Mock(return_value=response))
+
+        result = self.client.get_owner_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+
+        self.assertEqual(fake.NODE_NAME2, result)
+
+    def test_get_owner_node_for_aggregate_no_name(self):
+        result = self.client.get_owner_node_for_aggregate('')
+        self.assertIsNone(result)
+
+    def test_get_owner_node_for_aggregate_none(self):
+        result = self.client.get_owner_node_for_aggregate(None)
+        self.assertIsNone(result)
+
+    @ddt.data(netapp_api.EREST_NOT_AUTHORIZED, None)
+    def test_get_owner_node_for_aggregate_error(self, code):
+        self.mock_object(self.client, '_get_aggregates',
+                         mock.Mock(side_effect=self._mock_api_error(code)))
+        if code:
+            result = self.client.get_owner_node_for_aggregate(
+                fake.SHARE_AGGREGATE_NAME)
+            self.assertIsNone(result)
+        else:
+            self.assertRaises(netapp_api.api.NaApiError,
+                              self.client.get_owner_node_for_aggregate,
+                              fake.SHARE_AGGREGATE_NAME)
+
+    def test_get_owner_node_for_aggregate_not_found(self):
+        self.mock_object(self.client,
+                         '_get_aggregates',
+                         mock.Mock(return_value=[]))
+
+        result = self.client.get_owner_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+        self.assertIsNone(result)
+
     @ddt.data({'types': {'FCAL'}, 'expected': ['FCAL']},
               {'types': {'SATA', 'SSD'}, 'expected': ['SATA', 'SSD']}, )
     @ddt.unpack

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -649,8 +649,55 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
                          '_get_aggregates',
                          mock.Mock(return_value=response))
         result = self.client.get_node_for_aggregate(fake.SHARE_AGGREGATE_NAME)
-        expected = 'fake_home_node_name'
+        expected = {
+            'home_node': 'fake_home_node_name',
+            'owner_node': 'fake_owner_node_name',
+        }
         self.assertEqual(expected, result)
+
+    def test_get_owner_node_for_aggregate(self):
+        response = fake.AGGR_GET_OWNER_NODE_FAILOVER_RESPONSE_REST['records']
+        self.mock_object(self.client,
+                         '_get_aggregates',
+                         mock.Mock(return_value=response))
+
+        result = self.client.get_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+
+        self.assertEqual({
+            'home_node': fake.NODE_NAMES[0],
+            'owner_node': fake.NODE_NAMES[1],
+        }, result)
+
+    def test_get_owner_node_for_aggregate_no_name(self):
+        result = self.client.get_node_for_aggregate('')
+        self.assertIsNone(result)
+
+    def test_get_owner_node_for_aggregate_none(self):
+        result = self.client.get_node_for_aggregate(None)
+        self.assertIsNone(result)
+
+    @ddt.data(netapp_api.EREST_NOT_AUTHORIZED, None)
+    def test_get_owner_node_for_aggregate_error(self, code):
+        self.mock_object(self.client, '_get_aggregates',
+                         mock.Mock(side_effect=self._mock_api_error(code)))
+        if code:
+            result = self.client.get_node_for_aggregate(
+                fake.SHARE_AGGREGATE_NAME)
+            self.assertIsNone(result)
+        else:
+            self.assertRaises(netapp_api.api.NaApiError,
+                              self.client.get_node_for_aggregate,
+                              fake.SHARE_AGGREGATE_NAME)
+
+    def test_get_owner_node_for_aggregate_not_found(self):
+        self.mock_object(self.client,
+                         '_get_aggregates',
+                         mock.Mock(return_value=[]))
+
+        result = self.client.get_node_for_aggregate(
+            fake.SHARE_AGGREGATE_NAME)
+        self.assertIsNone(result)
 
     @ddt.data({'types': {'FCAL'}, 'expected': ['FCAL']},
               {'types': {'SATA', 'SSD'}, 'expected': ['SATA', 'SSD']}, )

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -423,7 +423,10 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.library._have_cluster_creds = True
         self.mock_object(self.library._client,
                          'get_node_for_aggregate',
-                         mock.Mock(return_value=fake.CLUSTER_NODE))
+                         mock.Mock(return_value={
+                             'home_node': fake.CLUSTER_NODE,
+                             'owner_node': 'fake_owner'
+                         }))
 
         result = self.library._get_aggregate_node(fake.AGGREGATE)
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_performance.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_performance.py
@@ -382,14 +382,18 @@ class PerformanceLibraryTestCase(test.TestCase):
         expected_aggregate_names = ['aggr1', 'aggr2', 'aggr3']
         self.assertEqual(sorted(expected_aggregate_names), sorted(result))
 
-    def test_get_nodes_for_aggregates(self):
+    def test_get_nodes_for_aggregates_with_owner_node(self):
 
         aggregate_names = ['aggr1', 'aggr2', 'aggr3']
-        aggregate_nodes = ['node1', 'node2', 'node2']
+        owner_nodes = [
+            {'owner_node': 'node1', 'home_node': 'node1'},
+            {'owner_node': 'node2', 'home_node': 'node1'},
+            {'owner_node': 'node2', 'home_node': 'node3'}
+        ]
 
         mock_get_node_for_aggregate = self.mock_object(
             self.zapi_client, 'get_node_for_aggregate',
-            mock.Mock(side_effect=aggregate_nodes))
+            mock.Mock(side_effect=owner_nodes))
 
         result = self.perf_library._get_nodes_for_aggregates(aggregate_names)
 
@@ -397,7 +401,11 @@ class PerformanceLibraryTestCase(test.TestCase):
         result_node_names, result_aggr_node_map = result
 
         expected_node_names = ['node1', 'node2']
-        expected_aggr_node_map = dict(zip(aggregate_names, aggregate_nodes))
+        expected_aggr_node_map = {
+            'aggr1': 'node1',
+            'aggr2': 'node2',
+            'aggr3': 'node2',
+        }
         self.assertEqual(sorted(expected_node_names),
                          sorted(result_node_names))
         self.assertEqual(expected_aggr_node_map, result_aggr_node_map)

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_performance.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_performance.py
@@ -382,14 +382,14 @@ class PerformanceLibraryTestCase(test.TestCase):
         expected_aggregate_names = ['aggr1', 'aggr2', 'aggr3']
         self.assertEqual(sorted(expected_aggregate_names), sorted(result))
 
-    def test_get_nodes_for_aggregates(self):
+    def test_get_nodes_for_aggregates_with_owner_node(self):
 
         aggregate_names = ['aggr1', 'aggr2', 'aggr3']
-        aggregate_nodes = ['node1', 'node2', 'node2']
+        owner_nodes = ['node1', 'node2', 'node2']
 
-        mock_get_node_for_aggregate = self.mock_object(
-            self.zapi_client, 'get_node_for_aggregate',
-            mock.Mock(side_effect=aggregate_nodes))
+        mock_get_owner_node_for_aggregate = self.mock_object(
+            self.zapi_client, 'get_owner_node_for_aggregate',
+            mock.Mock(side_effect=owner_nodes))
 
         result = self.perf_library._get_nodes_for_aggregates(aggregate_names)
 
@@ -397,11 +397,11 @@ class PerformanceLibraryTestCase(test.TestCase):
         result_node_names, result_aggr_node_map = result
 
         expected_node_names = ['node1', 'node2']
-        expected_aggr_node_map = dict(zip(aggregate_names, aggregate_nodes))
+        expected_aggr_node_map = dict(zip(aggregate_names, owner_nodes))
         self.assertEqual(sorted(expected_node_names),
                          sorted(result_node_names))
         self.assertEqual(expected_aggr_node_map, result_aggr_node_map)
-        mock_get_node_for_aggregate.assert_has_calls([
+        mock_get_owner_node_for_aggregate.assert_has_calls([
             mock.call('aggr1'), mock.call('aggr2'), mock.call('aggr3')])
 
     def test_get_node_utilization_kahuna_overutilized(self):

--- a/releasenotes/notes/owner-node-for-aggregates-issue-d90ec96bf4ee42a8.yaml
+++ b/releasenotes/notes/owner-node-for-aggregates-issue-d90ec96bf4ee42a8.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed an issue on the NetApp ONTAP driver where performance data
+    collection failed when a cluster node was down and its aggregates
+    had been taken over by a partner node. Performance counters are
+    now retrieved from the node that currently owns the aggregate
+    instead of its configured home node, allowing pool capabilities
+    and scheduler weighing to keep working correctly during storage
+    failover scenarios.


### PR DESCRIPTION
- added get_node_for_aggregate function to retrieve the current owner node of an aggregate. This is needed for takeover scenarios where the aggregate owner may differ from its home node
- fix owner node retrieval for aggregates when the home node is unaccessible

Closes-Bug: #2142115
Change-Id: I78090e1f84e4b846d8d2b5723d9e57c782036b1a