### PR TITLE
[SCI] Make snapshot provider_location visible to all members

### DIFF
--- a/manila/api/views/share_snapshots.py
+++ b/manila/api/views/share_snapshots.py
@@ -64,11 +64,12 @@ class ViewBuilder(common.ViewBuilder):
         return {'snapshot': snapshot_dict}
 
     @common.ViewBuilder.versioned_method("2.12")
-    def add_provider_location_field(self, context, snapshot_dict, snapshot):
+    def add_provider_location_field(self, _context, snapshot_dict, snapshot):
         # NOTE(xyang): Only retrieve provider_location for admin.
-        if context.is_admin:
-            snapshot_dict['provider_location'] = snapshot.get(
-                'provider_location')
+        # if context.is_admin:
+        # provider_location is now visible to all users, not just admins.
+        snapshot_dict['provider_location'] = snapshot.get(
+            'provider_location')
 
     @common.ViewBuilder.versioned_method("2.17")
     def add_project_and_user_ids(self, context, snapshot_dict, snapshot):

--- a/manila/tests/fake_share.py
+++ b/manila/tests/fake_share.py
@@ -202,6 +202,11 @@ def expected_snapshot(version=None, id='fake_snapshot_id', **kwargs):
     }
 
     if version and (api_version.APIVersionRequest(version)
+                    >= api_version.APIVersionRequest('2.12')):
+        snapshot.update({
+            'provider_location': None,
+        })
+    if version and (api_version.APIVersionRequest(version)
                     >= api_version.APIVersionRequest('2.17')):
         snapshot.update({
             'user_id': 'fakesnapuser',


### PR DESCRIPTION
__Summary__
Expose `provider_location` in the share snapshot detail response to all users, not only admins.

__Changes__
- Removed the context.is_admin guard for provider_location
- Renamed the unused context parameter to _context
- Kept the field populated from snapshot.get('provider_location')
