### PR TITLE
Create a new transaction for processing each table

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -6026,6 +6026,65 @@ def availability_zone_get_all(context):
 
 
 @require_admin_context
+@context_manager.writer.independent
+def _purge_table_records(context, model, table_name, deleted_age):
+    s_deleted_records = context.session.query(
+        model
+    ).filter(model.deleted_at <= deleted_age)
+    deleted_count = 0
+
+    # delete records one by one,
+    # skip the records which has FK constraints
+    for record in s_deleted_records:
+        try:
+            with context.session.begin_nested():
+                context.session.delete(record)
+                deleted_count += 1
+        except db_exc.DBError:
+            LOG.warning(
+                "Deleting soft-deleted resource %s failed, skipping.",
+                record
+            )
+    if deleted_count != 0:
+        LOG.info(
+            "Deleted %(count)s records in table %(table)s.",
+            {'count': deleted_count, 'table': table_name}
+        )
+
+#####################
+
+
+@require_admin_context
+@context_manager.writer.independent
+def _purge_sec_service_associations(context, deleted_age):
+    """Own transaction: delete stale share-network/security-service assocs."""
+    sec_assoc_to_delete = context.session.query(
+        models.ShareNetworkSecurityServiceAssociation
+    ).join(
+        models.ShareNetwork
+    ).join(
+        models.SecurityService
+    ).filter(
+        or_(
+            models.ShareNetwork.deleted_at <= deleted_age,
+            models.SecurityService.deleted_at <= deleted_age,
+        )
+    ).all()
+
+    for assoc in sec_assoc_to_delete:
+        try:
+            with context.session.begin_nested():
+                context.session.delete(assoc)
+        except db_exc.DBError:
+            LOG.warning(
+                "Deleting association %s failed, skipping.",
+                assoc
+            )
+
+####################
+
+
+@require_admin_context
 def purge_deleted_records(context, age_in_days):
     """Purge soft-deleted records older than(and equal) age from tables."""
 
@@ -6034,65 +6093,34 @@ def purge_deleted_records(context, age_in_days):
         LOG.error(msg)
         raise exception.InvalidParameterValue(msg)
 
+    deleted_age = timeutils.utcnow() - datetime.timedelta(days=age_in_days)
+
+    _purge_sec_service_associations(context, deleted_age)
+
     metadata = MetaData()
     metadata.reflect(get_engine())
     tables = metadata.sorted_tables
     if not tables:
         msg = 'No tables found, check database connection'
         raise exception.InvalidResults(msg)
-    tables_without_id = ['async_operation_data', 'backend_info',
-                         'drivers_private_data']
-    session = get_session()
-    deleted_age = timeutils.utcnow() - datetime.timedelta(days=age_in_days)
+
+    # Build model lookup once
+    model_by_table = {m.__tablename__: m
+                      for m in models.__dict__.values()
+                      if hasattr(m, '__tablename__')}
 
     for table in reversed(tables):
-        if 'deleted' in table.columns.keys():
-            session.begin()
-            try:
-                mds = [m for m in models.__dict__.values() if
-                       (hasattr(m, '__tablename__') and
-                        m.__tablename__ == str(table))]
-                if len(mds) > 0:
-                    # collect all soft-deleted records
-                    with session.begin_nested():
-                        model = mds[0]
-                        if str(table) in tables_without_id:
-                            s_deleted_records = session.query(model).filter(
-                                model.deleted_at <= deleted_age,
-                                model.deleted == 1)
-                        else:
-                            # NOTE: table.columns['deleted'].type.python_type
-                            # is str (default 'False') or int (default 0),
-                            # but both are set to the id on soft-delete
-                            s_deleted_records = (
-                                session.query(model)
-                                .filter(
-                                    model.deleted_at <= deleted_age,
-                                    model.deleted == model.id,
-                                )
-                                .order_by('deleted_at')
-                            )
+        if 'deleted' not in table.columns.keys():
+            continue
 
-                    deleted_count = 0
-                    # delete records one by one,
-                    # skip the records which has FK constraints
-                    for record in s_deleted_records:
-                        try:
-                            with session.begin_nested():
-                                session.delete(record)
-                                deleted_count += 1
-                        except db_exc.DBError:
-                            LOG.error(
-                                ("Deleting soft-deleted resource %s "
-                                 "failed, skipping."), record)
-                    if deleted_count != 0:
-                        LOG.info("Deleted %(count)s records in "
-                                 "table %(table)s.",
-                                 {'count': deleted_count, 'table': table})
+        table_name = table.name
+        if table_name in model_by_table:
+            try:
+                _purge_table_records(context, model_by_table[table_name],
+                                     table_name, deleted_age)
             except db_exc.DBError:
-                LOG.error("Querying table %s's soft-deleted records "
-                          "failed, skipping.", table)
-            session.commit()
+                LOG.warning("Querying table %s's soft-deleted records "
+                            "failed, skipping.", table_name)
 
 
 ####################

--- a/releasenotes/notes/bug-2081827-improve-api-performance-when-purging-delete-records.yaml
+++ b/releasenotes/notes/bug-2081827-improve-api-performance-when-purging-delete-records.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Improved the ``purge_deleted_records`` database cleanup logic to
+    process each table in an independent transaction instead of a
+    single long-running transaction. This reduces the duration of
+    table locks during purge.


### PR DESCRIPTION
Single-transaction approach holds locks across all tables during purge, potentially blocking tables for long.

This patch introduces a behavioural change on errors: previously, in theory, a fatal error could roll back everything; now it only rolls back partially (per-table).

Closes-Bug: #2081827

Change-Id: Ieee2a5c5ac3ae33f1f145d3b8ade7bc497231660

(cherry picked from commit 6fc88854b1acd0fa92328ba7d87c397b2574407e)