### PR TITLE
SCI: add user-facing messages for CIFS server setup failures

### DIFF
--- a/manila/exception.py
+++ b/manila/exception.py
@@ -663,6 +663,14 @@ class SecurityServiceFailedAuth(ManilaException):
     message = _("Failed to authenticate user against security service.")
 
 
+class CifsServerSetupFailed(ManilaException):
+    message = _("Failed to setup CIFS/Active Directory server.")
+
+
+class CifsServerCertificateError(ManilaException):
+    message = _("Failed to setup CIFS server due to a certificate error.")
+
+
 class InvalidVolume(Invalid):
     message = _("Invalid volume.")
 

--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -171,6 +171,19 @@ class Detail(object):
           "it is not passed to share driver to perform required operation."))
 
     # ////////////////////////// SCI custom message //////////////////////////
+    CIFS_SERVER_CERTIFICATE_ERROR = (
+        '993',
+        _("Share Driver failed to setup the CIFS server due to a TLS/SSL "
+          "certificate error. Either the CA certificate used to sign the "
+          "Active Directory domain controller certificate is not in the list "
+          "of allowed CAs, or the domain controller hostname does not match "
+          "the certificate. Please refer to the documentation for the list "
+          "of allowed CAs."))
+    CIFS_SERVER_SETUP_FAILED = (
+        '994',
+        _("Failed to setup the CIFS/Active Directory server after multiple "
+          "attempts. Please contact your administrator to check the storage "
+          "backend logs for details."))
     EXTERNAL_SCHEDULER_FILTERED_ALL_HOSTS = (
         '995',
         _("External scheduler API has filtered out all hosts."))
@@ -228,7 +241,9 @@ class Detail(object):
         SHARE_BACKEND_NOT_READY_YET,
         UPDATE_METADATA_SUCCESS,
         UPDATE_METADATA_FAILURE,
-        UPDATE_METADATA_NOT_DELETED
+        UPDATE_METADATA_NOT_DELETED,
+        CIFS_SERVER_SETUP_FAILED,
+        CIFS_SERVER_CERTIFICATE_ERROR,
     )
 
     # Exception and detail mappings

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2078,6 +2078,9 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             except netapp_api.NaApiError as e:
                 credential_msg = "could not authenticate"
                 privilege_msg = "insufficient access"
+                cert_missing_msg = "required certificate with ca"
+                cert_verify_msg = "certificate verify failed"
+                tls_mismatch_msg = "does not match cn"
                 if (e.code == netapp_api.EAPIERROR and (
                         credential_msg in e.message.lower() or
                         privilege_msg in e.message.lower())):
@@ -2086,6 +2089,12 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                                  "or privileges. %s")
                     raise exception.SecurityServiceFailedAuth(
                         auth_msg % e.message)
+                msg_lower = e.message.lower()
+                if e.code == netapp_api.EAPIERROR and (
+                        cert_missing_msg in msg_lower or
+                        cert_verify_msg in msg_lower or
+                        tls_mismatch_msg in msg_lower):
+                    raise exception.CifsServerCertificateError(e.message)
                 LOG.debug("Failed to create CIFS server entry. %s", e.message)
                 time.sleep(3)
                 if attempt == 2:
@@ -2098,7 +2107,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                     self.configure_cifs_encryption(secure=True)
                 continue
         msg = _('Cannot setup CIFS server after 12 attempts.')
-        raise exception.NetAppException(msg)
+        raise exception.CifsServerSetupFailed(msg)
 
     @na_utils.trace
     def modify_active_directory_security_service(

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2341,6 +2341,38 @@ class ShareManager(manager.SchedulerDependentManager):
                         resource_id=share_id,
                         detail=(message_field.Detail
                                 .SECURITY_SERVICE_FAILED_AUTH))
+            except exception.CifsServerCertificateError:
+                with excutils.save_and_reraise_exception():
+                    LOG.warning("Provision of share server failed: CIFS AD "
+                                "join failed due to a certificate error.")
+                    self.db.share_instance_update(
+                        context, share_instance_id,
+                        {'status': constants.STATUS_ERROR}
+                    )
+                    self.message_api.create(
+                        context,
+                        message_field.Action.CREATE,
+                        share['project_id'],
+                        resource_type=message_field.Resource.SHARE,
+                        resource_id=share_id,
+                        detail=(message_field.Detail
+                                .CIFS_SERVER_CERTIFICATE_ERROR))
+            except exception.CifsServerSetupFailed:
+                with excutils.save_and_reraise_exception():
+                    LOG.warning("Provision of share server failed: CIFS "
+                                "server could not be set up after all "
+                                "retries.")
+                    self.db.share_instance_update(
+                        context, share_instance_id,
+                        {'status': constants.STATUS_ERROR}
+                    )
+                    self.message_api.create(
+                        context,
+                        message_field.Action.CREATE,
+                        share['project_id'],
+                        resource_type=message_field.Resource.SHARE,
+                        resource_id=share_id,
+                        detail=message_field.Detail.CIFS_SERVER_SETUP_FAILED)
             except exception.IpAddressGenerationFailureClient:
                 with excutils.save_and_reraise_exception():
                     error = ("Creation of share instance %s failed: "


### PR DESCRIPTION
Add two new SCI custom messages (993, 994) to surface actionable
error details to users when CIFS/AD server setup fails:
- 994: generic setup failure after all retries exhausted
- 993: TLS/SSL certificate error (missing/invalid CA or CN mismatch)
