### PR TITLE
fix to get soft-deleted objects on db model query

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -289,8 +289,10 @@ def model_query(context, model, *args, **kwargs):
         kwargs['project_id'] = context.project_id
     if read_deleted in ('no', 'n', False):
         kwargs['deleted'] = False
-    elif read_deleted in ('yes', 'y', True):
+    elif read_deleted == 'only':
         kwargs['deleted'] = True
+    elif read_deleted in ('yes', 'y', True):
+        pass
 
     return db_utils.model_query(
         model=model,

--- a/manila/tests/db/sqlalchemy/test_api.py
+++ b/manila/tests/db/sqlalchemy/test_api.py
@@ -343,6 +343,29 @@ class ShareDatabaseAPITestCase(test.TestCase):
         super(ShareDatabaseAPITestCase, self).setUp()
         self.ctxt = context.get_admin_context()
 
+    @ddt.data('yes', 'no', 'only')
+    def test_share_read_deleted(self, read_deleted):
+        share = db_utils.create_share()
+        test_ctxt = context.get_admin_context(read_deleted=read_deleted)
+        admin_ctxt = context.get_admin_context(read_deleted='yes')
+
+        if read_deleted in ('yes', 'no'):
+            self.assertIsNotNone(db_api.share_get(test_ctxt, share['id']))
+        elif read_deleted == 'only':
+            self.assertRaises(exception.NotFound, db_api.share_get,
+                              test_ctxt, share['id'])
+
+        # we don't use the to be tested context here and
+        # we need to delete the share instance before we can delete the share
+        db_api.share_instance_delete(admin_ctxt, share['instance']['id'])
+        db_api.share_delete(admin_ctxt, share['id'])
+
+        if read_deleted in ('yes', 'only'):
+            self.assertIsNotNone(db_api.share_get(test_ctxt, share['id']))
+        elif read_deleted == 'no':
+            self.assertRaises(exception.NotFound, db_api.share_get,
+                              test_ctxt, share['id'])
+
     def test_share_filter_by_host_with_pools(self):
         share_instances = [[
             db_api.share_create(self.ctxt, {'host': value}).instance
@@ -4170,9 +4193,7 @@ class PurgeDeletedTest(test.TestCase):
 
     def setUp(self):
         super(PurgeDeletedTest, self).setUp()
-        # FIXME: adjust to read_deleted="yes" after 2023.2 bobcat
-        # because of https://review.opendev.org/c/openstack/manila/+/879294
-        self.context = context.get_admin_context(read_deleted="only")
+        self.context = context.get_admin_context(read_deleted="yes")
 
     def _days_ago(self, begin, end):
         return timeutils.utcnow() - datetime.timedelta(

--- a/releasenotes/notes/bug-2015094-fix-read-deleted-sqlalchemy-cda2dca772ce8d0a.yaml
+++ b/releasenotes/notes/bug-2015094-fix-read-deleted-sqlalchemy-cda2dca772ce8d0a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Internal sqlalchemy model_query has been fixed to honor the options of the
+    `read_deleted` parameter. For more details, please refer to
+    `launchpad bug #2015094 <https://bugs.launchpad.net/manila/+bug/2015094>`_


### PR DESCRIPTION
backport of https://review.opendev.org/c/openstack/manila/+/879294

This fixes 9f7f9bd03736d2d0d49904efb569d6ea9161311a, if the subnet is not deleted at that point. Avoids orphaned ports.

we need a follow-up to adjust https://github.com/sapcc/manila-extensions/blob/8e8c9cca3ce776ba9eee11f4a5abf7c6a2c5df63/cc/manila/cmd/manage.py#L209-L215 after this has been merged
