### PR TITLE
db purge: fix share_access_map FK violation on purge

### DIFF
--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -6096,6 +6096,37 @@ def _purge_sec_service_associations(context, deleted_age):
 
 
 @require_admin_context
+@context_manager.writer.independent
+def _purge_share_access_map(context, deleted_age):
+    """Purge share_access_map and child share_instance_access_map rows."""
+    # Find share_access_map records that are eligible for purge.
+    access_maps_to_delete = context.session.query(
+        models.ShareAccessMapping
+    ).filter(
+        models.ShareAccessMapping.deleted_at <= deleted_age,
+        models.ShareAccessMapping.deleted == models.ShareAccessMapping.id,
+    ).all()
+
+    for access_map in access_maps_to_delete:
+        try:
+            with context.session.begin_nested():
+                # Delete child share_instance_access_map rows first.
+                context.session.query(
+                    models.ShareInstanceAccessMapping
+                ).filter_by(access_id=access_map.id).delete(
+                    synchronize_session='fetch')
+                context.session.delete(access_map)
+        except db_exc.DBError:
+            LOG.warning(
+                "Deleting access_map %s failed, skipping.",
+                access_map,
+            )
+
+
+####################
+
+
+@require_admin_context
 def purge_deleted_records(context, age_in_days):
     """Purge soft-deleted records older than(and equal) age from tables."""
 
@@ -6107,6 +6138,7 @@ def purge_deleted_records(context, age_in_days):
     deleted_age = timeutils.utcnow() - datetime.timedelta(days=age_in_days)
 
     _purge_sec_service_associations(context, deleted_age)
+    _purge_share_access_map(context, deleted_age)
 
     metadata = MetaData()
     metadata.reflect(get_engine())
@@ -6120,6 +6152,13 @@ def purge_deleted_records(context, age_in_days):
     tables_without_id = {'async_operation_data', 'backend_info',
                          'drivers_private_data'}
 
+    # Tables handled by dedicated purge helpers above; skip in the main loop
+    # to avoid FK constraint errors from incorrect deletion ordering.
+    tables_with_dedicated_purge = {
+        'share_access_map',
+        'share_network_security_service_association'
+    }
+
     # Build model lookup once
     model_by_table = {m.__tablename__: m
                       for m in models.__dict__.values()
@@ -6130,6 +6169,8 @@ def purge_deleted_records(context, age_in_days):
             continue
 
         table_name = table.name
+        if table_name in tables_with_dedicated_purge:
+            continue
         if table_name in model_by_table:
             try:
                 _purge_table_records(

--- a/manila/tests/db/sqlalchemy/test_api.py
+++ b/manila/tests/db/sqlalchemy/test_api.py
@@ -4310,6 +4310,116 @@ class PurgeDeletedTest(test.TestCase):
                                       models.ShareTypes).count()
         self.assertEqual(0, s_row + type_row)
 
+    def test_purge_skips_records_with_stale_deleted_at_but_not_soft_deleted(
+            self):
+        fake_now = timeutils.utcnow()
+        with mock.patch.object(timeutils, 'utcnow',
+                               mock.Mock(return_value=fake_now)):
+            share_type_id = uuidutils.generate_uuid()
+            # Create a share type with deleted_at set but deleted NOT equal
+            # to its id (simulates an un-deleted record with a stale
+            # deleted_at).
+            db_utils.create_share_type(
+                id=share_type_id,
+                deleted='False',
+                deleted_at=fake_now - datetime.timedelta(days=1))
+
+            db_api.purge_deleted_records(self.context, age_in_days=0)
+
+            rows = db_api.model_query(
+                self.context, models.ShareTypes).count()
+            # The record must survive because deleted != id.
+            self.assertEqual(1, rows)
+
+    def test_purge_tables_without_id_uses_deleted_equals_one(self):
+        fake_now = timeutils.utcnow()
+        with mock.patch.object(timeutils, 'utcnow',
+                               mock.Mock(return_value=fake_now)):
+            entity_uuid = uuidutils.generate_uuid()
+            old_time = fake_now - datetime.timedelta(days=2)
+
+            # Insert a soft-deleted drivers_private_data row directly via
+            # the session (deleted=1, deleted_at set).
+            with db_api.context_manager.writer.using(self.context):
+                self.context.session.execute(
+                    models.DriverPrivateData.__table__.insert(),
+                    {'entity_uuid': entity_uuid,
+                     'key': 'test_key',
+                     'value': 'test_value',
+                     'deleted': 1,
+                     'deleted_at': old_time,
+                     'created_at': old_time,
+                     'updated_at': None})
+            # Insert a live row (deleted=0) that must survive.
+            entity_uuid_live = uuidutils.generate_uuid()
+            with db_api.context_manager.writer.using(self.context):
+                self.context.session.execute(
+                    models.DriverPrivateData.__table__.insert(),
+                    {'entity_uuid': entity_uuid_live,
+                     'key': 'live_key',
+                     'value': 'live_value',
+                     'deleted': 0,
+                     'deleted_at': None,
+                     'created_at': fake_now,
+                     'updated_at': None})
+
+            db_api.purge_deleted_records(self.context, age_in_days=0)
+
+            with db_api.context_manager.reader.using(self.context):
+                rows = self.context.session.query(
+                    models.DriverPrivateData).count()
+            # Only the live row must remain.
+            self.assertEqual(1, rows)
+
+    def test_purge_share_access_map_cleans_up_instance_access_map(self):
+        """Purging share_access_map must not raise an IntegrityError. """
+        fake_now = timeutils.utcnow()
+        with mock.patch.object(timeutils, 'utcnow',
+                               mock.Mock(return_value=fake_now)):
+            deleted_at = fake_now - datetime.timedelta(days=1)
+            access_id = uuidutils.generate_uuid()
+
+            # Create share and instance while access rule is live.
+            share = db_utils.create_share_without_instance(metadata={})
+            instance = db_utils.create_share_instance(
+                share_id=share['id'])
+
+            # Create soft-deleted access rule directly via db_utils.
+            db_utils.create_share_access(
+                context=self.context,
+                id=access_id,
+                share_id=share['id'],
+                deleted=access_id,
+                deleted_at=deleted_at)
+
+            # Insert a live share_instance_access_map row referencing the
+            # access rule (worst case for FK violation).
+            instance_access_id = uuidutils.generate_uuid()
+            with db_api.context_manager.writer.using(self.context):
+                self.context.session.execute(
+                    models.ShareInstanceAccessMapping.__table__.insert(),
+                    {'id': instance_access_id,
+                     'share_instance_id': instance['id'],
+                     'access_id': access_id,
+                     'state': 'active',
+                     'deleted': 'False',
+                     'created_at': fake_now,
+                     'updated_at': None,
+                     'deleted_at': None})
+
+            # Must not raise an IntegrityError.
+            db_api.purge_deleted_records(self.context, age_in_days=0)
+
+            with db_api.context_manager.reader.using(self.context):
+                access_rows = db_api.model_query(
+                    self.context, models.ShareAccessMapping,
+                    read_deleted='yes').count()
+                instance_access_rows = self.context.session.query(
+                    models.ShareInstanceAccessMapping).count()
+            # Parent purged, child cleaned up.
+            self.assertEqual(0, access_rows)
+            self.assertEqual(0, instance_access_rows)
+
 
 @ddt.ddt
 class ShareTypeAPITestCase(test.TestCase):


### PR DESCRIPTION
Purging a soft-deleted share_access_map row while
share_instance_access_map rows still reference it (via the NOT NULL access_id FK) causes an IntegrityError. This mirrors the same pattern already handled by _purge_sec_service_associations.

Add _purge_share_access_map which deletes all referencing share_instance_access_map child rows first, then deletes the parent share_access_map row in the same nested transaction. Exclude share_access_map from the generic _purge_table_records loop to avoid double-processing.

Closes-bug: #2081827
Change-Id: I361e1bb56c17360f9ff625a48c92fc64ac5b9294