### PR TITLE
Fix TypeError in capacity weigher when capacity is None

### DIFF
--- a/manila/scheduler/weighers/capacity.py
+++ b/manila/scheduler/weighers/capacity.py
@@ -78,10 +78,17 @@ class CapacityWeigher(base_host.BaseHostWeigher):
             if use_thin_logic and thin_provisioning:
                 # NOTE(xyang): Calculate virtual free capacity for thin
                 # provisioning.
-                free = math.floor(
-                    total * host_state.max_over_subscription_ratio -
-                    host_state.provisioned_capacity_gb -
-                    total * reserved)
+                if host_state.provisioned_capacity_gb is not None:
+                    free = math.floor(
+                        total * host_state.max_over_subscription_ratio -
+                        host_state.provisioned_capacity_gb -
+                        total * reserved)
+                else:
+                    # None is treated same as 'unknown'
+                    if CONF.capacity_weight_multiplier > 0:
+                        free = float('-inf')
+                    else:
+                        free = float('inf')
             else:
                 # NOTE(xyang): Calculate how much free space is left after
                 # taking into account the reserved space.

--- a/manila/tests/scheduler/weighers/test_capacity.py
+++ b/manila/tests/scheduler/weighers/test_capacity.py
@@ -146,6 +146,30 @@ class CapacityWeigherTestCase(test.TestCase):
             'host6', utils.extract_host(last_host.obj.host))
         self.assertEqual(0.0, last_host.weight)
 
+    def test_none_provisioned_capacity_thin_is_treated_as_unknown(self):
+        """None provisioned_capacity_gb in thin path must sort to worst."""
+        host_state = mock.Mock()
+        host_state.free_capacity_gb = 500
+        host_state.total_capacity_gb = 1024
+        host_state.provisioned_capacity_gb = None
+        host_state.max_over_subscription_ratio = 2.0
+        host_state.thin_provisioning = True
+        host_state.reserved_percentage = 0
+        host_state.reserved_snapshot_percentage = 0
+        host_state.reserved_share_extend_percentage = 0
+
+        weigher = capacity.CapacityWeigher()
+        weight_properties = {
+            'size': 1,
+            'share_type': {
+                'extra_specs': {
+                    'capabilities:thin_provisioning': '<is> True',
+                }
+            }
+        }
+        result = weigher._weigh_object(host_state, weight_properties)
+        self.assertEqual(float('-inf'), result)
+
     @ddt.data(
         {'cap_thin': '<is> True',
          'cap_thin_key': 'capabilities:thin_provisioning',

--- a/releasenotes/notes/bug-2145805-Fix-TypeError-in-capacity-weigher-1facc9636e4abdde.yaml
+++ b/releasenotes/notes/bug-2145805-Fix-TypeError-in-capacity-weigher-1facc9636e4abdde.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Manila scheduler capacity weigher is fixed in case provisioned_capacity_gb
+    is None. For more details, please refer to
+    `launchpad bug #2145805 <https://bugs.launchpad.net/manila/+bug/2145805>`_.


### PR DESCRIPTION
When free_capacity_gb, total_capacity_gb, or provisioned_capacity_gb is None, the weigher previously raised a TypeError by attempting arithmetic with None. Following the existing 'unknown' treatment, None values are now handled as worst-case (sorts to bottom), which is safer than assuming zero provisioned capacity.

Closes-bug: #2145805
Change-Id: I6e7e9dce772beebadd6199039aed5906e6ba24e6

(cherry picked from commit 3c04a171dee22bf41cac8c8df2c7f04910c88d36)