### PR TITLE
NetApp: Fix cross-volume-dedup preservation during SVM migration

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -830,16 +830,17 @@ class NetAppCmodeFileStorageLibrary(object):
     def create_share(self, context, share, share_server):
         """Creates new share."""
         vserver, vserver_client = self._get_vserver(share_server=share_server)
-        # SAPCC
+        # SCI
         # Force enabling logical-space-reporting on new Volumes.
-        # Disable cross volume dedupe in neo projects.
         # Set logical space settings to False for hypervisor_storage types
+        # Disable cross volume dedupe based on share metadata
         provisioning_options = {'logical_space_reporting': True}
         share_type = (
             share_types.get_share_type(context, share.get('share_type_id')))
         if share_type['name'].startswith('hypervisor_storage'):
             provisioning_options = {'logical_space_reporting': False}
-        if context.project_domain_name in ['neo']:
+        metadata = share.get('metadata', {})
+        if metadata.get('cross_dedup_disabled') == 'true':
             provisioning_options['dedup_enabled'] = True
             provisioning_options['compression_enabled'] = True
             provisioning_options['cross_dedup_disabled'] = True
@@ -2696,6 +2697,12 @@ class NetAppCmodeFileStorageLibrary(object):
         if share_comment is None:
             share_comment = self._get_backend_share_comment(share)
 
+        replica_state = share.get('replica_state')
+        is_replica = True
+        if (replica_state is None or
+                replica_state == constants.REPLICA_STATE_ACTIVE):
+            is_replica = False
+
         extra_specs = share_types.get_extra_specs_from_share(share)
         provisioning_options = self._get_provisioning_options_for_share(
             share, vserver, vserver_client=vserver_client, set_qos=False)
@@ -2731,6 +2738,18 @@ class NetAppCmodeFileStorageLibrary(object):
             if snapshot_policy:
                 provisioning_options['snapshot_policy'] = snapshot_policy
 
+            # SCI: Allow setting cross-dedup-disabled via metadata
+            # Admins can set metadata 'cross_dedup_disabled=true' on any share
+            # to enable this setting. This is useful for:
+            # - Fixing neo shares that lost this setting during SVM migration
+            # - Applying the setting to shares in other domains if needed
+            if metadata.get('cross_dedup_disabled') == 'true':
+                LOG.info('Applying cross_dedup_disabled from metadata for '
+                         'share %s', share_name)
+                provisioning_options['cross_dedup_disabled'] = True
+                provisioning_options['dedup_enabled'] = True
+                provisioning_options['compression_enabled'] = True
+
         modify_args = {
             'share': share_name,
             'aggr': aggregate_name,
@@ -2740,30 +2759,19 @@ class NetAppCmodeFileStorageLibrary(object):
         try:
             vserver_client.modify_volume(aggregate_name, share_name,
                                          comment=share_comment,
+                                         replica=is_replica,
                                          **provisioning_options)
         except netapp_api.NaApiError:
             LOG.warning('update share %(share)s on aggregate %(aggr)s with '
                         'provisioning options %(options)s failed', modify_args)
 
-        # TODO(carthaca): change to 'is_readable' condition
         # non-active (i.e. 'dr') replicas do not have export locations
         # and cannot have their max files modified
         is_readable_replica = self._is_readable_replica(share)
-        replica_state = share.get('replica_state')
-        if (replica_state is not None and
-                replica_state != constants.REPLICA_STATE_ACTIVE and
-                not is_readable_replica):
+        if (is_replica and not is_readable_replica):
             return []
 
-        if not is_readable_replica:
-            if provisioning_options.get('max_files_multiplier') is not None:
-                max_files_multiplier = provisioning_options.pop(
-                    'max_files_multiplier')
-                max_files = na_utils.calculate_max_files(share['size'],
-                                                         max_files_multiplier)
-                vserver_client.set_volume_max_files(share_name, max_files)
-
-        else:
+        if is_readable_replica:
             # we do not build a different vserver client for the
             # readable replicas (here and for _create_export() below),
             # because we trust that we only operate on share instances local
@@ -2773,6 +2781,13 @@ class NetAppCmodeFileStorageLibrary(object):
 
             if not existing_mount:
                 vserver_client.mount_volume(share_name)
+        else:   # is active replica (or non-replica share)
+            if provisioning_options.get('max_files_multiplier') is not None:
+                max_files_multiplier = provisioning_options.pop(
+                    'max_files_multiplier')
+                max_files = na_utils.calculate_max_files(share['size'],
+                                                         max_files_multiplier)
+                vserver_client.set_volume_max_files(share_name, max_files)
 
         return self._create_export(share, share_server, vserver,
                                    vserver_client,

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -2046,9 +2046,14 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 dest_aggregate = volume.get('aggregate')
 
                 if not migration_id:
+                    # SVM DR
                     # Update share attributes according with share extra specs.
                     self._update_share_attributes_after_server_migration(
                         instance, src_client, dest_aggregate, dest_client)
+                else:
+                    # SVM Migrate
+                    self._update_share_efficiency_after_server_migration(
+                        instance, dest_client)
 
             except Exception:
                 msg_args = {
@@ -2250,6 +2255,32 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         # Modify volume to match extra specs
         dest_client.modify_volume(dest_aggregate, volume_name,
                                   **provisioning_options)
+
+    def _update_share_efficiency_after_server_migration(
+            self, share_instance, dest_client):
+        """Updates efficiency settings after SVM Migrate based on metadata.
+
+        SVM Migrate is a physical copy operation that may not preserve
+        cross-volume-deduplication settings correctly. This method checks
+        the share's metadata (set at creation) and re-applies the efficiency
+        settings to the destination volume if needed.
+        """
+        volume_name = self._get_backend_share_name(share_instance['id'])
+
+        metadata = share_instance.get('metadata', {})
+        if metadata.get('cross_dedup_disabled') == 'true':
+            LOG.info('Restoring cross-dedup-disabled for share %s after '
+                     'migration based on metadata', volume_name)
+            try:
+                dest_client.update_volume_efficiency_attributes(
+                    volume_name,
+                    dedup_enabled=True,
+                    compression_enabled=True,
+                    cross_dedup_disabled=True,
+                    is_flexgroup=False)
+            except Exception as e:
+                LOG.warning('Failed to restore efficiency settings for share '
+                            '%s after migration: %s', volume_name, e)
 
     def validate_provisioning_options_for_share(self, provisioning_options,
                                                 extra_specs=None,

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2439,10 +2439,21 @@ class ShareManager(manager.SchedulerDependentManager):
                             "mandatory for protocol %s.") %
                             share_instance.get('share_proto'))
 
-        # SAPCC Get project_domain_name from request_spec and set to context
+        # SCI: Get project_domain_name from request_spec and set to context
+        # IDEA: reuse to set domain name to volume tags in the future
         if context.project_domain_name is None and request_spec:
             context.project_domain_name = request_spec.get(
                 'project_domain_name')
+
+        # SCI: Set cross_dedup_disabled metadata for neo domain shares
+        if (hasattr(context, 'project_domain_name') and
+                context.project_domain_name in ['neo']):
+            self.db.share_metadata_update(
+                context, share['id'],
+                {'cross_dedup_disabled': 'true'},
+                delete=False)
+            LOG.debug('Set cross_dedup_disabled metadata for neo share %s',
+                      share['id'])
 
         status = constants.STATUS_AVAILABLE
         try:

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -3077,6 +3077,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library, '_delete_share')
         mock_update_share_attrs = self.mock_object(
             self.library, '_update_share_attributes_after_server_migration')
+        mock_update_efficiency = self.mock_object(
+            self.library, '_update_share_efficiency_after_server_migration')
         self.mock_object(data_motion, 'get_client_for_host',
                          mock.Mock(return_value=self.mock_dest_client))
         self.mock_object(self.mock_dest_client, 'list_network_interfaces',
@@ -3146,9 +3148,14 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             mock_update_share_attrs.assert_called_once_with(
                 fake.SHARE_INSTANCE, self.mock_src_client,
                 fake_volume['aggregate'], self.mock_dest_client)
+            mock_update_efficiency.assert_not_called()
         else:
             mock_complete_svm_migrate.assert_called_once_with(
                 migration_id, self.fake_dest_share_server)
+            # SCI: SVM Migrate should update efficiency settings
+            mock_update_efficiency.assert_called_once_with(
+                fake.SHARE_INSTANCE, self.mock_dest_client)
+            mock_update_share_attrs.assert_not_called()
             self.mock_dest_client.list_network_interfaces.assert_called_once()
             data_motion.get_client_for_host.assert_has_calls([
                 mock.call(self.fake_dest_share_server['host']),


### PR DESCRIPTION
SVM Migrate does not preserve cross-volume-deduplication settings,
causing neo domain shares to lose their inline-only efficiency
policy after migration. This results in metadata bloat that can
fill volumes.

This change introduces a manila share metadata-based approach where
cross_dedup_disabled is stored as share metadata and used as the
single source of truth across all flows (create/update/migration).

Changes:
- Manager: Set cross_dedup_disabled=true metadata for neo shares
  at creation time (share/manager.py)
- Driver: Check metadata instead of context.project_domain_name
  in create_share and update_share (lib_base.py)
- Migration: Read metadata and restore ONTAP settings after
  SVM Migrate completes (lib_multi_svm.py)
- Tests: Update migration tests to verify efficiency restoration

Benefits:
- Transparent: Users can see/modify metadata
- Consistent: Same mechanism for all operations
- Self-healing: ensure reapplies settings from metadata
- User-serviceable: Broken shares can be fixed by setting metadata

For already-migrated shares, admins/users can remediate by setting:
  openstack share metadata set <share-id> cross_dedup_disabled=true

Assisted-By: Claude 4.5 Sonnet
Change-Id: I372878a7815849edc237c47d7f33a6eb32eb1a98
