### PR TITLE
Improve share snapshot and access list performance

### DIFF
--- a/manila/db/sqlalchemy/models.py
+++ b/manila/db/sqlalchemy/models.py
@@ -588,7 +588,7 @@ class ShareAccessMapping(BASE, ManilaBase):
 
     instance_mappings = orm.relationship(
         "ShareInstanceAccessMapping",
-        lazy='subquery',
+        lazy='selectin',
         primaryjoin=(
             'and_('
             'ShareAccessMapping.id == '
@@ -610,7 +610,7 @@ class ShareAccessRulesMetadata(BASE, ManilaBase):
     access = orm.relationship(
         ShareAccessMapping, backref="share_access_rules_metadata",
         foreign_keys=access_id,
-        lazy='subquery',
+        lazy='selectin',
         primaryjoin='and_('
         'ShareAccessRulesMetadata.access_id == ShareAccessMapping.id,'
         'ShareAccessRulesMetadata.deleted == "False")')
@@ -635,7 +635,7 @@ class ShareInstanceAccessMapping(BASE, ManilaBase):
 
     instance = orm.relationship(
         "ShareInstance",
-        lazy='subquery',
+        lazy='selectin',
         primaryjoin=(
             'and_('
             'ShareInstanceAccessMapping.share_instance_id == '
@@ -828,7 +828,7 @@ class ShareSnapshotInstance(BASE, ManilaBase):
 
     export_locations = orm.relationship(
         "ShareSnapshotInstanceExportLocation",
-        lazy='subquery',
+        lazy='selectin',
         primaryjoin=(
             'and_('
             'ShareSnapshotInstance.id == '
@@ -838,7 +838,7 @@ class ShareSnapshotInstance(BASE, ManilaBase):
     )
     share_instance = orm.relationship(
         ShareInstance, backref="snapshot_instances",
-        lazy='subquery',
+        lazy='selectin',
         primaryjoin=(
             'and_('
             'ShareSnapshotInstance.share_instance_id == ShareInstance.id,'
@@ -846,7 +846,7 @@ class ShareSnapshotInstance(BASE, ManilaBase):
     )
     snapshot = orm.relationship(
         "ShareSnapshot",
-        lazy="subquery",
+        lazy='selectin',
         foreign_keys=snapshot_id,
         backref="instances",
         primaryjoin=(
@@ -860,7 +860,7 @@ class ShareSnapshotInstance(BASE, ManilaBase):
     )
     share_group_snapshot = orm.relationship(
         "ShareGroupSnapshot",
-        lazy="subquery",
+        lazy='selectin',
         foreign_keys=share_group_snapshot_id,
         backref="share_group_snapshot_members",
         primaryjoin=('ShareGroupSnapshot.id == '
@@ -893,7 +893,7 @@ class ShareSnapshotAccessMapping(BASE, ManilaBase):
 
     instance_mappings = orm.relationship(
         "ShareSnapshotInstanceAccessMapping",
-        lazy='subquery',
+        lazy='selectin',
         primaryjoin=(
             'and_('
             'ShareSnapshotAccessMapping.id == '
@@ -924,7 +924,7 @@ class ShareSnapshotInstanceAccessMapping(BASE, ManilaBase):
 
     instance = orm.relationship(
         "ShareSnapshotInstance",
-        lazy='subquery',
+        lazy='selectin',
         primaryjoin=(
             'and_('
             'ShareSnapshotInstanceAccessMapping.share_snapshot_instance_id == '

--- a/releasenotes/notes/bug-1859785-share-snapshot-and-access-list-speed-improvement-a7a0c4019de1164d.yaml
+++ b/releasenotes/notes/bug-1859785-share-snapshot-and-access-list-speed-improvement-a7a0c4019de1164d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Improved share snapshot and access list speed using lazy='selectin'. The
+    sqlalchemy models of share snapshot and access rule relationships previously
+    had lazy='immediate'. This resulted in extra queries when querying for all
+    share snapshot and access rule details.


### PR DESCRIPTION
lazy='immediate' leads to each relationship being collected when it is accessed. This results in at least three extra queries when we query for all share snapshot details. lazy='selectin' collects all data when the query is executed.

Closes-Bug: #1859785
Change-Id: Ic38a94aa1ecdc78c3b06863b6bbe5be9a77b332b


(cherry picked from commit 777018a8c22240a6e2d2b1585f93e094c814dd07)