### PR TITLE
NetApp: Make metadata single source of truth for cross_volume_dedupe

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -3415,7 +3415,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         """Update dedupe & compression attributes to match desired values."""
         efficiency_status = self.get_volume_efficiency_status(volume_name)
 
-        # SAPCC Kepp deduplication metadata from filling up the volume
+        # SCI Keep deduplication metadata from filling up the volume
         if cross_dedup_disabled:
             if not efficiency_status['dedupe']:
                 self.enable_dedup(volume_name)
@@ -3429,6 +3429,21 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                     'enable-data-compaction': 'true',
                 })
             return
+
+        # Reset policy to default if it was previously set to inline-only
+        current_policy = efficiency_status.get('policy')
+        LOG.debug('Current deduplication policy for volume %s is %s.',
+                  volume_name, current_policy)
+        if current_policy == 'inline-only':
+            LOG.debug('Resetting deduplication policy for volume %s to auto.',
+                      volume_name)
+            self.set_sis_config(
+                volume_name, {
+                    'policy-name': 'auto',
+                    'enable-cross-volume-background-dedupe': 'true',
+                    'enable-cross-volume-inline-dedupe': 'true',
+                    'enable-data-compaction': 'true',
+                })
 
         # cDOT compression requires dedup to be enabled
         dedup_enabled = dedup_enabled or compression_enabled

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -1162,10 +1162,13 @@ class NetAppRestClient(object):
         """Get dedupe & compression status for a volume."""
         query = {
             'efficiency.volume_path': f'/vol/{volume_name}',
-            'fields': 'efficiency.state,efficiency.compression'
+            'fields': 'efficiency.state,'
+                      'efficiency.compression,'
+                      'efficiency.policy'
         }
         dedupe = False
         compression = False
+        policy = None
         try:
             response = self.send_request('/storage/volumes', 'get',
                                          query=query)
@@ -1173,6 +1176,7 @@ class NetAppRestClient(object):
                 efficiency = response['records'][0]['efficiency']
                 dedupe = (efficiency['state'] == 'enabled')
                 compression = (efficiency['compression'] != 'none')
+                policy = efficiency.get('policy', {}).get('name')
         except netapp_api.api.NaApiError:
             msg = _('Failed to get volume efficiency status for %s.')
             LOG.error(msg, volume_name)
@@ -1180,6 +1184,7 @@ class NetAppRestClient(object):
         return {
             'dedupe': dedupe,
             'compression': compression,
+            'policy': policy,
         }
 
     @na_utils.trace
@@ -1214,11 +1219,49 @@ class NetAppRestClient(object):
     @na_utils.trace
     def update_volume_efficiency_attributes(self, volume_name, dedup_enabled,
                                             compression_enabled,
+                                            cross_dedup_disabled=False,
                                             is_flexgroup=False,
                                             efficiency_policy=None):
         """Update dedupe & compression attributes to match desired values."""
 
         efficiency_status = self.get_volume_efficiency_status(volume_name)
+
+        # SCI Keep deduplication metadata from filling up the volume
+        if cross_dedup_disabled:
+            volume = self._get_volume_by_args(vol_name=volume_name)
+            uuid = volume['uuid']
+
+            # Enable dedup and compression if not already enabled
+            if not efficiency_status['dedupe']:
+                self.enable_dedupe_async(volume_name)
+            if not efficiency_status['compression']:
+                self.enable_compression_async(volume_name)
+
+            # Set efficiency policy to inline-only & disable cross-volume dedup
+            body = {
+                'efficiency': {
+                    'policy': {'name': 'inline-only'},
+                    'cross_volume_dedupe': 'none',
+                    'compaction': 'inline'
+                }
+            }
+            self.send_request(f'/storage/volumes/{uuid}', 'patch', body=body)
+            return
+
+        # Reset policy to default if it was previously set to inline-only
+        current_policy = efficiency_status.get('policy')
+        if current_policy == 'inline-only':
+            volume = self._get_volume_by_args(vol_name=volume_name)
+            uuid = volume['uuid']
+            body = {
+                'efficiency': {
+                    'policy': {'name': 'auto'},
+                    'cross_volume_dedupe': 'both',
+                    'compaction': 'inline'
+                }
+            }
+            self.send_request(f'/storage/volumes/{uuid}', 'patch', body=body)
+
         # cDOT compression requires dedup to be enabled
         dedup_enabled = dedup_enabled or compression_enabled
         # enable/disable compression if needed

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -882,21 +882,23 @@ class NetAppCmodeFileStorageLibrary(object):
                 src_volume.get('is-space-reporting-logical')
         }
 
-    def _get_efficiency_options(self, vserver_client, share_name,
-                                extra_logging=False):
-        status = vserver_client.get_volume_efficiency_status(share_name)
-        if extra_logging:
-            LOG.debug(f"volume_efficiency_status of share '{share_name}'"
-                      f"is '{status}'")
-        cross_dedup_disabled = (status.get('policy') == 'inline-only'
-                                and status.get('cross_dedup_disabled'))
-        provisioning_opts = {
-            'dedup_enabled': status.get('dedupe'),
-            'compression_enabled': status.get('compression'),
-            'policy': None,
-            'cross_dedup_disabled': cross_dedup_disabled,
-        }
-        return provisioning_opts
+    def _get_cross_volume_dedupe_options(self, share):
+        """Map ``cross_volume_dedupe`` metadata to driver kwargs.
+
+        Reads the ``cross_volume_dedupe`` metadata key (positive form,
+        mirroring the ONTAP field). When metadata sets it to ``false``,
+        cross-volume dedup is disabled (inline-only policy). Any other
+        value (including missing) leaves cross-volume dedup enabled and
+        resets the policy to auto if it was previously inline-only.
+
+        Returns the ``cross_dedup_disabled`` kwarg expected by
+        :meth:`update_volume_efficiency_attributes`.
+        """
+        metadata = share.get('metadata', {})
+        if metadata.get('cross_volume_dedupe') == 'false':
+            return {'cross_dedup_disabled': True}
+        else:
+            return {'cross_dedup_disabled': False}
 
     @na_utils.trace
     def create_share(self, context, share, share_server):
@@ -911,10 +913,9 @@ class NetAppCmodeFileStorageLibrary(object):
             share_types.get_share_type(context, share.get('share_type_id')))
         if share_type['name'].startswith('hypervisor_storage'):
             provisioning_options = {'logical_space_reporting': False}
-        if context.project_domain_name in ['neo']:
-            provisioning_options['dedup_enabled'] = True
-            provisioning_options['compression_enabled'] = True
-            provisioning_options['cross_dedup_disabled'] = True
+
+        provisioning_options.update(
+            self._get_cross_volume_dedupe_options(share))
         self._allocate_container(share, vserver, vserver_client,
                                  **provisioning_options)
         return self._create_export(share, share_server, vserver,
@@ -934,12 +935,14 @@ class NetAppCmodeFileStorageLibrary(object):
             src_vserver, src_vserver_client = self._get_vserver(
                 share_server=share_server)
             # Creating a new share from snapshot in the source share's pool
-            # SAPCC Get attribuets from parent Share and apply.
+            # SCI Get attributes from parent Share and apply.
             src_share_name = self._get_backend_share_name(snapshot['share_id'])
             logical_opts = self._get_logical_space_options(
                 src_vserver_client, src_share_name)
-            effi_opts = self._get_efficiency_options(src_vserver_client,
-                                                     src_share_name)
+
+            # SCI: Apply cross_volume_dedupe based on new share's metadata
+            effi_opts = self._get_cross_volume_dedupe_options(share)
+
             self._allocate_container_from_snapshot(
                 share, snapshot, src_vserver, src_vserver_client,
                 **logical_opts, **effi_opts)
@@ -1025,11 +1028,12 @@ class NetAppCmodeFileStorageLibrary(object):
             parent_aggr = share_utils.extract_host(parent_share['host'],
                                                    level='pool')
 
-        # SAPCC Get attributes from parent share
+        # SCI Get attributes from parent share
         logical_opts = self._get_logical_space_options(src_vserver_client,
                                                        parent_share_name)
-        effi_opts = self._get_efficiency_options(src_vserver_client,
-                                                 parent_share_name)
+
+        # SCI: Apply cross_volume_dedupe based on new share's metadata
+        effi_opts = self._get_cross_volume_dedupe_options(share)
 
         try:
             # NOTE(felipe_rodrigues): no support to move volumes that are
@@ -1267,9 +1271,10 @@ class NetAppCmodeFileStorageLibrary(object):
                 provisioning_options.update(
                     self._get_logical_space_options(src_vserver_client,
                                                     share_name))
+
+                # SCI: Apply cross_volume_dedupe based on share's metadata
                 provisioning_options.update(
-                    self._get_efficiency_options(src_vserver_client,
-                                                 share_name))
+                    self._get_cross_volume_dedupe_options(share))
 
                 qos_type_specs = qos_types.get_specs_from_share(share)
                 qos_type_specs = self._get_normalized_qos_type_specs(
@@ -3210,11 +3215,8 @@ class NetAppCmodeFileStorageLibrary(object):
             share, vserver, vserver_client=vserver_client, set_qos=False)
 
         # SAPCC Keep logical space reporting attributes while update share
-        # SAPCC Keep efficiency attributes while update share
         provisioning_options.update(
             self._get_logical_space_options(vserver_client, share_name))
-        provisioning_options.update(
-            self._get_efficiency_options(vserver_client, share_name))
 
         qos_policy_group_name = self._modify_or_create_qos_for_existing_share(
             share, extra_specs, vserver, vserver_client)
@@ -3225,7 +3227,13 @@ class NetAppCmodeFileStorageLibrary(object):
             vserver_client, share_name)
         provisioning_options.update(snap_attributes)
 
-        metadata = share.get('metadata')
+        # SCI: Metadata explicitly controls cross_volume_dedupe setting
+        provisioning_options.update(
+            self._get_cross_volume_dedupe_options(share))
+
+        # Get metadata from share
+        metadata = share.get('metadata', {})
+        # Apply snapshot_policy from metadata if present
         if metadata:
             snapshot_policy = metadata.get('snapshot_policy')
             if snapshot_policy:
@@ -3839,7 +3847,6 @@ class NetAppCmodeFileStorageLibrary(object):
         # SAPCC Get space logical reporting settings from original replica.
         logical_opts = {}
         is_logical_space_rep = None
-        effi_opts = {}
         orig_active_vserver_client = None
         orig_active_vserver = dm_session.get_vserver_from_share(
             orig_active_replica)
@@ -3860,10 +3867,6 @@ class NetAppCmodeFileStorageLibrary(object):
             logical_opts = self._get_logical_space_options(
                 orig_active_vserver_client, orig_active_replica_name)
             is_logical_space_rep = logical_opts['logical_space_reporting']
-            effi_opts = self._get_efficiency_options(
-                orig_active_vserver_client,
-                orig_active_replica_name,
-                extra_logging=True)
 
         new_replica_list = []
 
@@ -3969,21 +3972,19 @@ class NetAppCmodeFileStorageLibrary(object):
         else:
             LOG.exception(logical_space_error_msg)
 
-        effi_opts_error_msg = (
-            f"With efficiency options '{effi_opts}'"
-            f"could not apply cross_dedup_disabled to the promoted "
-            f"replica."
-        )
-        if effi_opts:
-            if effi_opts['cross_dedup_disabled']:
-                try:
-                    new_active_vserver_cli.update_volume_efficiency_attributes(
-                        new_active_replica_name, True, True,
-                        cross_dedup_disabled=True)
-                except Exception as e:
-                    LOG.exception(f"{effi_opts_error_msg} {e}")
-        else:
-            LOG.exception(effi_opts_error_msg)
+        # SCI: Check metadata to determine if cross-volume dedup should be
+        # disabled on the promoted replica. All replicas of the same share
+        # share the same metadata.
+        metadata = new_active_replica.get('metadata', {})
+        if metadata.get('cross_volume_dedupe') == 'false':
+            try:
+                new_active_vserver_cli.update_volume_efficiency_attributes(
+                    new_active_replica_name, True, True,
+                    cross_dedup_disabled=True)
+            except Exception as e:
+                LOG.exception(
+                    f"Could not disable cross_volume_dedupe on the promoted "
+                    f"replica. {e}")
 
         return new_replica_list
 
@@ -5560,6 +5561,23 @@ class NetAppCmodeFileStorageLibrary(object):
         return pool_name in pools
 
     @na_utils.trace
+    def update_cross_volume_dedupe(self, share, value, share_server=None):
+        """Update cross_volume_dedupe setting for a share."""
+        value = value.lower()
+        if value not in ('true', 'false'):
+            err_msg = _("Invalid cross_volume_dedupe value supplied: %s.")
+            err_msg = err_msg % value
+            raise exception.NetAppException(err_msg)
+
+        vserver, vserver_client = self._get_vserver(share_server=share_server)
+        share_name = self._get_backend_share_name(share['id'])
+
+        # value 'false' (cross-volume dedup disabled) -> inline-only policy
+        # value 'true'  (cross-volume dedup enabled)  -> reset to auto policy
+        vserver_client.update_volume_efficiency_attributes(
+            share_name, True, True, cross_dedup_disabled=(value == 'false'))
+
+    @na_utils.trace
     def create_backup(self, context, share_instance, backup,
                       share_server=None):
         """Create backup for NetApp share"""
@@ -6274,6 +6292,7 @@ class NetAppCmodeFileStorageLibrary(object):
                                    share_server=None):
         metadata_update_func_map = {
             "snapshot_policy": "update_volume_snapshot_policy",
+            "cross_volume_dedupe": "update_cross_volume_dedupe",
         }
 
         for k, v in metadata.items():

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -644,6 +644,8 @@ class ShareManager(manager.SchedulerDependentManager):
                         {'id': share_instance['id']},
                     )
                     continue
+            else:
+                metadata = {}
 
             # only busy aka shares undergoing a migration might not have
             # their pool fixed, but other skip reasons do not apply
@@ -659,8 +661,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 continue
             share_instance_dict = self._get_share_instance_dict(
                 ctxt, share_instance)
-            if metadata:
-                share_instance_dict.update({'metadata': metadata})
+            share_instance_dict.update({'metadata': metadata})
             update_share_instances.append(share_instance_dict)
 
         do_service_status_update = False
@@ -2599,6 +2600,25 @@ class ShareManager(manager.SchedulerDependentManager):
         if context.project_domain_name is None and request_spec:
             context.project_domain_name = request_spec.get(
                 'project_domain_name')
+
+        # SCI: Disable cross-volume dedup on shares in the neo domain by
+        # setting cross_volume_dedupe=false metadata.
+        if (hasattr(context, 'project_domain_name') and
+                context.project_domain_name in ['neo']):
+            self.db.share_metadata_update(
+                context, share['id'],
+                {'cross_volume_dedupe': 'false'},
+                delete=False)
+            LOG.debug('Set cross_volume_dedupe=false metadata for neo share '
+                      '%s', share['id'])
+            # Refresh share to get the updated metadata
+            share = self.db.share_get(context, share['id'])
+
+        # Add share_metadata to share_instance for driver access
+        share_metadata_list = share.get('share_metadata', [])
+        share_instance['metadata'] = {
+            m['key']: m['value'] for m in share_metadata_list
+        } if share_metadata_list else {}
 
         status = constants.STATUS_AVAILABLE
         try:
@@ -6771,6 +6791,20 @@ class ShareManager(manager.SchedulerDependentManager):
             self.db.share_instance_get_all_by_share_server(
                 context, src_share_server_id, with_share_data=True))
         share_instance_ids = [x.id for x in share_instances]
+
+        # Add metadata dict to share_instances for driver access
+        for instance in share_instances:
+            share_id = instance.get('share_id')
+            if share_id:
+                # Get share to access metadata
+                # (instance.share relationship is detached)
+                share = self.db.share_get(context, share_id)
+                share_metadata_list = share.get('share_metadata', [])
+                instance['metadata'] = {
+                    m['key']: m['value'] for m in share_metadata_list
+                } if share_metadata_list else {}
+            else:
+                instance['metadata'] = {}
 
         snapshot_instances = (
             self.db.share_snapshot_instance_get_all_with_filters(

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -1142,12 +1142,15 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
 
         query = {
             'efficiency.volume_path': '/vol/%s' % fake.VOLUME_NAMES[0],
-            'fields': 'efficiency.state,efficiency.compression'
+            'fields': 'efficiency.state,'
+                      'efficiency.compression,'
+                      'efficiency.policy'
         }
 
         expected_result = {
             'dedupe': True,
-            'compression': True
+            'compression': True,
+            'policy': None
         }
 
         self.mock_object(self.client, 'send_request',

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -858,7 +858,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         mock_allocate_container.assert_called_once_with(
             fake.SHARE, fake.VSERVER1, vserver_client,
-            logical_space_reporting=True)
+            logical_space_reporting=True, cross_dedup_disabled=False)
         mock_create_export.assert_called_once_with(fake.SHARE,
                                                    fake.SHARE_SERVER,
                                                    fake.VSERVER1,
@@ -901,7 +901,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         mock_allocate_container_from_snapshot.assert_called_once_with(
             share, fake.SNAPSHOT, fake.VSERVER1, vserver_client,
-            compression_enabled=True, dedup_enabled=True, policy=None,
             cross_dedup_disabled=False, logical_space_reporting=False)
         mock_create_export.assert_called_once_with(share, fake.SHARE_SERVER,
                                                    fake.VSERVER1,
@@ -1060,8 +1059,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                 self.src_vserver_client, split=False, create_fpolicy=False)
             self.mock_allocate_container.assert_called_once_with(
                 self.fake_share, fake.VSERVER2, self.dest_vserver_client,
-                replica=True, set_qos=False, compression_enabled=True,
-                dedup_enabled=True, policy=None, cross_dedup_disabled=False,
+                replica=True, set_qos=False, cross_dedup_disabled=False,
                 logical_space_reporting=False)
             self.mock_dm_create_snapmirror.assert_called_once()
             self.temp_src_share['replica_state'] = (
@@ -1070,9 +1068,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         else:
             self.mock_allocate_container_from_snapshot.assert_called_once_with(
                 self.fake_share, fake.SNAPSHOT, fake.VSERVER1,
-                self.src_vserver_client, split=True, compression_enabled=True,
-                dedup_enabled=True, policy=None, cross_dedup_disabled=False,
-                logical_space_reporting=False)
+                self.src_vserver_client, split=True,
+                cross_dedup_disabled=False, logical_space_reporting=False)
             state = self.library.STATE_SPLITTING_VOLUME_CLONE
 
             self.temp_src_share['aggregate'] = ([fake.POOL_NAME]
@@ -1127,7 +1124,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.mock_allocate_container_from_snapshot.assert_called_once_with(
                 self.fake_share, fake.SNAPSHOT, fake.VSERVER1,
                 self.src_vserver_client, split=True,
-                compression_enabled=True, dedup_enabled=True, policy=None,
                 cross_dedup_disabled=False, logical_space_reporting=False)
         else:
             self.mock_generate_uuid.assert_called_once()
@@ -1425,7 +1421,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.mock_modify_vol.assert_called_once_with(
                 fake.POOL_NAME, fake.SHARE_NAME,
                 **fake.PROVISIONING_OPTIONS_WITH_QOS,
-                logical_space_reporting=True, policy=None,
+                logical_space_reporting=True,
                 cross_dedup_disabled=False)
             self.mock_pvt_storage_delete.assert_called_once_with(
                 fake.SHARE['id'])
@@ -1535,7 +1531,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.mock_modify_vol.assert_called_once_with(
                 fake.POOL_NAME, fake.SHARE_NAME,
                 **fake.PROVISIONING_OPTIONS_WITH_QOS,
-                logical_space_reporting=True, policy=None,
+                logical_space_reporting=True,
                 cross_dedup_disabled=False)
             expect_result['status'] = constants.STATUS_AVAILABLE
             self.mock_pvt_storage_delete.assert_called_once_with(
@@ -5149,9 +5145,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(
             self.library, '_get_logical_space_options',
             mock.Mock(return_value={'logical_space_reporting': False}))
-        self.mock_object(
-            self.library, '_get_efficiency_options',
-            mock.Mock(return_value={'cross_dedup_disabled': False}))
         self.mock_object(self.client, 'cleanup_demoted_replica')
         self.mock_object(self.library,
                          '_is_readable_replica',
@@ -5223,9 +5216,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(
             self.library, '_get_logical_space_options',
             mock.Mock(return_value={'logical_space_reporting': False}))
-        self.mock_object(
-            self.library, '_get_efficiency_options',
-            mock.Mock(return_value={'cross_dedup_disabled': False}))
         self.mock_object(
             protocol_helper, 'cleanup_demoted_replica',
             mock.Mock(side_effect=exception.StorageCommunicationException))
@@ -5316,9 +5306,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(
             self.library, '_get_logical_space_options',
             mock.Mock(return_value={'logical_space_reporting': False}))
-        self.mock_object(
-            self.library, '_get_efficiency_options',
-            mock.Mock(return_value={'cross_dedup_disabled': False}))
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))
@@ -5386,9 +5373,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(
             self.library, '_get_logical_space_options',
             mock.Mock(return_value={'logical_space_reporting': False}))
-        self.mock_object(
-            self.library, '_get_efficiency_options',
-            mock.Mock(return_value={'cross_dedup_disabled': False}))
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -1001,6 +1001,8 @@ class ShareManagerTestCase(test.TestCase):
             'availability_zone': share_instance.get('availability_zone'),
             'export_locations': share_instance.get('export_locations') or [],
             'qos_type_id': share_instance.get('qos_type_id'),
+            'metadata': share_instance.get('metadata') if isinstance(
+                share_instance.get('metadata'), dict) else {},
         }
         share_type = share_instance.get('share_type')
         if share_type:


### PR DESCRIPTION
Changes metadata to be the authoritative source for
cross_dedup_disabled setting across all driver operations
(create, snapshot restore, migration, update, replica promotion).

Key changes:
- Remove efficiency settings copying from source volumes during
  create_from_snapshot and migration operations
- Share type extra specs still control dedup/compression settings
- Only cross_dedup_disabled comes from metadata
- Add policy reset logic: when metadata has no cross_dedup_disabled
  or is not 'true', explicitly set False to reset inline-only policy
  back to auto

Manager layer changes:
- Always convert share_metadata relationship to dict before passing
  to driver (fixes AttributeError on share.get('metadata'))
- Ensure metadata dict is always present (even if empty) to avoid
  implicit/explicit override issues
- Refresh share object after setting neo domain metadata to get
  updated metadata list

Before rollout: set metadata on existing neo domain shares.

Change-Id: I84f75d02057a009aeee2c73014e20db21f328e9f
Assisted-By: Claude (Anthropic, claude-4.5-sonnet)
Signed-off-by: Maurice Escher <maurice.escher@sap.com>
