### PR TITLE
NetApp: handle other active op error in snapmirror break

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -449,6 +449,10 @@ class DataMotionSession(object):
                         undergoing_abort in e.message):
                     raise exception.ReplicationException(
                         reason="Snapmirror relationship is aborting.")
+                elif e.code == netapp_api.EANOTHER_OP_ACTIVE:
+                    raise exception.ReplicationException(
+                        reason="Another operation is active on the snapmirror "
+                               "relationship.")
                 else:
                     raise
 


### PR DESCRIPTION
When breaking a snapmirror relationship and when another
operation is already running, retry the break operation.

Change-Id: Ide84445c5e7879d3621e0edf7c7399fb835ffb14
Signed-off-by: Maurice Escher <maurice.escher@sap.com>
