### PR TITLE
Fix TypeError in share creation when metadata is not provided

### DIFF
--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -529,7 +529,8 @@ class API(base.Base):
             if metadata_key in driver_keys:
                 metadata_from_share_type.update({metadata_key: v})
 
-        metadata_from_share_type.update(user_metadata)
+        if user_metadata:
+            metadata_from_share_type.update(user_metadata)
         return metadata_from_share_type
 
     def update_share_from_metadata(self, context, share_id, metadata):

--- a/releasenotes/notes/bug-2156346-fix-metadata-typeerror-6d25a2713bd8a60e.yaml
+++ b/releasenotes/notes/bug-2156346-fix-metadata-typeerror-6d25a2713bd8a60e.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed TypeError when creating shares without metadata parameter
+    when driver_updatable_metadata is configured and share types
+    have extra_specs that map to metadata keys. For more details,
+    please refer to `launchpad bug 2156346
+    <https://bugs.launchpad.net/manila/+bug/2156346>`_.


### PR DESCRIPTION
When driver_updatable_metadata is configured and share types have
extra_specs that map to metadata keys, creating a share without
passing metadata in the API call resulted in TypeError.

The update_metadata_from_share_type_extra_specs() method assumed
user_metadata would always be a dict, but it can be None when
not provided by the client.

Change-Id: I7e9fa84261c365fa932b22f2e0f84b8bcc1b3a26
Closes-Bug: #2156346
Signed-off-by: Maurice Escher <maurice.escher@sap.com>

downstream version of https://review.opendev.org/c/openstack/manila/+/992622
