### PR TITLE
NetApp - Add support for Synchronous replication for share

### DIFF
--- a/manila/message/message_field.py
+++ b/manila/message/message_field.py
@@ -177,6 +177,11 @@ class Detail(object):
           "or create a new subnet/share network. If this doesn't work, "
           "contact your administrator to troubleshoot "
           "issues with your network."))
+    UNSUPPORTED_REPLICA_CREATE_CONFIG = (
+        '034',
+        _("Share driver has failed to create share replica "
+          "because of unsupported configuration options. "
+          "Please try again with a different configuration."))
 
     # SCI: Keep the SCI CUSTOM MESSAGE at the end of list and count backwards
 
@@ -246,6 +251,7 @@ class Detail(object):
         UPDATE_METADATA_NOT_DELETED,
         CIFS_SERVER_SETUP_FAILED,
         CIFS_SERVER_CERTIFICATE_ERROR,
+        UNSUPPORTED_REPLICA_CREATE_CONFIG
     )
 
     # Exception and detail mappings

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -5623,6 +5623,22 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             if e.code != netapp_api.ERELATION_EXISTS:
                 raise
 
+    def _snapmirror_path(self, vserver, volume=None):
+        """Return a formatted SnapMirror endpoint path.
+
+        :param vserver: the vServer (SVM) name.
+        :param volume: optional volume name. When provided the path is
+            ``<vserver>:<volume>`` (volume endpoint); when omitted the
+            path is ``<vserver>:`` (SVM endpoint).
+        :returns: formatted path string, or ``None`` if *vserver* is
+            ``None``.
+        """
+        if vserver is None:
+            return None
+        if volume:
+            return f"{vserver}:{volume}"
+        return f"{vserver}:"
+
     def _build_snapmirror_request(self, source_path=None, dest_path=None,
                                   source_vserver=None, dest_vserver=None,
                                   source_volume=None, dest_volume=None):
@@ -5648,8 +5664,13 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def initialize_snapmirror_vol(self, source_vserver, source_volume,
                                   dest_vserver, dest_volume,
                                   source_snapshot=None,
-                                  transfer_priority=None):
+                                  transfer_priority=None,
+                                  state=None):
         """Initializes a SnapMirror relationship between volumes."""
+        # NOTE(kumart): The 'state' argument is always None
+        # as it is not required for ZAPI. It was kept in the signature
+        # due to compatibility with the REST implementation.
+
         return self._initialize_snapmirror(
             source_vserver=source_vserver, dest_vserver=dest_vserver,
             source_volume=source_volume, dest_volume=dest_volume,
@@ -5660,8 +5681,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def initialize_snapmirror_svm(self, source_vserver, dest_vserver,
                                   transfer_priority=None):
         """Initializes a SnapMirror relationship between vServer."""
-        source_path = source_vserver + ':'
-        dest_path = dest_vserver + ':'
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         return self._initialize_snapmirror(source_path=source_path,
                                            dest_path=dest_path,
                                            transfer_priority=transfer_priority)
@@ -5715,9 +5736,11 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                    "List returned: %s." % snapmirror_destinations_list)
             raise exception.NetAppException(msg)
 
+        source_path = self._snapmirror_path(source_vserver, source_volume)
+        dest_path = self._snapmirror_path(dest_vserver, dest_volume)
+
         api_args = self._build_snapmirror_request(
-            source_vserver=source_vserver, dest_vserver=dest_vserver,
-            source_volume=source_volume, dest_volume=dest_volume)
+            source_path=source_path, dest_path=dest_path)
         api_args['relationship-info-only'] = (
             'true' if relationship_info_only else 'false')
 
@@ -5736,8 +5759,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def release_snapmirror_svm(self, source_vserver, dest_vserver,
                                relationship_info_only=False):
         """Removes a SnapMirror relationship on the source endpoint."""
-        source_path = source_vserver + ':'
-        dest_path = dest_vserver + ':'
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         dest_info = self._build_snapmirror_request(
             source_path=source_path, dest_path=dest_path)
         self._ensure_snapmirror_v2()
@@ -5755,16 +5778,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def quiesce_snapmirror_vol(self, source_vserver, source_volume,
                                dest_vserver, dest_volume):
         """Disables future transfers to a SnapMirror destination."""
-        self._quiesce_snapmirror(source_vserver=source_vserver,
-                                 dest_vserver=dest_vserver,
-                                 source_volume=source_volume,
-                                 dest_volume=dest_volume)
+        source_path = self._snapmirror_path(source_vserver, source_volume)
+        dest_path = self._snapmirror_path(dest_vserver, dest_volume)
+        self._quiesce_snapmirror(source_path=source_path,
+                                 dest_path=dest_path)
 
     @na_utils.trace
     def quiesce_snapmirror_svm(self, source_vserver, dest_vserver):
         """Disables future transfers to a SnapMirror destination."""
-        source_path = source_vserver + ':'
-        dest_path = dest_vserver + ':'
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         self._quiesce_snapmirror(source_path=source_path, dest_path=dest_path)
 
     @na_utils.trace
@@ -5785,18 +5808,18 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                              dest_vserver, dest_volume,
                              clear_checkpoint=False):
         """Stops ongoing transfers for a SnapMirror relationship."""
-        self._abort_snapmirror(source_vserver=source_vserver,
-                               dest_vserver=dest_vserver,
-                               source_volume=source_volume,
-                               dest_volume=dest_volume,
+        source_path = self._snapmirror_path(source_vserver, source_volume)
+        dest_path = self._snapmirror_path(dest_vserver, dest_volume)
+        self._abort_snapmirror(source_path=source_path,
+                               dest_path=dest_path,
                                clear_checkpoint=clear_checkpoint)
 
     @na_utils.trace
     def abort_snapmirror_svm(self, source_vserver, dest_vserver,
                              clear_checkpoint=False):
         """Stops ongoing transfers for a SnapMirror relationship."""
-        source_path = source_vserver + ':'
-        dest_path = dest_vserver + ':'
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         self._abort_snapmirror(source_path=source_path, dest_path=dest_path,
                                clear_checkpoint=clear_checkpoint)
 
@@ -5823,16 +5846,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def break_snapmirror_vol(self, source_vserver, source_volume,
                              dest_vserver, dest_volume):
         """Breaks a data protection SnapMirror relationship."""
-        self._break_snapmirror(source_vserver=source_vserver,
-                               dest_vserver=dest_vserver,
-                               source_volume=source_volume,
-                               dest_volume=dest_volume)
+        source_path = self._snapmirror_path(source_vserver, source_volume)
+        dest_path = self._snapmirror_path(dest_vserver, dest_volume)
+        self._break_snapmirror(source_path=source_path,
+                               dest_path=dest_path)
 
     @na_utils.trace
     def break_snapmirror_svm(self, source_vserver=None, dest_vserver=None):
         """Breaks a data protection SnapMirror relationship."""
-        source_path = source_vserver + ':' if source_vserver else None
-        dest_path = dest_vserver + ':' if dest_vserver else None
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         self._break_snapmirror(source_path=source_path, dest_path=dest_path)
 
     @na_utils.trace
@@ -5893,16 +5916,16 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def delete_snapmirror_vol(self, source_vserver, source_volume,
                               dest_vserver, dest_volume):
         """Destroys a SnapMirror relationship between volumes."""
-        self._delete_snapmirror(source_vserver=source_vserver,
-                                dest_vserver=dest_vserver,
-                                source_volume=source_volume,
-                                dest_volume=dest_volume)
+        source_path = self._snapmirror_path(source_vserver, source_volume)
+        dest_path = self._snapmirror_path(dest_vserver, dest_volume)
+        self._delete_snapmirror(source_path=source_path,
+                                dest_path=dest_path)
 
     @na_utils.trace
     def delete_snapmirror_svm(self, source_vserver, dest_vserver):
         """Destroys a SnapMirror relationship between vServers."""
-        source_path = source_vserver + ':'
-        dest_path = dest_vserver + ':'
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         self._delete_snapmirror(source_path=source_path, dest_path=dest_path)
 
     @na_utils.trace
@@ -5935,8 +5958,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     @na_utils.trace
     def update_snapmirror_svm(self, source_vserver, dest_vserver):
         """Schedules a snapmirror update between vServers."""
-        source_path = source_vserver + ':'
-        dest_path = dest_vserver + ':'
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         self._update_snapmirror(source_path=source_path, dest_path=dest_path)
 
     @na_utils.trace
@@ -5961,16 +5984,15 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def resume_snapmirror_vol(self, source_vserver, source_volume,
                               dest_vserver, dest_volume):
         """Resume a SnapMirror relationship if it is quiesced."""
-        self._resume_snapmirror(source_vserver=source_vserver,
-                                dest_vserver=dest_vserver,
-                                source_volume=source_volume,
-                                dest_volume=dest_volume)
+        source_path = self._snapmirror_path(source_vserver, source_volume)
+        dest_path = self._snapmirror_path(dest_vserver, dest_volume)
+        self._resume_snapmirror(source_path=source_path, dest_path=dest_path)
 
     @na_utils.trace
     def resume_snapmirror_svm(self, source_vserver, dest_vserver):
         """Resume a SnapMirror relationship if it is quiesced."""
-        source_path = source_vserver + ':'
-        dest_path = dest_vserver + ':'
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         self._resume_snapmirror(source_path=source_path, dest_path=dest_path)
 
     @na_utils.trace
@@ -5994,16 +6016,15 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     def resync_snapmirror_vol(self, source_vserver, source_volume,
                               dest_vserver, dest_volume):
         """Resync a SnapMirror relationship between volumes."""
-        self._resync_snapmirror(source_vserver=source_vserver,
-                                dest_vserver=dest_vserver,
-                                source_volume=source_volume,
-                                dest_volume=dest_volume)
+        source_path = self._snapmirror_path(source_vserver, source_volume)
+        dest_path = self._snapmirror_path(dest_vserver, dest_volume)
+        self._resync_snapmirror(source_path=source_path, dest_path=dest_path)
 
     @na_utils.trace
     def resync_snapmirror_svm(self, source_vserver, dest_vserver):
         """Resync a SnapMirror relationship between vServers."""
-        source_path = source_vserver + ':'
-        dest_path = dest_vserver + ':'
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         self._resync_snapmirror(source_path=source_path, dest_path=dest_path)
 
     @na_utils.trace
@@ -6046,8 +6067,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
     @na_utils.trace
     def get_snapmirrors_svm(self, source_vserver=None, dest_vserver=None,
                             desired_attributes=None):
-        source_path = source_vserver + ':' if source_vserver else None
-        dest_path = dest_vserver + ':' if dest_vserver else None
+        source_path = self._snapmirror_path(source_vserver)
+        dest_path = self._snapmirror_path(dest_vserver)
         return self.get_snapmirrors(source_path=source_path,
                                     dest_path=dest_path,
                                     desired_attributes=desired_attributes)
@@ -7620,3 +7641,8 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             }
             data_lif_info.append(lif_info_node)
         return data_lif_info
+
+    @na_utils.trace
+    def get_desired_sync_snapmirror_state(self):
+        """Returns the desired Sync SnapMirror state for ZAPI."""
+        return na_utils.SM_SNAPMIRRORED_STATE

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -2469,7 +2469,7 @@ class NetAppRestClient(object):
         fields = ['state', 'source.svm.name', 'source.path',
                   'destination.svm.name', 'destination.path',
                   'transfer.end_time', 'uuid', 'policy.type',
-                  'transfer_schedule.name', 'transfer.state',
+                  'policy.name', 'transfer_schedule.name', 'transfer.state',
                   'last_transfer_type', 'transfer.bytes_transferred',
                   'healthy']
 
@@ -2522,6 +2522,7 @@ class NetAppRestClient(object):
                      record.get('transfer', {}).get('end_time') else 0),
                 'uuid': record['uuid'],
                 'policy-type': record.get('policy', {}).get('type'),
+                'policy': record.get('policy', {}).get('name'),
                 'is-healthy': (
                     'true'
                     if record.get('healthy', {}) is True else 'false'),
@@ -3364,27 +3365,34 @@ class NetAppRestClient(object):
     def initialize_snapmirror_vol(self, source_vserver, source_volume,
                                   dest_vserver, dest_volume,
                                   source_snapshot=None,
-                                  transfer_priority=None):
+                                  transfer_priority=None,
+                                  state=None):
         """Initializes a SnapMirror relationship between volumes."""
         return self._initialize_snapmirror(
             source_vserver=source_vserver, dest_vserver=dest_vserver,
             source_volume=source_volume, dest_volume=dest_volume,
             source_snapshot=source_snapshot,
-            transfer_priority=transfer_priority)
+            transfer_priority=transfer_priority,
+            state=state)
 
     @na_utils.trace
     def _initialize_snapmirror(self, source_path=None, dest_path=None,
                                source_vserver=None, dest_vserver=None,
                                source_volume=None, dest_volume=None,
-                               source_snapshot=None, transfer_priority=None):
+                               source_snapshot=None, transfer_priority=None,
+                               state=None):
         """Initializes a SnapMirror relationship."""
 
         # NOTE(nahimsouza): The args source_snapshot and transfer_priority are
         # always None and they are not available on REST API, they were
-        # kept in the signature due to compatilbity with ZAPI implementation.
+        # kept in the signature due to compatibility with ZAPI implementation.
+
+        # If state is not passed use async init state
+        if not state:
+            state = na_utils.SM_SNAPMIRRORED_STATE
 
         return self._set_snapmirror_state(
-            'snapmirrored', source_path, dest_path,
+            state, source_path, dest_path,
             source_vserver, source_volume,
             dest_vserver, dest_volume, wait_result=False)
 
@@ -5931,3 +5939,8 @@ class NetAppRestClient(object):
                 if failover_policy in ('default', 'sfo_partners_only'):
                     migratable_lif.append(lif["name"])
         return migratable_lif
+
+    @na_utils.trace
+    def get_desired_sync_snapmirror_state(self):
+        """Returns the desired Sync SnapMirror state for REST."""
+        return na_utils.SM_IN_SYNC_STATE

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -184,6 +184,19 @@ class DataMotionSession(object):
 
         return volume_name, vserver, backend_name
 
+    @na_utils.trace
+    def get_policy_from_share_replica_metadata(self, share_replica):
+        """Extracts replication policy from share replica metadata."""
+        metadata = share_replica.get('metadata', {})
+        LOG.debug("share_replica metadata is %s", metadata)
+        replication_policy = (metadata.get('replication_policy',
+                              na_utils.MIRROR_ALL_SNAP_POLICY))
+        # Determine if the policy is synchronous. We need to change
+        # to call ONTAP when we support custom policies.
+        is_sync_policy = replication_policy in na_utils.SUPPORTED_SYNC_POLICIES
+        LOG.debug("is_sync_policy: %s", is_sync_policy)
+        return replication_policy, is_sync_policy
+
     def get_client_and_vserver_name(self, share_server):
         destination_host = share_server.get('host')
         vserver = self.get_vserver_from_share_server(share_server)
@@ -205,6 +218,8 @@ class DataMotionSession(object):
             source_vserver=src_vserver, dest_vserver=dest_vserver,
             source_volume=src_volume_name, dest_volume=dest_volume_name,
             desired_attributes=['relationship-status',
+                                'policy',
+                                'policy-type',
                                 'mirror-state',
                                 'schedule',
                                 'source-vserver',
@@ -214,6 +229,7 @@ class DataMotionSession(object):
                                 'last-transfer-error'])
         return snapmirrors
 
+    @na_utils.trace
     def create_snapmirror(self, source_share_obj, dest_share_obj,
                           relationship_type, mount=False):
         """Sets up a SnapMirror relationship between two volumes.
@@ -230,21 +246,37 @@ class DataMotionSession(object):
         src_volume_name, src_vserver, __ = self.get_backend_info_for_share(
             source_share_obj)
 
+        policy, is_sync_policy = (
+            self.get_policy_from_share_replica_metadata(dest_share_obj))
+
         # 1. Create SnapMirror relationship
         config = get_backend_configuration(dest_backend)
-        schedule = config.netapp_snapmirror_schedule
+        if is_sync_policy:
+            """skip the schedule setting incase of sync policy type
+            as per NetApp design"""
+            schedule = None
+        else:
+            schedule = config.netapp_snapmirror_schedule
+
         dest_client.create_snapmirror_vol(src_vserver,
                                           src_volume_name,
                                           dest_vserver,
                                           dest_volume_name,
                                           relationship_type,
-                                          schedule=schedule)
+                                          schedule=schedule,
+                                          policy=policy)
 
-        # 2. Initialize async transfer of the initial data
+        # 2. Initialize snapmirror transfer of the initial data
+        state = (
+            na_utils.SM_IN_SYNC_STATE
+            if is_sync_policy
+            else na_utils.SM_SNAPMIRRORED_STATE
+        )
         dest_client.initialize_snapmirror_vol(src_vserver,
                                               src_volume_name,
                                               dest_vserver,
-                                              dest_volume_name)
+                                              dest_volume_name,
+                                              state=state)
 
         # 3. Mount the destination volume and create a junction path
         if mount:
@@ -258,8 +290,9 @@ class DataMotionSession(object):
         """Ensures all information about a SnapMirror relationship is removed.
 
         1. Abort snapmirror
-        2. Delete the snapmirror
-        3. Release snapmirror to cleanup snapmirror metadata and snapshots
+        2. Quiesce snapmirror
+        3. Delete the snapmirror
+        3. Release snapmirror to clean up snapmirror metadata and snapshots
         """
         dest_volume_name, dest_vserver, dest_backend = (
             self.get_backend_info_for_share(dest_share_obj))
@@ -280,7 +313,17 @@ class DataMotionSession(object):
             # Snapmirror is already deleted
             pass
 
-        # 2. Delete SnapMirror Relationship and cleanup destination snapshots
+        # 2. Quiesce the snapmirror relationship
+        try:
+            dest_client.quiesce_snapmirror_vol(src_vserver,
+                                               src_volume_name,
+                                               dest_vserver,
+                                               dest_volume_name)
+        except netapp_api.NaApiError:
+            # Snapmirror is already deleted
+            pass
+
+        # 3. Delete SnapMirror Relationship and cleanup destination snapshots
         try:
             dest_client.delete_snapmirror_vol(src_vserver,
                                               src_volume_name,
@@ -302,7 +345,7 @@ class DataMotionSession(object):
             except Exception:
                 src_client = None
 
-            # 3. Cleanup SnapMirror relationship on source
+            # 4. Cleanup SnapMirror relationship on source
             if src_client:
                 src_config = get_backend_configuration(src_backend)
                 release_timeout = (
@@ -566,6 +609,7 @@ class DataMotionSession(object):
                                           dest_vserver,
                                           dest_volume_name)
 
+    @na_utils.trace
     def change_snapmirror_source(self, replica,
                                  orig_source_replica,
                                  new_source_replica, replica_list,
@@ -588,6 +632,30 @@ class DataMotionSession(object):
         new_src_volume_name, new_src_vserver, new_src_backend = (
             self.get_backend_info_for_share(new_source_replica))
 
+        if replica['id'] == orig_source_replica['id']:
+            # Take the policy from the existing snapmirror relationship
+            # if the replica is the original active replica. This is to ensure
+            # the same policy is used when the replica is resynced with the
+            # new source.
+            try:
+                snapmirrors = self.get_snapmirrors(
+                    orig_source_replica, new_source_replica)
+                policy = (snapmirrors[0].get("policy")
+                          if snapmirrors and len(snapmirrors) > 0
+                          else None)
+                is_sync_policy = policy in na_utils.SUPPORTED_SYNC_POLICIES
+            except netapp_api.NaApiError:
+                LOG.exception("Could not get snapmirrors for replica %s.",
+                              replica['id'])
+                msg = (_('Could not get snapmirrors for replica %s.')
+                       % replica['id'])
+                raise exception.NetAppException(message=msg)
+        else:
+            """If the replica is not the original active replica then
+            get the policy from the replica's metadata."""
+            policy, is_sync_policy = (
+                self.get_policy_from_share_replica_metadata(replica))
+
         # 1. delete
         for other_replica in replica_list:
             if other_replica['id'] == replica['id']:
@@ -595,14 +663,13 @@ class DataMotionSession(object):
 
             # deletes all snapmirror relationships involving this replica to
             # ensure new relation can be set. For efficient snapmirror, it
-            # does not remove the snapshots, only releasing the relationship
-            # info if FlexGroup volume.
+            # does not remove the snapshots, always releasing the relationship.
             self.delete_snapmirror(other_replica, replica,
-                                   release=is_flexgroup,
-                                   relationship_info_only=is_flexgroup)
+                                   release=True,
+                                   relationship_info_only=True)
             self.delete_snapmirror(replica, other_replica,
-                                   release=is_flexgroup,
-                                   relationship_info_only=is_flexgroup)
+                                   release=True,
+                                   relationship_info_only=True)
 
         # 2. vserver operations when driver handles share servers
         replica_config = get_backend_configuration(replica_backend)
@@ -625,20 +692,28 @@ class DataMotionSession(object):
                                                        replica_vserver)
 
         # 3. create
-        relationship_type = na_utils.get_relationship_type(is_flexgroup)
-        schedule = replica_config.netapp_snapmirror_schedule
+        if is_sync_policy:
+            """skip the schedule setting incase of sync policy type
+            as per NetApp design"""
+            schedule = None
+        else:
+            schedule = replica_config.netapp_snapmirror_schedule
+        relationship_type = na_utils.EXTENDED_DATA_PROTECTION_TYPE
         replica_client.create_snapmirror_vol(new_src_vserver,
                                              new_src_volume_name,
                                              replica_vserver,
                                              replica_volume_name,
                                              relationship_type,
-                                             schedule=schedule)
+                                             schedule=schedule,
+                                             policy=policy)
 
         # 4. resync
         replica_client.resync_snapmirror_vol(new_src_vserver,
                                              new_src_volume_name,
                                              replica_vserver,
                                              replica_volume_name)
+
+        return is_sync_policy
 
     @na_utils.trace
     def remove_qos_on_old_active_replica(self, orig_active_replica):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -42,6 +42,7 @@ from manila import coordination
 from manila import exception
 from manila.i18n import _
 from manila.message import api as message_api
+from manila.message import message_field
 from manila.share.drivers.netapp.dataontap.client import api as netapp_api
 from manila.share.drivers.netapp.dataontap.client import client_cmode
 from manila.share.drivers.netapp.dataontap.client import client_cmode_rest
@@ -166,6 +167,15 @@ class NetAppCmodeFileStorageLibrary(object):
         'setattr', 'symlink']
 
     SNAPLOCK_TYPE = ['compliance', 'enterprise']
+
+    # Replication policies supported by the driver
+    # this can be extended with additional pre-canned policies
+    # which requires some changes in data_motion.py module.
+    SUPPORTED_REPLICATION_POLICIES = [
+        "Sync",
+        "StrictSync",
+        "MirrorAllSnapshots"
+    ]
 
     def __init__(self, driver_name, **kwargs):
         na_utils.validate_driver_instantiation(**kwargs)
@@ -3062,9 +3072,26 @@ class NetAppCmodeFileStorageLibrary(object):
         return [replica for replica in replica_list
                 if replica['replica_state'] != constants.REPLICA_STATE_ACTIVE]
 
+    def _validate_replication_policy(self, replication_policy):
+        """Validates that the replication policy is supported by the driver.
+
+        :param replication_policy: The replication policy to validate.
+        :returns: True if the replication policy is supported, False otherwise.
+        """
+        return replication_policy in self.SUPPORTED_REPLICATION_POLICIES
+
+    @na_utils.trace
     def create_replica(self, context, replica_list, new_replica,
                        access_rules, share_snapshots, share_server=None):
         """Creates the new replica on this backend and sets up SnapMirror."""
+        # Cache frequently used fields
+        new_replica_id = new_replica['id']
+        new_replica_host = new_replica['host']
+        base_msg_args = {
+            'replica_id': new_replica_id,
+            'share_id': new_replica['share_id'],
+        }
+
         active_replica = self.find_active_replica(replica_list)
         dm_session = data_motion.DataMotionSession()
 
@@ -3076,9 +3103,52 @@ class NetAppCmodeFileStorageLibrary(object):
             src_backend, vserver_name=src_vserver)
         src_is_flexgroup = self._is_flexgroup_share(src_client, src_share_name)
 
-        pool_name = share_utils.extract_host(new_replica['host'], level='pool')
+        pool_name = share_utils.extract_host(new_replica_host, level='pool')
         dest_is_flexgroup = self._is_flexgroup_pool(pool_name)
 
+        # Get replication policy and validate (if present)
+        replication_policy, is_sync_policy = (
+            dm_session.get_policy_from_share_replica_metadata(new_replica)
+        )
+        LOG.debug("Replication policy for new replica %(replica_id)s "
+                  "from share %(share_id)s is '%(policy)s'.",
+                  {**base_msg_args,
+                   'policy': replication_policy})
+        if (replication_policy and not
+                self._validate_replication_policy(replication_policy)):
+            msg = _('Could not create replica %(replica_id)s from share '
+                    '%(share_id)s in the destination host %(dest_host)s. The '
+                    'replication policy %(policy)s is not supported.')
+            msg_args = {
+                **base_msg_args,
+                'dest_host': new_replica_host,
+                'policy': replication_policy,
+            }
+            raise exception.NetAppException(msg % msg_args)
+
+        if is_sync_policy and len(share_snapshots) > 0:
+            msg = _('Could not create replica %(replica_id)s from share '
+                    '%(share_id)s in the destination host %(dest_host)s. '
+                    'Synchronous replication is not supported for shares '
+                    'that have snapshots. Either use asynchronous replication '
+                    '(MirrorAllSnapshots) or '
+                    'delete existing snapshots on the share.')
+            msg_args = {
+                **base_msg_args,
+                'dest_host': new_replica_host,
+            }
+            self.message_api.create(
+                context,
+                message_field.Action.CREATE,
+                context.project_id,
+                resource_type=message_field.Resource.SHARE_REPLICA,
+                resource_id=new_replica_id,
+                detail=(message_field.Detail
+                        .UNSUPPORTED_REPLICA_CREATE_CONFIG)
+            )
+            raise exception.NetAppException(msg % msg_args)
+
+        # Ensure source and destination are the same pool type
         if src_is_flexgroup != dest_is_flexgroup:
             src_type = 'FlexGroup' if src_is_flexgroup else 'FlexVol'
             dest_type = 'FlexGroup' if dest_is_flexgroup else 'FlexVol'
@@ -3086,10 +3156,32 @@ class NetAppCmodeFileStorageLibrary(object):
                     '%(share_id)s in the destination host %(dest_host)s. The '
                     'source share is from %(src_type)s style, while the '
                     'destination replica host is %(dest_type)s style.')
-            msg_args = {'replica_id': new_replica['id'],
-                        'share_id': new_replica['share_id'],
-                        'dest_host': new_replica['host'],
-                        'src_type': src_type, 'dest_type': dest_type}
+            msg_args = {
+                **base_msg_args,
+                'dest_host': new_replica_host,
+                'src_type': src_type,
+                'dest_type': dest_type,
+            }
+            raise exception.NetAppException(msg % msg_args)
+
+        if (dest_is_flexgroup and replication_policy and is_sync_policy):
+            msg = _('Could not create replica %(replica_id)s from share '
+                    '%(share_id)s in the destination host %(dest_host)s. '
+                    'FlexGroup shares are not supported for Sync type '
+                    'replication as per ONTAP design.')
+            msg_args = {
+                **base_msg_args,
+                'dest_host': new_replica_host,
+            }
+            self.message_api.create(
+                context,
+                message_field.Action.CREATE,
+                context.project_id,
+                resource_type=message_field.Resource.SHARE_REPLICA,
+                resource_id=new_replica_id,
+                detail=(message_field.Detail
+                        .UNSUPPORTED_REPLICA_CREATE_CONFIG)
+            )
             raise exception.NetAppException(msg % msg_args)
 
         # NOTE(felipe_rodrigues): The FlexGroup replication does not support
@@ -3102,13 +3194,14 @@ class NetAppCmodeFileStorageLibrary(object):
                 msg = _('Could not create replica %(replica_id)s from share '
                         '%(share_id)s in the destination host %(dest_host)s. '
                         'The share does not support more than one replica.')
-                msg_args = {'replica_id': new_replica['id'],
-                            'share_id': new_replica['share_id'],
-                            'dest_host': new_replica['host']}
+                msg_args = {
+                    **base_msg_args,
+                    'dest_host': new_replica_host,
+                }
                 raise exception.NetAppException(msg % msg_args)
 
         # 1. Create the destination share
-        dest_backend = share_utils.extract_host(new_replica['host'],
+        dest_backend = share_utils.extract_host(new_replica_host,
                                                 level='backend_name')
 
         vserver = (dm_session.get_vserver_from_share(new_replica) or
@@ -3123,11 +3216,11 @@ class NetAppCmodeFileStorageLibrary(object):
                                  set_qos=is_readable)
 
         # 2. Setup SnapMirror with mounting replica whether 'readable' type.
-        relationship_type = na_utils.get_relationship_type(dest_is_flexgroup)
+        relationship_type = na_utils.EXTENDED_DATA_PROTECTION_TYPE
         dm_session.create_snapmirror(active_replica, new_replica,
                                      relationship_type, mount=is_readable)
 
-        # 3. Create export location
+        # 3. Create export location and update access rules (if readable)
         model_update = {
             'export_locations': [],
             'replica_state': constants.REPLICA_STATE_OUT_OF_SYNC,
@@ -3141,7 +3234,7 @@ class NetAppCmodeFileStorageLibrary(object):
             if access_rules:
                 helper = self._get_helper(new_replica)
                 helper.set_client(vserver_client)
-                share_name = self._get_backend_share_name(new_replica['id'])
+                share_name = self._get_backend_share_name(new_replica_id)
                 try:
                     helper.update_access(new_replica, share_name, access_rules,
                                          replica=True)
@@ -3151,6 +3244,7 @@ class NetAppCmodeFileStorageLibrary(object):
 
         return model_update
 
+    @na_utils.trace
     def delete_replica(self, context, replica_list, replica, share_snapshots,
                        share_server=None):
         """Removes the replica on this backend and destroys SnapMirror."""
@@ -3238,10 +3332,7 @@ class NetAppCmodeFileStorageLibrary(object):
         if not snapmirrors:
             if replica['status'] != constants.STATUS_CREATING:
                 try:
-                    pool_name = share_utils.extract_host(replica['host'],
-                                                         level='pool')
-                    relationship_type = na_utils.get_relationship_type(
-                        self._is_flexgroup_pool(pool_name))
+                    relationship_type = na_utils.EXTENDED_DATA_PROTECTION_TYPE
                     dm_session.create_snapmirror(active_replica, replica,
                                                  relationship_type,
                                                  mount=is_readable)
@@ -3252,18 +3343,50 @@ class NetAppCmodeFileStorageLibrary(object):
             return constants.REPLICA_STATE_OUT_OF_SYNC
 
         snapmirror = snapmirrors[0]
+
+        # Determine desired steady state based on policy type.
+        # Async policies target 'snapmirrored';
+        # sync policies target 'in_sync'.
+        policy_type = snapmirror.get('policy-type', '').lower()
+        LOG.debug("policy_type %s for replica %s.", policy_type,
+                  replica['id'])
+        is_sync_policy = (
+            policy_type in (
+                na_utils.SYNC_POLICY_TYPE_NAME,
+                na_utils.ZAPI_STRICT_SYNC_POLICY_TYPE_NAME,
+                na_utils.ZAPI_SYNC_POLICY_TYPE_NAME
+            )
+        )
+        LOG.debug("is_sync_policy %s for replica %s.", is_sync_policy,
+                  replica['id'])
+        desired_state = (
+            vserver_client.get_desired_sync_snapmirror_state()
+            if is_sync_policy
+            else na_utils.SM_SNAPMIRRORED_STATE
+        )
+        LOG.debug("desired_state %s for replica %s.", desired_state,
+                  replica['id'])
+
         # NOTE(dviroel): Don't try to resume or resync a SnapMirror that has
         # one of the in progress transfer states, because the storage will
         # answer with an error.
-        in_progress_status = ['preparing', 'transferring', 'finalizing',
-                              'synchronizing']
-        if (snapmirror.get('mirror-state') != 'snapmirrored' and
-                (snapmirror.get('relationship-status') in in_progress_status or
-                 snapmirror.get('transferring-state') in in_progress_status)):
+        in_progress_status = [
+            na_utils.SM_PREPARING_STATE,
+            na_utils.SM_TRANSFERRING_STATE,
+            na_utils.SM_SYNCHRONIZING_STATE,
+            na_utils.SM_FINALIZING_STATE
+        ]
+        if (snapmirror.get('mirror-state') != desired_state and
+            (snapmirror.get('relationship-status') in in_progress_status or
+             snapmirror.get('transferring-state') in in_progress_status)):
+            LOG.debug("Entered in-progress state for replica %s.",
+                      replica['id'])
             return constants.REPLICA_STATE_OUT_OF_SYNC
 
-        if snapmirror.get('mirror-state') != 'snapmirrored':
+        if snapmirror.get('mirror-state') != desired_state:
             try:
+                LOG.debug("Invoking snapmirror resume/resync for replica %s.",
+                          replica['id'])
                 vserver_client.resume_snapmirror_vol(
                     snapmirror['source-vserver'],
                     snapmirror['source-volume'],
@@ -3279,31 +3402,36 @@ class NetAppCmodeFileStorageLibrary(object):
                 LOG.exception("Could not resync snapmirror.")
                 return constants.STATUS_ERROR
 
-        if skip_conf_snapmirror_schedule is False:
-            # Enforce the SnapMirror schedule to match the configuration
-            current_schedule = snapmirror.get('schedule')
-            new_schedule = self.configuration.netapp_snapmirror_schedule
-            if current_schedule != new_schedule:
-                dm_session.modify_snapmirror(active_replica, replica,
-                                             schedule=new_schedule)
-                LOG.debug('Modify snapmirror schedule for replica:'
-                          '%(replica)s from %(from)s to %(to)s',
-                          {'replica': replica['id'],
-                           'from': current_schedule,
-                           'to': new_schedule})
+        # For async type policy, reconcile schedules/RPO if they differ.
+        # Sync/StrictSync do not use schedules; skip modification.
+        # Also skip if the schedule is overridden via share metadata (snapmirror_schedule).     # noqa: E501
+        if not is_sync_policy:
+            if not skip_conf_snapmirror_schedule:
+                current_schedule = snapmirror.get('schedule')
+                new_schedule = self.configuration.netapp_snapmirror_schedule
+                if current_schedule != new_schedule:
+                    dm_session.modify_snapmirror(active_replica, replica,
+                                                 schedule=new_schedule)
+                    LOG.debug('Modify snapmirror schedule for replica:'
+                              '%(replica)s from %(from)s to %(to)s',
+                              {'replica': replica['id'],
+                               'from': current_schedule,
+                               'to': new_schedule})
 
-        last_update_timestamp = float(
-            snapmirror.get('last-transfer-end-timestamp', 0))
-        # Recovery Point Objective (RPO) indicates the point in time to
-        # which data can be recovered. The RPO target is typically less
-        # than twice the replication schedule.
-        if (last_update_timestamp and
-            (timeutils.is_older_than(
-                datetime.datetime.fromtimestamp(
-                    last_update_timestamp,
-                    tz=datetime.timezone.utc).replace(tzinfo=None)
-                .isoformat(), (2 * self._snapmirror_schedule)))):
-            return constants.REPLICA_STATE_OUT_OF_SYNC
+            last_update_timestamp = float(
+                snapmirror.get('last-transfer-end-timestamp', 0))
+            # Recovery Point Objective (RPO) indicates the point in time to
+            # which data can be recovered. The RPO target is typically less
+            # than twice the replication schedule.
+            if (last_update_timestamp and
+                (timeutils.is_older_than(
+                    datetime.datetime.fromtimestamp(
+                        last_update_timestamp,
+                        tz=datetime.timezone.utc).replace(tzinfo=None)
+                    .isoformat(), (2 * self._snapmirror_schedule)))):
+                LOG.debug("Last updated timestamp is too old for replica %s.",
+                          replica['id'])
+                return constants.REPLICA_STATE_OUT_OF_SYNC
 
         last_transfer_error = snapmirror.get('last-transfer-error', None)
         if last_transfer_error:
@@ -3320,6 +3448,12 @@ class NetAppCmodeFileStorageLibrary(object):
             if (not snapshot_name or
                     not vserver_client.snapshot_exists(snapshot_name,
                                                        share_name)):
+                LOG.debug('Could not find the share snapshot ' +
+                          '%(snap)s on destination site or ' +
+                          'provider_location is not set for ' +
+                          'replica %(replica)s.', {
+                              'snap': snapshot_name,
+                              'replica': replica['id']})
                 return constants.REPLICA_STATE_OUT_OF_SYNC
 
         # NOTE(sfernand): When promoting replicas, the previous source volume
@@ -3333,6 +3467,7 @@ class NetAppCmodeFileStorageLibrary(object):
 
         return constants.REPLICA_STATE_IN_SYNC
 
+    @na_utils.trace
     def promote_replica(self, context, replica_list, replica, access_rules,
                         share_server=None, quiesce_wait_time=None):
         """Switch SnapMirror relationships and allow r/w ops on replica.
@@ -3705,6 +3840,7 @@ class NetAppCmodeFileStorageLibrary(object):
 
         return new_active_replica
 
+    @na_utils.trace
     def _safe_change_replica_source(self, dm_session, replica,
                                     orig_source_replica,
                                     new_source_replica, replica_list,
@@ -3725,11 +3861,12 @@ class NetAppCmodeFileStorageLibrary(object):
         :return: Updated replica.
         """
         try:
-            dm_session.change_snapmirror_source(replica,
-                                                orig_source_replica,
-                                                new_source_replica,
-                                                replica_list,
-                                                is_flexgroup=is_flexgroup)
+            is_sync_policy = dm_session.change_snapmirror_source(
+                replica,
+                orig_source_replica,
+                new_source_replica,
+                replica_list,
+                is_flexgroup=is_flexgroup)
         # Catch everything! The original source may be down,
         # but in this disaster scenario we still want to continue
         except Exception as e:
@@ -3742,7 +3879,11 @@ class NetAppCmodeFileStorageLibrary(object):
             LOG.exception(msg)
             return replica
 
-        replica['replica_state'] = constants.REPLICA_STATE_OUT_OF_SYNC
+        replica['replica_state'] = (
+            constants.REPLICA_STATE_IN_SYNC
+            if is_sync_policy
+            else constants.REPLICA_STATE_OUT_OF_SYNC
+        )
         replica['status'] = constants.STATUS_AVAILABLE
         if is_dr:
             replica['export_locations'] = []

--- a/manila/share/drivers/netapp/utils.py
+++ b/manila/share/drivers/netapp/utils.py
@@ -54,6 +54,26 @@ FLEXGROUP_DEFAULT_POOL_NAME = 'flexgroup_auto'
 
 ABSOLUTE_MAX_INODES = 2_040_109_45
 
+CLONE_SPLIT_STATUS_ONGOING = 'ongoing'
+CLONE_SPLIT_STATUS_UNKNOWN = 'unknown'
+CLONE_SPLIT_STATUS_FINISHED = 'finished'
+
+SYNC_POLICY_NAME = 'Sync'
+STRICT_SYNC_POLICY_NAME = 'StrictSync'
+SUPPORTED_SYNC_POLICIES = (SYNC_POLICY_NAME, STRICT_SYNC_POLICY_NAME)
+
+SYNC_POLICY_TYPE_NAME = 'sync'
+ASYNC_POLICY_TYPE_NAME = 'async'
+ZAPI_STRICT_SYNC_POLICY_TYPE_NAME = 'strict_sync_mirror'
+ZAPI_SYNC_POLICY_TYPE_NAME = 'sync_mirror'
+
+SM_SNAPMIRRORED_STATE = 'snapmirrored'
+SM_IN_SYNC_STATE = 'in_sync'
+SM_PREPARING_STATE = 'preparing'
+SM_TRANSFERRING_STATE = 'transferring'
+SM_FINALIZING_STATE = 'finalizing'
+SM_SYNCHRONIZING_STATE = 'synchronizing'
+
 
 class NetAppDriverException(exception.ShareBackendException):
     message = _("NetApp Manila Driver exception.")

--- a/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
@@ -4096,7 +4096,8 @@ SNAPMIRROR_GET_ITER_RESPONSE_REST = {
                 }
             },
             "policy": {
-                "type": "async"
+                "type": "async",
+                "name": "MirrorAllSnapshots"
             },
             "state": "snapmirrored",
             "healthy": True,
@@ -4122,6 +4123,7 @@ REST_GET_SNAPMIRRORS_RESPONSE = [{
     'source-volume': SM_SOURCE_VOLUME,
     'source-vserver': SM_SOURCE_VSERVER,
     'uuid': FAKE_UUID,
+    'policy': 'MirrorAllSnapshots',
     'policy-type': 'async',
     'schedule': 'hourly',
     'transferring-state': 'success',

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -7265,10 +7265,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
             relationship_info_only=relationship_info_only)
 
         snapmirror_release_args = {
-            'source-vserver': fake.SM_SOURCE_VSERVER,
-            'source-volume': fake.SM_SOURCE_VOLUME,
-            'destination-vserver': fake.SM_DEST_VSERVER,
-            'destination-volume': fake.SM_DEST_VOLUME,
+            'source-location':
+                f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+            'destination-location':
+                f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
             'relationship-info-only': ('true' if relationship_info_only
                                        else 'false'),
         }
@@ -7321,10 +7321,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
             fake.SM_DEST_VSERVER, fake.SM_DEST_VOLUME)
 
         snapmirror_quiesce_args = {
-            'source-vserver': fake.SM_SOURCE_VSERVER,
-            'source-volume': fake.SM_SOURCE_VOLUME,
-            'destination-vserver': fake.SM_DEST_VSERVER,
-            'destination-volume': fake.SM_DEST_VOLUME,
+            'source-location':
+                f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+            'destination-location':
+                f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
         }
         self.client.send_request.assert_has_calls([
             mock.call('snapmirror-quiesce', snapmirror_quiesce_args)])
@@ -7354,10 +7354,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
             clear_checkpoint=clear_checkpoint)
 
         snapmirror_abort_args = {
-            'source-vserver': fake.SM_SOURCE_VSERVER,
-            'source-volume': fake.SM_SOURCE_VOLUME,
-            'destination-vserver': fake.SM_DEST_VSERVER,
-            'destination-volume': fake.SM_DEST_VOLUME,
+            'source-location':
+                f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+            'destination-location':
+                f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
             'clear-checkpoint': 'true' if clear_checkpoint else 'false',
         }
         self.client.send_request.assert_has_calls([
@@ -7388,10 +7388,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
             fake.SM_DEST_VSERVER, fake.SM_DEST_VOLUME)
 
         snapmirror_abort_args = {
-            'source-vserver': fake.SM_SOURCE_VSERVER,
-            'source-volume': fake.SM_SOURCE_VOLUME,
-            'destination-vserver': fake.SM_DEST_VSERVER,
-            'destination-volume': fake.SM_DEST_VOLUME,
+            'source-location':
+                f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+            'destination-location':
+                f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
             'clear-checkpoint': 'false',
         }
         self.client.send_request.assert_has_calls([
@@ -7415,10 +7415,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
             fake.SM_DEST_VSERVER, fake.SM_DEST_VOLUME)
 
         snapmirror_break_args = {
-            'source-vserver': fake.SM_SOURCE_VSERVER,
-            'source-volume': fake.SM_SOURCE_VOLUME,
-            'destination-vserver': fake.SM_DEST_VSERVER,
-            'destination-volume': fake.SM_DEST_VOLUME,
+            'source-location':
+                f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+            'destination-location':
+                f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
         }
         self.client.send_request.assert_has_calls([
             mock.call('snapmirror-break', snapmirror_break_args)])
@@ -7567,10 +7567,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
         snapmirror_delete_args = {
             'query': {
                 'snapmirror-info': {
-                    'source-vserver': fake.SM_SOURCE_VSERVER,
-                    'source-volume': fake.SM_SOURCE_VOLUME,
-                    'destination-vserver': fake.SM_DEST_VSERVER,
-                    'destination-volume': fake.SM_DEST_VOLUME,
+                    'source-location':
+                        f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+                    'destination-location':
+                        f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
                 }
             }
         }
@@ -7802,10 +7802,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
             fake.SM_DEST_VSERVER, fake.SM_DEST_VOLUME)
 
         snapmirror_resume_args = {
-            'source-vserver': fake.SM_SOURCE_VSERVER,
-            'source-volume': fake.SM_SOURCE_VOLUME,
-            'destination-vserver': fake.SM_DEST_VSERVER,
-            'destination-volume': fake.SM_DEST_VOLUME,
+            'source-location':
+                f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+            'destination-location':
+                f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
         }
         self.client.send_request.assert_has_calls([
             mock.call('snapmirror-resume', snapmirror_resume_args)])
@@ -7833,10 +7833,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
             fake.SM_DEST_VSERVER, fake.SM_DEST_VOLUME)
 
         snapmirror_resume_args = {
-            'source-vserver': fake.SM_SOURCE_VSERVER,
-            'source-volume': fake.SM_SOURCE_VOLUME,
-            'destination-vserver': fake.SM_DEST_VSERVER,
-            'destination-volume': fake.SM_DEST_VOLUME,
+            'source-location':
+                f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+            'destination-location':
+                f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
         }
         self.client.send_request.assert_has_calls([
             mock.call('snapmirror-resume', snapmirror_resume_args)])
@@ -7858,10 +7858,10 @@ class NetAppClientCmodeTestCase(test.TestCase):
             fake.SM_DEST_VSERVER, fake.SM_DEST_VOLUME)
 
         snapmirror_resync_args = {
-            'source-vserver': fake.SM_SOURCE_VSERVER,
-            'source-volume': fake.SM_SOURCE_VOLUME,
-            'destination-vserver': fake.SM_DEST_VSERVER,
-            'destination-volume': fake.SM_DEST_VOLUME,
+            'source-location':
+                f"{fake.SM_SOURCE_VSERVER}:{fake.SM_SOURCE_VOLUME}",
+            'destination-location':
+                f"{fake.SM_DEST_VSERVER}:{fake.SM_DEST_VOLUME}",
         }
         self.client.send_request.assert_has_calls([
             mock.call('snapmirror-resync', snapmirror_resync_args)])

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -2376,7 +2376,7 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
                                  ':' + fake.SM_DEST_VOLUME),
             'fields': 'state,source.svm.name,source.path,destination.svm.name,'
                       'destination.path,transfer.end_time,uuid,policy.type,'
-                      'transfer_schedule.name,transfer.state,'
+                      'policy.name,transfer_schedule.name,transfer.state,'
                       'last_transfer_type,transfer.bytes_transferred,healthy'
         }
 
@@ -2409,7 +2409,7 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
                                  ':' + fake.SM_DEST_VOLUME),
             'fields': 'state,source.svm.name,source.path,destination.svm.name,'
                       'destination.path,transfer.end_time,uuid,policy.type,'
-                      'transfer_schedule.name,transfer.state,'
+                      'policy.name,transfer_schedule.name,transfer.state,'
                       'last_transfer_type,transfer.bytes_transferred,healthy'
         }
 
@@ -2438,7 +2438,7 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
                                  ':' + fake.SM_DEST_VOLUME),
             'fields': 'state,source.svm.name,source.path,destination.svm.name,'
                       'destination.path,transfer.end_time,uuid,policy.type,'
-                      'transfer_schedule.name,transfer.state,'
+                      'policy.name,transfer_schedule.name,transfer.state,'
                       'last_transfer_type,transfer.bytes_transferred,healthy'
         }
 

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
@@ -252,11 +252,44 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
 
         mock_dest_client.create_snapmirror_vol.assert_called_once_with(
             mock.ANY, self.fake_src_vol_name, mock.ANY,
-            self.fake_dest_vol_name, 'data_protection', schedule='hourly'
+            self.fake_dest_vol_name, 'data_protection', schedule='hourly',
+            policy='MirrorAllSnapshots'
         )
         mock_dest_client.initialize_snapmirror_vol.assert_called_once_with(
             mock.ANY, self.fake_src_vol_name, mock.ANY,
-            self.fake_dest_vol_name
+            self.fake_dest_vol_name, state='snapmirrored'
+        )
+        if mount:
+            self.dm_session.wait_for_mount_replica.assert_called_once_with(
+                mock_dest_client, self.fake_dest_vol_name, timeout=30)
+        else:
+            self.dm_session.wait_for_mount_replica.assert_not_called()
+
+    @ddt.data(True, False)
+    def test_create_snapmirror_sync_policy(self, mount):
+        mock_dest_client = mock.Mock()
+        self.mock_object(data_motion, 'get_client_for_backend',
+                         mock.Mock(return_value=mock_dest_client))
+        self.mock_object(self.dm_session, 'wait_for_mount_replica')
+        mock_backend_config = na_fakes.create_configuration()
+        mock_backend_config.netapp_mount_replica_timeout = 30
+        self.mock_object(data_motion, 'get_backend_configuration',
+                         mock.Mock(return_value=mock_backend_config))
+
+        self.fake_dest_share['metadata'] = {'replication_policy': 'Sync'}
+
+        self.dm_session.create_snapmirror(self.fake_src_share,
+                                          self.fake_dest_share,
+                                          'data_protection', mount=mount)
+
+        mock_dest_client.create_snapmirror_vol.assert_called_once_with(
+            mock.ANY, self.fake_src_vol_name, mock.ANY,
+            self.fake_dest_vol_name, 'data_protection', schedule=None,
+            policy='Sync'
+        )
+        mock_dest_client.initialize_snapmirror_vol.assert_called_once_with(
+            mock.ANY, self.fake_src_vol_name, mock.ANY,
+            self.fake_dest_vol_name, state='in_sync'
         )
         if mount:
             self.dm_session.wait_for_mount_replica.assert_called_once_with(
@@ -807,14 +840,14 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
 
         self.assertEqual(4, self.dm_session.delete_snapmirror.call_count)
         self.dm_session.delete_snapmirror.assert_called_with(
-            mock.ANY, mock.ANY, release=False, relationship_info_only=False
+            mock.ANY, mock.ANY, release=True, relationship_info_only=True
         )
 
-        na_utils.get_relationship_type.assert_called_once_with(False)
         self.mock_dest_client.create_snapmirror_vol.assert_called_once_with(
             mock.ANY, fake_new_src_share_name, mock.ANY,
-            self.fake_dest_vol_name, na_utils.DATA_PROTECTION_TYPE,
-            schedule='hourly'
+            self.fake_dest_vol_name, na_utils.EXTENDED_DATA_PROTECTION_TYPE,
+            schedule='hourly',
+            policy=na_utils.MIRROR_ALL_SNAP_POLICY
         )
 
         self.mock_dest_client.resync_snapmirror_vol.assert_called_once_with(
@@ -862,14 +895,15 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
         self.mock_src_client.accept_vserver_peer.assert_called_once_with(
             fake_new_src_ss_name, self.dest_vserver
         )
-        na_utils.get_relationship_type.assert_called_once_with(False)
         self.dm_session.delete_snapmirror.assert_called_with(
-            mock.ANY, mock.ANY, release=False, relationship_info_only=False
+            mock.ANY, mock.ANY, release=True, relationship_info_only=True
         )
         self.mock_dest_client.create_snapmirror_vol.assert_called_once_with(
             mock.ANY, fake_new_src_share_name, mock.ANY,
-            self.fake_dest_vol_name, na_utils.DATA_PROTECTION_TYPE,
-            schedule='hourly'
+            self.fake_dest_vol_name,
+            na_utils.EXTENDED_DATA_PROTECTION_TYPE,
+            schedule='hourly',
+            policy=na_utils.MIRROR_ALL_SNAP_POLICY
         )
         self.mock_dest_client.resync_snapmirror_vol.assert_called_once_with(
             mock.ANY, fake_new_src_share_name, mock.ANY,
@@ -888,6 +922,8 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
             source_volume=self.fake_src_vol_name,
             dest_volume=self.fake_dest_vol_name,
             desired_attributes=['relationship-status',
+                                'policy',
+                                'policy-type',
                                 'mirror-state',
                                 'schedule',
                                 'source-vserver',
@@ -1402,3 +1438,18 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
                                  source_snapshot=mock.ANY,
                                  transfer_priority=mock.ANY,
                                  ))
+
+    def test_get_policy_from_share_replica_metadata_with_sync_policy(self):
+        share = copy.deepcopy(fake.SHARE)
+        share['metadata'] = {'replication_policy': 'Sync'}
+        policy, is_async_policy = (
+            self.dm_session.get_policy_from_share_replica_metadata(share))
+        self.assertEqual('Sync', policy)
+        self.assertTrue(is_async_policy)
+
+    def test_get_policy_from_share_replica_metadata_without_metadata(self):
+        share = copy.deepcopy(fake.SHARE)
+        policy, is_async_policy = (
+            self.dm_session.get_policy_from_share_replica_metadata(share))
+        self.assertEqual('MirrorAllSnapshots', policy)
+        self.assertFalse(is_async_policy)

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -4162,6 +4162,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          mock.Mock(return_value=fake.VSERVER1))
         self.mock_object(self.library, '_get_backend_share_name',
                          mock.Mock(return_value=fake.SHARE_NAME))
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('MirrorAllSnapshots', False)))
         mock_is_readable = self.mock_object(
             self.library, '_is_readable_replica',
             mock.Mock(return_value=is_readable))
@@ -4185,8 +4188,10 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          mock.Mock(return_value=False))
         self.mock_object(self.library, '_is_flexgroup_pool',
                          mock.Mock(return_value=False))
-        self.mock_object(na_utils, 'get_relationship_type',
-                         mock.Mock(return_value=na_utils.DATA_PROTECTION_TYPE))
+        self.mock_object(
+            na_utils,
+            'get_relationship_type',
+            mock.Mock(return_value=na_utils.EXTENDED_DATA_PROTECTION_TYPE))
         expected_model_update = {
             'export_locations': [],
             'replica_state': constants.REPLICA_STATE_OUT_OF_SYNC,
@@ -4199,7 +4204,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         self.assertDictEqual(expected_model_update, model_update)
         mock_dm_session.create_snapmirror.assert_called_once_with(
-            fake.SHARE, fake.SHARE, na_utils.DATA_PROTECTION_TYPE,
+            fake.SHARE, fake.SHARE, na_utils.EXTENDED_DATA_PROTECTION_TYPE,
             mount=is_readable)
         mock_is_readable.assert_called_once_with(fake.SHARE)
         if is_readable:
@@ -4218,7 +4223,6 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             [mock.call(fake.BACKEND_NAME, vserver_name=fake.VSERVER1),
              mock.call(fake.BACKEND_NAME, vserver_name=fake.VSERVER1)])
         self.library._is_flexgroup_pool.assert_called_once_with(fake.POOL_NAME)
-        na_utils.get_relationship_type.assert_called_once_with(False)
 
     def test_create_replica_with_share_server(self):
         self.mock_object(self.library,
@@ -4238,6 +4242,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(data_motion, 'get_client_for_backend')
         self.mock_object(mock_dm_session, 'get_vserver_from_share',
                          mock.Mock(return_value=fake.VSERVER1))
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('MirrorAllSnapshots', False)))
         self.mock_object(self.library,
                          '_is_readable_replica',
                          mock.Mock(return_value=False))
@@ -4253,7 +4260,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
 
         self.assertDictEqual(expected_model_update, model_update)
         mock_dm_session.create_snapmirror.assert_called_once_with(
-            fake.SHARE, fake.SHARE, na_utils.DATA_PROTECTION_TYPE,
+            fake.SHARE, fake.SHARE, na_utils.EXTENDED_DATA_PROTECTION_TYPE,
             mount=False)
         data_motion.get_client_for_backend.assert_has_calls(
             [mock.call(fake.BACKEND_NAME, vserver_name=fake.VSERVER1),
@@ -4274,6 +4281,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library, '_is_flexgroup_pool',
                          mock.Mock(return_value=False))
         self.mock_object(data_motion, 'get_client_for_backend')
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('MirrorAllSnapshots', False)))
 
         self.assertRaises(exception.NetAppException,
                           self.library.create_replica,
@@ -4293,6 +4303,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          mock.Mock(return_value=True))
         self.mock_object(self.library, '_is_flexgroup_pool',
                          mock.Mock(return_value=True))
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('MirrorAllSnapshots', False)))
 
         mock_src_client = mock.Mock()
         self.mock_object(mock_src_client,
@@ -4301,6 +4314,61 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library._client,
                          'is_flexgroup_fan_out_supported',
                          mock.Mock(return_value=False))
+        self.mock_object(data_motion, 'get_client_for_backend',
+                         mock.Mock(return_value=mock_src_client))
+
+        self.assertRaises(exception.NetAppException,
+                          self.library.create_replica,
+                          None, [fake.SHARE, fake.SHARE, fake.SHARE],
+                          fake.SHARE, [], [], share_server=None)
+
+    def test_create_replica_raise_flexgroup_no_sync_support(self):
+
+        mock_dm_session = mock.Mock()
+        self.mock_object(data_motion, "DataMotionSession",
+                         mock.Mock(return_value=mock_dm_session))
+        self.mock_object(mock_dm_session, 'get_backend_info_for_share',
+                         mock.Mock(return_value=(fake.SHARE_NAME,
+                                                 fake.VSERVER1,
+                                                 fake.BACKEND_NAME)))
+        self.mock_object(self.library, '_is_flexgroup_share',
+                         mock.Mock(return_value=True))
+        self.mock_object(self.library, '_is_flexgroup_pool',
+                         mock.Mock(return_value=True))
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('Sync', True)))
+
+        mock_src_client = mock.Mock()
+
+        self.mock_object(data_motion, 'get_client_for_backend',
+                         mock.Mock(return_value=mock_src_client))
+
+        context = mock.Mock()
+        self.assertRaises(exception.NetAppException,
+                          self.library.create_replica,
+                          context, [fake.SHARE, fake.SHARE, fake.SHARE],
+                          fake.SHARE, [], [], share_server=None)
+
+    def test_create_replica_raise_unsupported_policy(self):
+
+        mock_dm_session = mock.Mock()
+        self.mock_object(data_motion, "DataMotionSession",
+                         mock.Mock(return_value=mock_dm_session))
+        self.mock_object(mock_dm_session, 'get_backend_info_for_share',
+                         mock.Mock(return_value=(fake.SHARE_NAME,
+                                                 fake.VSERVER1,
+                                                 fake.BACKEND_NAME)))
+        self.mock_object(self.library, '_is_flexgroup_share',
+                         mock.Mock(return_value=False))
+        self.mock_object(self.library, '_is_flexgroup_pool',
+                         mock.Mock(return_value=False))
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('MirrorAndVault', False)))
+
+        mock_src_client = mock.Mock()
+
         self.mock_object(data_motion, 'get_client_for_backend',
                          mock.Mock(return_value=mock_src_client))
 
@@ -4510,6 +4578,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             'relationship-status': 'idle',
             'source-vserver': fake.VSERVER2,
             'source-volume': 'fake_volume',
+            'policy-type': 'async',
             'last-transfer-end-timestamp': '%s' % float(time.time() - 10000)
         }
         vserver_client = mock.Mock()
@@ -4541,6 +4610,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             'relationship-status': 'transferring',
             'source-vserver': fake.VSERVER2,
             'source-volume': 'fake_volume',
+            'policy-type': 'async',
             'last-transfer-end-timestamp': '%s' % float(time.time() - 10000)
         }
         vserver_client = mock.Mock()
@@ -4615,6 +4685,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
     def test_update_replica_state_stale_snapmirror(self):
         fake_snapmirror = {
             'mirror-state': 'snapmirrored',
+            'source-vserver': 'fake_source_vserver',
+            'source-volume': 'fake_source_volume',
+            'policy-type': 'async',
             'schedule': self.library.configuration.netapp_snapmirror_schedule,
             'last-transfer-end-timestamp': '%s' % float(
                 timeutils.utcnow_ts() - 10000)
@@ -4645,6 +4718,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         fake_snapmirror = {
             'mirror-state': 'snapmirrored',
             'schedule': self.library.configuration.netapp_snapmirror_schedule,
+            'source-vserver': 'fake_source_vserver',
+            'source-volume': 'fake_source_volume',
+            'policy-type': 'async',
             'relationship-status': 'idle',
             'last-transfer-end-timestamp': '%s' % float(time.time())
         }
@@ -4663,6 +4739,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         mock_backend_config = fake.get_config_cmode()
         self.mock_object(data_motion, 'get_backend_configuration',
                          mock.Mock(return_value=mock_backend_config))
+        self.mock_object(self.mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('MirrorAllSnapshots', False)))
 
         result = self.library.update_replica_state(None, [fake.SHARE],
                                                    fake.SHARE, None, [],
@@ -4672,10 +4751,13 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
          .assert_not_called())
         self.assertEqual(constants.REPLICA_STATE_IN_SYNC, result)
 
-    def test_update_replica_state_replica_change_to_in_sycn(self):
+    def test_update_replica_state_replica_change_to_in_sync(self):
         fake_snapmirror = {
             'mirror-state': 'snapmirrored',
             'relationship-status': 'idle',
+            'source-vserver': 'fake_source_vserver',
+            'source-volume': 'fake_source_volume',
+            'policy-type': 'async',
             'last-transfer-end-timestamp': '%s' % float(time.time())
         }
         # fake SHARE has replica_state set to active already
@@ -4687,6 +4769,49 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         vserver_client = mock.Mock()
         self.mock_object(vserver_client, 'volume_exists',
                          mock.Mock(return_value=True))
+        self.mock_object(self.library,
+                         '_get_vserver',
+                         mock.Mock(return_value=(fake.VSERVER1,
+                                                 vserver_client)))
+        self.mock_dm_session.get_snapmirrors = mock.Mock(
+            return_value=[fake_snapmirror])
+        mock_config = mock.Mock()
+        mock_config.safe_get = mock.Mock(return_value=0)
+        self.mock_object(data_motion, 'get_backend_configuration',
+                         mock.Mock(return_value=mock_config))
+        self.mock_object(self.library,
+                         '_is_readable_replica',
+                         mock.Mock(return_value=False))
+
+        result = self.library.update_replica_state(
+            None, replica_list, out_of_sync_replica,
+            None, [], share_server=None)
+
+        # Expect a snapmirror cleanup as replica was in out of sync state
+        (self.mock_dm_session.cleanup_previous_snapmirror_relationships
+         .assert_called_once_with(out_of_sync_replica, replica_list))
+        self.assertEqual(constants.REPLICA_STATE_IN_SYNC, result)
+
+    def test_update_replica_state_sync_replica_change_to_in_sync(self):
+        fake_snapmirror = {
+            'mirror-state': 'in_sync',
+            'relationship-status': 'idle',
+            'source-vserver': 'fake_source_vserver',
+            'source-volume': 'fake_source_volume',
+            'policy-type': 'sync',
+            'last-transfer-end-timestamp': '%s' % float(time.time())
+        }
+        # fake SHARE has replica_state set to active already
+        active_replica = fake.SHARE
+        out_of_sync_replica = copy.deepcopy(fake.SHARE)
+        out_of_sync_replica['replica_state'] = (
+            constants.REPLICA_STATE_OUT_OF_SYNC)
+        replica_list = [out_of_sync_replica, active_replica]
+        vserver_client = mock.Mock()
+        self.mock_object(vserver_client, 'volume_exists',
+                         mock.Mock(return_value=True))
+        self.mock_object(vserver_client, 'get_desired_sync_snapmirror_state',
+                         mock.Mock(return_value='in_sync'))
         self.mock_object(self.library,
                          '_get_vserver',
                          mock.Mock(return_value=(fake.VSERVER1,
@@ -4729,6 +4854,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             'mirror-state': 'snapmirrored',
             'schedule': self.library.configuration.netapp_snapmirror_schedule,
             'relationship-status': 'idle',
+            'source-vserver': 'fake_source_vserver',
+            'source-volume': 'fake_source_volume',
+            'policy-type': 'async',
             'last-transfer-end-timestamp': '%s' % float(time.time())
         }
         fake_snapshot = copy.deepcopy(fake.SNAPSHOT)
@@ -4763,6 +4891,10 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         fake_snapmirror = {
             'mirror-state': 'snapmirrored',
             'relationship-status': 'idle',
+            'source-vserver': 'fake_source_vserver',
+            'source-volume': 'fake_source_volume',
+            'policy': 'MirrorAllSnapshots',
+            'policy-type': 'async',
             'last-transfer-end-timestamp': '%s' % float(time.time())
         }
         fake_snapshot = copy.deepcopy(fake.SNAPSHOT)
@@ -4812,6 +4944,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          mock.Mock(return_value={}))
 
         mock_dm_session = mock.Mock()
+        mock_dm_session.change_snapmirror_source.return_value = False
         self.mock_object(data_motion, "DataMotionSession",
                          mock.Mock(return_value=mock_dm_session))
         self.mock_object(mock_dm_session, 'get_vserver_from_share',
@@ -4987,6 +5120,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library, '_create_export',
                          mock.Mock(return_value='fake_export_location'))
         mock_dm_session = mock.Mock()
+        mock_dm_session.change_snapmirror_source.return_value = False
         self.mock_object(data_motion, "DataMotionSession",
                          mock.Mock(return_value=mock_dm_session))
         self.mock_object(mock_dm_session, 'get_vserver_from_share',
@@ -5319,6 +5453,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(share_types, 'get_extra_specs_from_share')
         self.mock_object(self.library, '_get_provisioning_options',
                          mock.Mock(return_value={}))
+        self.mock_dm_session.change_snapmirror_source.return_value = False
         replicas = self.library.promote_replica(
             None, [self.fake_replica, self.fake_replica_2],
             self.fake_replica_2, fake_access_rules, share_server=None)
@@ -5443,6 +5578,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         self.mock_object(self.library, '_handle_qos_on_replication_change')
 
         mock_dm_session = mock.Mock()
+        mock_dm_session.change_snapmirror_source.return_value = False
         mock_dm_session.wait_for_mount_replica.return_value = None
         self.mock_object(mock_dm_session, 'get_backend_info_for_share',
                          mock.Mock(return_value=(fake.SHARE_NAME,
@@ -5478,6 +5614,56 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             protocol_helper.update_access.assert_called_once_with(
                 self.fake_replica, fake.SHARE_NAME, [fake.SHARE_ACCESS],
                 replica=True)
+
+    @ddt.data(True, False)
+    def test_safe_change_replica_source_sync_policy(self, is_dr):
+        fake_replica_3 = copy.deepcopy(self.fake_replica_2)
+        fake_replica_3['id'] = fake.SHARE_ID3
+        fake_replica_3['replica_state'] = constants.REPLICA_STATE_OUT_OF_SYNC
+        protocol_helper = mock.Mock()
+        self.mock_object(self.library,
+                         '_get_helper',
+                         mock.Mock(return_value=protocol_helper))
+        self.mock_object(self.library, '_create_export',
+                         mock.Mock(return_value='fake_export_location'))
+        self.mock_object(self.library, '_unmount_orig_active_replica')
+        self.mock_object(self.library, '_handle_qos_on_replication_change')
+
+        mock_dm_session = mock.Mock()
+        mock_dm_session.change_snapmirror_source.return_value = True
+        mock_dm_session.wait_for_mount_replica.return_value = None
+        self.mock_object(mock_dm_session, 'get_backend_info_for_share',
+                         mock.Mock(return_value=(fake.SHARE_NAME,
+                                                 fake.VSERVER1,
+                                                 fake.BACKEND_NAME)))
+        mock_client = mock.Mock()
+        self.mock_object(data_motion, "get_client_for_backend",
+                         mock.Mock(return_value=mock_client))
+        mock_backend_config = fake.get_config_cmode()
+        mock_backend_config.netapp_mount_replica_timeout = 30
+        self.mock_object(data_motion, 'get_backend_configuration',
+                         mock.Mock(return_value=mock_backend_config))
+        self.mock_object(self.library, '_get_api_client_for_backend',
+                         mock.Mock(return_value=mock_client))
+
+        replica = self.library._safe_change_replica_source(
+            mock_dm_session, self.fake_replica, self.fake_replica_2,
+            fake_replica_3, [self.fake_replica, self.fake_replica_2,
+                             fake_replica_3], is_dr, [fake.SHARE_ACCESS]
+        )
+
+        self.assertEqual(constants.REPLICA_STATE_IN_SYNC,
+                         replica['replica_state'])
+        self.assertEqual(constants.STATUS_AVAILABLE,
+                         replica['status'])
+        if is_dr:
+            self.assertEqual([], replica['export_locations'])
+            mock_dm_session.wait_for_mount_replica.assert_not_called()
+        else:
+            self.assertEqual('fake_export_location',
+                             replica['export_locations'])
+            mock_dm_session.wait_for_mount_replica.assert_called_once_with(
+                mock_client, fake.SHARE_NAME, timeout=30)
 
     @ddt.data({'fail_create_export': False, 'fail_mount': True},
               {'fail_create_export': True, 'fail_mount': False})

--- a/releasenotes/notes/netapp-add-support-for-sync-replication-cd1b50f409816647.yaml
+++ b/releasenotes/notes/netapp-add-support-for-sync-replication-cd1b50f409816647.yaml
@@ -1,0 +1,32 @@
+---
+features:
+  - |
+    NetApp ONTAP driver now allows creating a share replica with
+    Sync/StrictSync policy by setting "replication_policy" metadata during
+    replica creation. If "replication_policy" is not set, the default async
+    policy (MirrorAllSnapshots) is used.
+
+    "replication_policy" accepted values:
+
+    - Sync - for Sync replication policy.
+    - StrictSync - for StrictSync replication policy.
+    - MirrorAllSnapshots - for Async replication policy.
+
+    The following operation are supported by Sync/StrictSync replication:
+    - Create replica
+    - Promote replica
+    - Delete replica
+    - Resync replica
+
+    Note:
+
+    - Synchronous replica creation is supported only for shares without
+      existing snapshots at the time of replica creation. If a share contains
+      snapshots, replica creation will fail.
+    - "MirrorAllSnapshots" policy can mirror all snapshots, including those
+      created before replica setup, to the secondary site.
+    - Changing replication policy of an existing share replica is
+      not supported.
+    - Metadata set on destination share replica will be used during unplanned
+      failover and failback operations.
+    - Sync/StrictSync replication policies are supported only for FlexVols.


### PR DESCRIPTION
Modified share replica create, resync, promote and delete code to support Synchronous SnapMirror replication.

Change-Id: Iec67d8935a448b5c2adc43061e106c48452b7727