### PR TITLE
Metadata for Share Replica Resource

### DIFF
--- a/api-ref/source/parameters.yaml
+++ b/api-ref/source/parameters.yaml
@@ -704,6 +704,16 @@ share_network_id_query:
   in: query
   required: false
   type: string
+share_replica_metadata_query:
+  description: |
+    Filters the list of share replicas by metadata. The value must be a string
+    representation of a key-value mapping that can be parsed by the API.
+    For example: ``{"env": "prod"}`` or ``{"key": "value"}``. If the
+    value cannot be parsed, the API responds with ``400 Bad Request``.
+  in: query
+  required: false
+  type: string
+  min_version: 2.89
 share_server_id_query:
   description: |
     The UUID of the share server.

--- a/api-ref/source/samples/share-replica-set-metadata-request.json
+++ b/api-ref/source/samples/share-replica-set-metadata-request.json
@@ -1,0 +1,9 @@
+{
+    "metadata": {
+        "aim": "changed_doc",
+        "project": "my_app",
+        "key1": "value1",
+        "new_metadata_key": "new_information",
+        "key": "value"
+    }
+}

--- a/api-ref/source/samples/share-replica-set-metadata-response.json
+++ b/api-ref/source/samples/share-replica-set-metadata-response.json
@@ -1,0 +1,9 @@
+{
+    "metadata": {
+        "aim": "changed_doc",
+        "project": "my_app",
+        "key1": "value1",
+        "new_metadata_key": "new_information",
+        "key": "value"
+    }
+}

--- a/api-ref/source/samples/share-replica-show-metadata-item-response.json
+++ b/api-ref/source/samples/share-replica-show-metadata-item-response.json
@@ -1,0 +1,5 @@
+{
+    "meta": {
+        "project": "my_app"
+    }
+}

--- a/api-ref/source/samples/share-replica-show-metadata-response.json
+++ b/api-ref/source/samples/share-replica-show-metadata-response.json
@@ -1,0 +1,6 @@
+{
+    "metadata": {
+        "project": "my_app",
+        "aim": "doc"
+    }
+}

--- a/api-ref/source/samples/share-replica-update-metadata-request.json
+++ b/api-ref/source/samples/share-replica-update-metadata-request.json
@@ -1,0 +1,7 @@
+{
+    "metadata": {
+        "aim": "changed_doc",
+        "project": "my_app",
+        "new_metadata_key": "new_information"
+    }
+}

--- a/api-ref/source/samples/share-replica-update-metadata-response.json
+++ b/api-ref/source/samples/share-replica-update-metadata-response.json
@@ -1,0 +1,7 @@
+{
+    "metadata": {
+        "aim": "changed_doc",
+        "project": "my_app",
+        "new_metadata_key": "new_information"
+    }
+}

--- a/api-ref/source/samples/share-replica-update-null-metadata-request.json
+++ b/api-ref/source/samples/share-replica-update-null-metadata-request.json
@@ -1,0 +1,3 @@
+{
+    "metadata": null
+}

--- a/api-ref/source/samples/share-replica-update-null-metadata-response.json
+++ b/api-ref/source/samples/share-replica-update-null-metadata-response.json
@@ -1,0 +1,3 @@
+{
+    "metadata": null
+}

--- a/api-ref/source/share-replica-metadata.inc
+++ b/api-ref/source/share-replica-metadata.inc
@@ -1,0 +1,263 @@
+.. -*- rst -*-
+
+Share Replica Metadata (Since API v2.89)
+========================================
+
+Shows, sets, updates, and unsets share replica metadata.
+
+
+Show all share replica metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rest_method::  GET /v2/share-replicas/{share_replica_id}/metadata
+
+.. versionadded:: 2.89
+
+Shows all the metadata for a share replica, as key and value pairs.
+
+Response codes
+--------------
+
+.. rest_status_code:: success status.yaml
+
+   - 200
+
+.. rest_status_code:: error status.yaml
+
+   - 400
+   - 401
+   - 403
+   - 404
+
+Request
+-------
+
+.. rest_parameters:: parameters.yaml
+
+   - project_id: project_id_path
+   - share_replica_id: share_replica_id_path
+
+Response parameters
+-------------------
+
+.. rest_parameters:: parameters.yaml
+
+   - metadata: metadata
+
+Response example
+----------------
+
+.. literalinclude:: samples/share-replica-show-metadata-response.json
+   :language: javascript
+
+
+Show share replica metadata item
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rest_method::  GET /v2/share-replicas/{share_replica_id}/metadata/{key}
+
+.. versionadded:: 2.89
+
+Retrieves a specific metadata item from a share replica's metadata by its key. If
+the specified key does not represent a valid metadata item, the API will
+respond with HTTP 404.
+
+Response codes
+--------------
+
+.. rest_status_code:: success status.yaml
+
+   - 200
+
+.. rest_status_code:: error status.yaml
+
+   - 400
+   - 401
+   - 403
+   - 404
+
+Request
+-------
+
+.. rest_parameters:: parameters.yaml
+
+   - project_id: project_id_path
+   - share_replica_id: share_replica_id_path
+   - key: metadata_key_path
+
+Response parameters
+-------------------
+
+.. rest_parameters:: parameters.yaml
+
+   - metadata: metadata_item
+
+Response example
+----------------
+
+.. literalinclude:: samples/share-replica-show-metadata-item-response.json
+   :language: javascript
+
+
+Set share replica metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rest_method::  POST /v2/share-replicas/{share_replica_id}/metadata
+
+.. versionadded:: 2.89
+
+Allows adding new metadata items as key-value pairs. This API will not delete
+pre-existing metadata items. If the request object contains metadata items
+that already exist, they will be updated with new values as specified in the
+request object.
+
+Response codes
+--------------
+
+.. rest_status_code:: success status.yaml
+
+   - 200
+
+.. rest_status_code:: error status.yaml
+
+   - 400
+   - 401
+   - 403
+   - 404
+   - 409
+
+Request
+-------
+
+.. rest_parameters:: parameters.yaml
+
+   - project_id: project_id_path
+   - share_replica_id: share_replica_id_path
+   - metadata: metadata_request
+
+
+Request example
+---------------
+
+.. literalinclude:: samples/share-replica-set-metadata-request.json
+   :language: javascript
+
+Response parameters
+-------------------
+
+.. rest_parameters:: parameters.yaml
+
+   - metadata: metadata
+
+Response example
+----------------
+
+.. literalinclude:: samples/share-replica-set-metadata-response.json
+   :language: javascript
+
+
+Update share replica metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rest_method::  PUT /v2/share-replicas/{share_replica_id}/metadata
+
+.. versionadded:: 2.89
+
+Replaces the metadata for a given share replica with the metadata (specified as
+key-value pairs) in the request object. All pre-existing metadata of the
+share replica will be deleted and replaced with the new metadata supplied.
+
+Response codes
+--------------
+
+.. rest_status_code:: success status.yaml
+
+   - 200
+
+.. rest_status_code:: error status.yaml
+
+   - 400
+   - 401
+   - 403
+   - 404
+
+Request
+-------
+
+.. rest_parameters:: parameters.yaml
+
+   - project_id: project_id_path
+   - share_replica_id: share_replica_id_path
+   - metadata: metadata_request
+
+
+Request example
+---------------
+
+.. literalinclude:: samples/share-replica-update-metadata-request.json
+   :language: javascript
+
+Response parameters
+-------------------
+
+.. rest_parameters:: parameters.yaml
+
+   - metadata: metadata
+
+Response example
+----------------
+
+.. literalinclude:: samples/share-replica-update-metadata-response.json
+   :language: javascript
+
+
+To delete all existing metadata items on a given share replica,
+the request object needs to specify an empty metadata object:
+
+Request example
+---------------
+
+.. literalinclude:: samples/share-replica-update-null-metadata-request.json
+   :language: javascript
+
+Response example
+----------------
+
+.. literalinclude:: samples/share-replica-update-null-metadata-response.json
+   :language: javascript
+
+
+Delete share replica metadata item
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rest_method::  DELETE /v2/share-replicas/{share_replica_id}/metadata/{key}
+
+.. versionadded:: 2.89
+
+Deletes a single metadata item on a share replica, identified by its key. If
+the specified key does not represent a valid metadata item, the API will
+respond with HTTP 404.
+
+Response codes
+--------------
+
+.. rest_status_code:: success status.yaml
+
+   - 200
+
+.. rest_status_code:: error status.yaml
+
+   - 400
+   - 401
+   - 403
+   - 404
+
+Request
+-------
+
+.. rest_parameters:: parameters.yaml
+
+   - project_id: project_id_path
+   - share_replica_id: share_replica_id_path
+   - key: metadata_key_path
+```

--- a/manila/api/openstack/api_version_request.py
+++ b/manila/api/openstack/api_version_request.py
@@ -210,6 +210,7 @@ REST_API_VERSION_HISTORY = """
              to driver.
     * 2.89 - Added encryption key reference option to share create API.
     * 2.89 - Added QoS type and specs APIs.
+    * 2.89 - Added Share Replica Metadata to Metadata API
 """
 
 # The minimum and maximum versions of the API supported

--- a/manila/api/openstack/rest_api_version_history.rst
+++ b/manila/api/openstack/rest_api_version_history.rst
@@ -483,3 +483,5 @@ user documentation.
 ----
   Added ``encryption_key_ref`` option to share create API.
   Added qos_type and specs APIs.
+  Added Metadata API methods (GET, PUT, POST, DELETE)
+  to Share Replicas.

--- a/manila/api/v2/metadata.py
+++ b/manila/api/v2/metadata.py
@@ -29,6 +29,7 @@ class MetadataController(object):
         "share_snapshot": "share_snapshot_get",
         "share_network_subnet": "share_network_subnet_get",
         "share_export_location": "export_location_get_by_uuid",
+        "share_replica": "share_replica_get",
     }
 
     resource_metadata_get = {
@@ -36,6 +37,7 @@ class MetadataController(object):
         "share_snapshot": "share_snapshot_metadata_get",
         "share_network_subnet": "share_network_subnet_metadata_get",
         "share_export_location": "export_location_metadata_get",
+        "share_replica": "share_replica_metadata_get",
     }
 
     resource_metadata_get_item = {
@@ -43,6 +45,7 @@ class MetadataController(object):
         "share_snapshot": "share_snapshot_metadata_get_item",
         "share_network_subnet": "share_network_subnet_metadata_get_item",
         "share_export_location": "export_location_metadata_get_item",
+        "share_replica": "share_replica_metadata_get_item",
     }
 
     resource_metadata_update = {
@@ -50,6 +53,7 @@ class MetadataController(object):
         "share_snapshot": "share_snapshot_metadata_update",
         "share_network_subnet": "share_network_subnet_metadata_update",
         "share_export_location": "export_location_metadata_update",
+        "share_replica": "share_replica_metadata_update",
     }
 
     resource_metadata_update_item = {
@@ -57,6 +61,7 @@ class MetadataController(object):
         "share_snapshot": "share_snapshot_metadata_update_item",
         "share_network_subnet": "share_network_subnet_metadata_update_item",
         "share_export_location": "export_location_metadata_update_item",
+        "share_replica": "share_replica_metadata_update_item",
     }
 
     resource_metadata_delete = {
@@ -64,12 +69,14 @@ class MetadataController(object):
         "share_snapshot": "share_snapshot_metadata_delete",
         "share_network_subnet": "share_network_subnet_metadata_delete",
         "share_export_location": "export_location_metadata_delete",
+        "share_replica": "share_replica_metadata_delete",
     }
 
     resource_policy_get = {
         'share': 'get',
         'share_snapshot': 'get_snapshot',
         'share_network_subnet': 'show',
+        'share_replica': 'show',
     }
 
     def __init__(self):
@@ -79,7 +86,7 @@ class MetadataController(object):
     def _get_resource(self, context, resource_id,
                       for_modification=False, parent_id=None):
         if self.resource_name in ['share', 'share_network_subnet',
-                                  'share_export_location']:
+                                  'share_export_location', 'share_replica']:
             # some resources don't have a "project_id" field (like
             # share_export_location or share_network_subnet),
             # and sometimes we want to retrieve "public" resources
@@ -93,6 +100,8 @@ class MetadataController(object):
                 db, self.resource_get[self.resource_name])
             if parent_id is not None:
                 kwargs["parent_id"] = parent_id
+            if self.resource_name == 'share_replica':
+                kwargs['with_share_data'] = True
             res = get_res_method(context, resource_id, **kwargs)
 
             if self.resource_name not in ["share_export_location"]:

--- a/manila/api/v2/router.py
+++ b/manila/api/v2/router.py
@@ -637,6 +637,45 @@ class APIRouter(manila.api.openstack.APIRouter):
                         collection={'detail': 'GET'},
                         member={'action': 'POST'})
 
+        for path_prefix in ['/{project_id}', '']:
+            # project_id is optional
+            mapper.connect("share_replica_metadata",
+                           "%s/share-replicas/{resource_id}/metadata"
+                           % path_prefix,
+                           controller=self.resources["share-replicas"],
+                           action="create_metadata",
+                           conditions={"method": ["POST"]})
+            mapper.connect("share_replica_metadata",
+                           "%s/share-replicas/{resource_id}/metadata"
+                           % path_prefix,
+                           controller=self.resources["share-replicas"],
+                           action="update_all_metadata",
+                           conditions={"method": ["PUT"]})
+            mapper.connect("share_replica_metadata",
+                           "%s/share-replicas/{resource_id}/metadata/{key}"
+                           % path_prefix,
+                           controller=self.resources["share-replicas"],
+                           action="update_metadata_item",
+                           conditions={"method": ["POST"]})
+            mapper.connect("share_replica_metadata",
+                           "%s/share-replicas/{resource_id}/metadata"
+                           % path_prefix,
+                           controller=self.resources["share-replicas"],
+                           action="index_metadata",
+                           conditions={"method": ["GET"]})
+            mapper.connect("share_replica_metadata",
+                           "%s/share-replicas/{resource_id}/metadata/{key}"
+                           % path_prefix,
+                           controller=self.resources["share-replicas"],
+                           action="show_metadata",
+                           conditions={"method": ["GET"]})
+            mapper.connect("share_replica_metadata",
+                           "%s/share-replicas/{resource_id}/metadata/{key}"
+                           % path_prefix,
+                           controller=self.resources["share-replicas"],
+                           action="delete_metadata",
+                           conditions={"method": ["DELETE"]})
+
         self.resources['share_transfers'] = (
             share_transfer.create_resource())
         mapper.resource("share-transfer", "share-transfers",

--- a/manila/api/v2/share_replicas.py
+++ b/manila/api/v2/share_replicas.py
@@ -26,6 +26,7 @@ from webob import exc
 from manila.api import common
 from manila.api.openstack import api_version_request as api_version
 from manila.api.openstack import wsgi
+from manila.api.v2 import metadata
 from manila.api.views import share_replicas as replication_view
 from manila.common import constants
 from manila import db
@@ -40,7 +41,8 @@ PRE_GRADUATION_VERSION = '2.55'
 GRADUATION_VERSION = '2.56'
 
 
-class ShareReplicationController(wsgi.Controller, wsgi.AdminActionsMixin):
+class ShareReplicationController(wsgi.Controller, metadata.MetadataController,
+                                 wsgi.AdminActionsMixin):
     """The Share Replication API controller for the OpenStack API."""
 
     resource_name = 'share_replica'
@@ -83,6 +85,37 @@ class ShareReplicationController(wsgi.Controller, wsgi.AdminActionsMixin):
     def detail(self, req):  # pylint: disable=function-redefined  # noqa F811
         """Returns a detailed list of replicas."""
         return self._get_replicas(req, is_detail=True)
+
+    @wsgi.Controller.api_version("2.89")
+    @wsgi.Controller.authorize("get_metadata")
+    def index_metadata(self, req, resource_id):
+        """Returns the list of metadata for a given share replica."""
+        return self._index_metadata(req, resource_id)
+
+    @wsgi.Controller.api_version("2.89")
+    @wsgi.Controller.authorize("update_metadata")
+    def create_metadata(self, req, resource_id, body):
+        return self._create_metadata(req, resource_id, body)
+
+    @wsgi.Controller.api_version("2.89")
+    @wsgi.Controller.authorize("update_metadata")
+    def update_all_metadata(self, req, resource_id, body):
+        return self._update_all_metadata(req, resource_id, body)
+
+    @wsgi.Controller.api_version("2.89")
+    @wsgi.Controller.authorize("update_metadata")
+    def update_metadata_item(self, req, resource_id, body, key):
+        return self._update_metadata_item(req, resource_id, body, key)
+
+    @wsgi.Controller.api_version("2.89")
+    @wsgi.Controller.authorize("get_metadata")
+    def show_metadata(self, req, resource_id, key):
+        return self._show_metadata(req, resource_id, key)
+
+    @wsgi.Controller.api_version("2.89")
+    @wsgi.Controller.authorize("delete_metadata")
+    def delete_metadata(self, req, resource_id, key):
+        return self._delete_metadata(req, resource_id, key)
 
     @wsgi.Controller.authorize('get_all')
     def _get_replicas(self, req, is_detail=False):
@@ -148,13 +181,20 @@ class ShareReplicationController(wsgi.Controller, wsgi.AdminActionsMixin):
     def create(self, req, body):  # pylint: disable=function-redefined  # noqa F811
         return self._create(req, body)
 
-    @wsgi.Controller.api_version("2.67") # noqa
+    @wsgi.Controller.api_version("2.67", "2.88") # noqa
     @wsgi.response(202)
     def create(self, req, body): # pylint: disable=function-redefined  # noqa F811
         return self._create(req, body, allow_scheduler_hints=True)
 
+    @wsgi.Controller.api_version("2.89")  # noqa
+    @wsgi.response(202)
+    def create(self, req, body):  # pylint: disable=function-redefined  # noqa F811
+        return self._create(req, body, allow_scheduler_hints=True,
+                            allow_metadata=True)
+
     @wsgi.Controller.authorize('create')
-    def _create(self, req, body, allow_scheduler_hints=False):
+    def _create(self, req, body, allow_scheduler_hints=False,
+                allow_metadata=False):
         """Add a replica to an existing share."""
         context = req.environ['manila.context']
         self._validate_body(body)
@@ -235,10 +275,16 @@ class ShareReplicationController(wsgi.Controller, wsgi.AdminActionsMixin):
             raise exc.HTTPBadRequest(explanation=msg % share_network_id)
 
         try:
+            metadata_dict = {}
+            if allow_metadata:
+                metadata_dict = body.get('share_replica').get(
+                    'metadata', {})
+
             new_replica = self.share_api.create_share_replica(
                 context, share_ref, availability_zone=availability_zone,
                 share_network_id=share_network_id,
-                scheduler_hints=scheduler_hints, replica_id=share_replica_id)
+                scheduler_hints=scheduler_hints, replica_id=share_replica_id,
+                metadata=metadata_dict)
         except exception.AvailabilityZoneNotFound as e:
             raise exc.HTTPBadRequest(explanation=e.msg)
         except exception.ReplicationException as e:

--- a/manila/api/views/share_replicas.py
+++ b/manila/api/views/share_replicas.py
@@ -25,6 +25,7 @@ class ReplicationViewBuilder(common.ViewBuilder):
 
     _detail_version_modifiers = [
         "add_cast_rules_to_readonly_field",
+        "add_metadata",
     ]
 
     def summary_list(self, request, replicas):
@@ -89,3 +90,9 @@ class ReplicationViewBuilder(common.ViewBuilder):
         if context.is_admin:
             replica_dict['cast_rules_to_readonly'] = replica.get(
                 'cast_rules_to_readonly', False)
+
+    @common.ViewBuilder.versioned_method("2.89")
+    def add_metadata(self, context, replica_dict, replica):
+        metadata = replica.get('share_instance_metadata', [])
+        metadata_dict = {meta['key']: meta['value'] for meta in metadata}
+        replica_dict['metadata'] = metadata_dict

--- a/manila/db/api.py
+++ b/manila/db/api.py
@@ -1694,6 +1694,39 @@ def share_replica_delete(context, replica_id, need_to_update_usages=True):
         context, replica_id, need_to_update_usages=need_to_update_usages)
 
 
+def share_replica_metadata_get(context, share_replica_id, **kwargs):
+    """Get all metadata for a share replica."""
+    return IMPL.share_replica_metadata_get(context,
+                                           share_replica_id,
+                                           **kwargs)
+
+
+def share_replica_metadata_get_item(context, share_replica_id, key):
+    """Get metadata item for a share replica."""
+    return IMPL.share_replica_metadata_get_item(context,
+                                                share_replica_id, key)
+
+
+def share_replica_metadata_delete(context, share_replica_id, key):
+    """Delete the given metadata item."""
+    IMPL.share_replica_metadata_delete(context, share_replica_id, key)
+
+
+def share_replica_metadata_update(context, share_replica_id,
+                                  metadata, delete):
+    """Update metadata if it exists, otherwise create it."""
+    return IMPL.share_replica_metadata_update(context, share_replica_id,
+                                              metadata, delete)
+
+
+def share_replica_metadata_update_item(context, share_replica_id,
+                                       metadata):
+    """Update metadata item if it exists, otherwise create it."""
+    return IMPL.share_replica_metadata_update_item(context,
+                                                   share_replica_id,
+                                                   metadata)
+
+
 def purge_deleted_records(context, age_in_days):
     """Purge deleted rows older than given age from all tables
 

--- a/manila/db/migrations/alembic/versions/004e506e922e_add_share_instance_metadata.py
+++ b/manila/db/migrations/alembic/versions/004e506e922e_add_share_instance_metadata.py
@@ -1,0 +1,66 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""add_share_instance_metadata
+
+Revision ID: 004e506e922e
+Revises: eead2cb81845
+Create Date: 2025-12-15 03:17:40.285486
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '004e506e922e'
+down_revision = 'eead2cb81845'
+
+from alembic import op
+from oslo_log import log
+import sqlalchemy as sql
+
+LOG = log.getLogger(__name__)
+
+share_instance_metadata_table_name = 'share_instance_metadata'
+
+
+def upgrade():
+    context = op.get_context()
+    mysql_dl = context.bind.dialect.name == 'mysql'
+    datetime_type = (sql.dialects.mysql.DATETIME(fsp=6)
+                     if mysql_dl else sql.DateTime)
+    try:
+        op.create_table(
+            share_instance_metadata_table_name,
+            sql.Column('deleted', sql.String(36), default='False'),
+            sql.Column('created_at', datetime_type),
+            sql.Column('updated_at', datetime_type),
+            sql.Column('deleted_at', datetime_type),
+            sql.Column('share_instance_id', sql.String(36),
+                       sql.ForeignKey('share_instances.id'), nullable=False),
+            sql.Column('key', sql.String(255), nullable=False),
+            sql.Column('value', sql.String(1023), nullable=False),
+            sql.Column('id', sql.Integer, primary_key=True, nullable=False),
+            mysql_engine='InnoDB',
+            mysql_charset='utf8'
+        )
+    except Exception:
+        LOG.error("Table |%s| not created!",
+                  share_instance_metadata_table_name)
+        raise
+
+
+def downgrade():
+    try:
+        op.drop_table(share_instance_metadata_table_name)
+    except Exception:
+        LOG.error("Table |%s| not dropped!",
+                  share_instance_metadata_table_name)
+        raise

--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -1654,7 +1654,8 @@ def _share_instance_create(context, share_id, values):
     if not values.get('id'):
         values['id'] = uuidutils.generate_uuid()
     values.update({'share_id': share_id})
-
+    values['share_instance_metadata'] = _metadata_refs(
+        values.pop('metadata', {}), models.ShareInstanceMetadata)
     share_instance_ref = models.ShareInstance()
     share_instance_ref.update(values)
     share_instance_ref.save(session=context.session)
@@ -1758,6 +1759,124 @@ def _share_instance_status_update(context, share_instance_ids, values):
     return result
 
 
+###################################
+# Share Replica Metadata functions
+###################################
+
+
+@require_context
+@require_share_instance_exists
+@context_manager.reader
+def share_replica_metadata_get(context, share_replica_id):
+    return _share_replica_metadata_get(context, share_replica_id)
+
+
+@require_context
+@require_share_instance_exists
+@context_manager.writer
+def share_replica_metadata_delete(context, share_replica_id, key):
+    meta_ref = _share_replica_metadata_get_item(
+        context, share_replica_id, key)
+    meta_ref.soft_delete(session=context.session)
+
+
+@require_context
+@require_share_instance_exists
+@context_manager.writer
+def share_replica_metadata_update(context, share_replica_id,
+                                  metadata, delete):
+    return _share_replica_metadata_update(context, share_replica_id,
+                                          metadata, delete)
+
+
+@context_manager.writer
+def share_replica_metadata_update_item(context, share_replica_id, item):
+    return _share_replica_metadata_update(context, share_replica_id,
+                                          item, delete=False)
+
+
+@context_manager.reader
+def share_replica_metadata_get_item(context, share_replica_id, key):
+
+    row = _share_replica_metadata_get_item(context, share_replica_id, key)
+    result = {}
+    result[row['key']] = row['value']
+
+    return result
+
+
+def _share_replica_metadata_get_query(context, share_replica_id):
+    return model_query(
+        context, models.ShareInstanceMetadata, read_deleted="no",
+    ).filter_by(
+        share_instance_id=share_replica_id,
+    )
+
+
+def _share_replica_metadata_get(context, share_replica_id):
+    rows = _share_replica_metadata_get_query(
+        context, share_replica_id,
+    ).all()
+
+    result = {}
+    for row in rows:
+        result[row['key']] = row['value']
+    return result
+
+
+def _share_replica_metadata_get_item(context, share_replica_id, key):
+    result = _share_replica_metadata_get_query(
+        context, share_replica_id).filter_by(
+            key=key).first()
+    if not result:
+        raise exception.MetadataItemNotFound
+    return result
+
+
+@oslo_db_api.wrap_db_retry(max_retries=5, retry_on_deadlock=True)
+def _share_replica_metadata_update(context, share_replica_id,
+                                   metadata, delete):
+    delete = strutils.bool_from_string(delete)
+
+    if delete:
+        original_metadata = _share_replica_metadata_get(
+            context, share_replica_id)
+        for meta_key, meta_value in original_metadata.items():
+            if meta_key not in metadata:
+                meta_ref = _share_replica_metadata_get_item(
+                    context, share_replica_id, meta_key,
+                )
+                meta_ref.soft_delete(session=context.session)
+
+    # Now update all existing items with new values, or create new meta
+    # objects
+    meta_ref = None
+
+    if metadata is None:
+        metadata = {}
+
+        # Fetch all existing metadata once
+    existing_meta = {
+        m.key: m for m in _share_replica_metadata_get_query(
+            context, share_replica_id
+        ).all()
+    }
+
+    for meta_key, meta_value in metadata.items():
+        meta_ref = existing_meta.get(meta_key)
+        item = {"value": meta_value}
+        if not meta_ref:
+            meta_ref = models.ShareInstanceMetadata()
+            item.update({"key": meta_key,
+                         "share_instance_id": share_replica_id})
+        meta_ref.update(item)
+        meta_ref.save(session=context.session)
+
+    return metadata
+
+#################################
+
+
 @require_context
 @context_manager.reader
 def share_instance_get(context, share_instance_id, with_share_data=False):
@@ -1777,6 +1896,7 @@ def _share_instance_get(context, share_instance_id, with_share_data=False):
             models.ShareInstance.export_locations
         ).joinedload(models.ShareInstanceExportLocations._el_metadata_bare),
         orm.joinedload(models.ShareInstance.share_type),
+        orm.joinedload(models.ShareInstance.share_instance_metadata),
     ).first()
     if result is None:
         raise exception.NotFound()
@@ -1798,6 +1918,7 @@ def _share_instance_get_all(context, filters=None):
         context, models.ShareInstance, read_deleted="no",
     ).options(
         orm.joinedload(models.ShareInstance.export_locations),
+        orm.joinedload(models.ShareInstance.share_instance_metadata),
     )
 
     filters = filters or {}
@@ -1853,7 +1974,19 @@ def _share_instance_get_all(context, filters=None):
     if encryption_key_ref:
         query = query.filter(
             models.ShareInstance.encryption_key_ref == encryption_key_ref)
-
+    if 'metadata' in filters:
+        for k, v in filters['metadata'].items():
+            alias = orm.aliased(models.ShareInstanceMetadata)
+            query = query.join(
+                alias,
+                and_(
+                    alias.share_instance_id == models.ShareInstance.id,
+                    alias.key == k,
+                    alias.value == v,
+                    alias.deleted == 'False'
+                )
+            )
+        filters.pop('metadata')
     # Returns list of share instances that satisfy filters.
     query = query.all()
     return query
@@ -1941,6 +2074,10 @@ def _share_instance_delete(context, instance_id,
         context.session.query(models.ShareMetadata).filter_by(
             share_id=share['id'],
         ).soft_delete()
+        context.session.query(models.ShareInstanceMetadata).filter_by(
+            share_instance_id=instance_id,
+        ).soft_delete()
+
         share.soft_delete(session=context.session)
 
     if need_to_update_usages:
@@ -2169,6 +2306,10 @@ def _share_replica_get_with_filters(context, share_id=None, replica_id=None,
         query = query.options(
             orm.joinedload(models.ShareInstance.share_server),
         )
+
+    query = query.options(
+        orm.joinedload(models.ShareInstance.share_instance_metadata)
+    )
 
     return query
 

--- a/manila/policies/share_replica.py
+++ b/manila/policies/share_replica.py
@@ -76,7 +76,24 @@ deprecated_replica_reset_status = policy.DeprecatedRule(
     deprecated_reason=DEPRECATED_REASON,
     deprecated_since=versionutils.deprecated.WALLABY
 )
-
+deprecated_update_replica_metadata = policy.DeprecatedRule(
+    name=BASE_POLICY_NAME % 'update_metadata',
+    check_str=base.RULE_DEFAULT,
+    deprecated_reason=DEPRECATED_REASON,
+    deprecated_since='2026.1/Gazpacho'
+)
+deprecated_delete_replica_metadata = policy.DeprecatedRule(
+    name=BASE_POLICY_NAME % 'delete_metadata',
+    check_str=base.RULE_DEFAULT,
+    deprecated_reason=DEPRECATED_REASON,
+    deprecated_since='2026.1/Gazpacho'
+)
+deprecated_get_replica_metadata = policy.DeprecatedRule(
+    name=BASE_POLICY_NAME % 'get_metadata',
+    check_str=base.RULE_DEFAULT,
+    deprecated_reason=DEPRECATED_REASON,
+    deprecated_since='2026.1/Gazpacho'
+)
 
 share_replica_policies = [
     policy.DocumentedRuleDefault(
@@ -203,6 +220,57 @@ share_replica_policies = [
             }
         ],
         deprecated_rule=deprecated_replica_reset_status
+    ),
+    policy.DocumentedRuleDefault(
+        name=BASE_POLICY_NAME % 'update_metadata',
+        check_str=base.ADMIN_OR_PROJECT_MEMBER,
+        scope_types=['system', 'project'],
+        description="Update replica metadata.",
+        operations=[
+            {
+                'method': 'PUT',
+                'path': '/share-replicas/{share_replica_id}/metadata',
+            },
+            {
+                'method': 'POST',
+                'path': '/share-replicas/{share_replica_id}/metadata/{key}',
+            },
+            {
+                'method': 'POST',
+                'path': '/share-replicas/{share_replica_id}/metadata',
+            },
+        ],
+        deprecated_rule=deprecated_update_replica_metadata
+    ),
+    policy.DocumentedRuleDefault(
+        name=BASE_POLICY_NAME % 'delete_metadata',
+        check_str=base.ADMIN_OR_PROJECT_MEMBER,
+        scope_types=['system', 'project'],
+        description="Delete replica metadata.",
+        operations=[
+            {
+                'method': 'DELETE',
+                'path': '/share-replicas/{share_replica_id}/metadata/{key}',
+            }
+        ],
+        deprecated_rule=deprecated_delete_replica_metadata
+    ),
+    policy.DocumentedRuleDefault(
+        name=BASE_POLICY_NAME % 'get_metadata',
+        check_str=base.ADMIN_OR_PROJECT_MEMBER,
+        scope_types=['system', 'project'],
+        description="Get replica metadata.",
+        operations=[
+            {
+                'method': 'GET',
+                'path': '/share-replicas/{share_replica_id}/metadata',
+            },
+            {
+                'method': 'GET',
+                'path': '/share-replicas/{share_replica_id}/metadata/{key}',
+            }
+        ],
+        deprecated_rule=deprecated_get_replica_metadata
     ),
 ]
 

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -785,7 +785,8 @@ class API(base.Base):
             availability_zones=None, snapshot_host=None,
             az_request_multiple_subnet_support_map=None,
             mount_point_name=None, share_instance_id=None,
-            encryption_key_ref=None, qos_type_id=None):
+            encryption_key_ref=None, qos_type_id=None,
+            share_instance_metadata=None):
 
         availability_zone_id = None
         if availability_zone:
@@ -809,6 +810,7 @@ class API(base.Base):
                 'mount_point_name': mount_point_name,
                 'encryption_key_ref': encryption_key_ref,
                 'qos_type_id': qos_type_id,
+                'metadata': share_instance_metadata,
             }
         )
 
@@ -870,7 +872,9 @@ class API(base.Base):
 
     def create_share_replica(self, context, share, availability_zone=None,
                              share_network_id=None, scheduler_hints=None,
-                             replica_id=None):
+                             replica_id=None, metadata=None):
+        if metadata:
+            api_common.check_metadata_properties(metadata)
 
         parent_share_network_id = share.get('share_network_id')
         if (parent_share_network_id and share_network_id and
@@ -1010,7 +1014,8 @@ class API(base.Base):
                     availability_zones=type_azs,
                     az_request_multiple_subnet_support_map=(
                         az_request_multiple_subnet_support_map),
-                    qos_type_id=qos_type_id)
+                    qos_type_id=qos_type_id,
+                    share_instance_metadata=metadata)
             )
             QUOTAS.commit(
                 context, reservations, project_id=share['project_id'],

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2842,6 +2842,10 @@ class ShareManager(manager.SchedulerDependentManager):
                         for r in replica_list]
         share_replica = self._get_share_instance_dict(context, share_replica)
 
+        share_replica['metadata'] = (
+            self.db.share_replica_metadata_get(
+                context, share_replica_id) or {})
+
         try:
             replica_ref = self.driver.create_replica(
                 context, replica_list, share_replica,
@@ -3065,7 +3069,15 @@ class ShareManager(manager.SchedulerDependentManager):
 
         replica_list = [self._get_share_instance_dict(context, r)
                         for r in replica_list]
+
+        for r in replica_list:
+            r['metadata'] = self.db.share_replica_metadata_get(
+                context, r["id"]) or {}
+
         share_replica = self._get_share_instance_dict(context, share_replica)
+        share_replica['metadata'] = (
+            self.db.share_replica_metadata_get(
+                context, share_replica_id) or {})
 
         try:
             updated_replica_list = (
@@ -3294,6 +3306,8 @@ class ShareManager(manager.SchedulerDependentManager):
                         for r in replica_list]
 
         share_replica = self._get_share_instance_dict(context, share_replica)
+        share_replica['metadata'] = (self.db.share_replica_metadata_get(
+            context, share_replica_id) or {})
 
         try:
             metadata = self.db.share_metadata_get(

--- a/manila/tests/api/v2/test_share_replicas.py
+++ b/manila/tests/api/v2/test_share_replicas.py
@@ -72,6 +72,8 @@ class ShareReplicasApiTest(test.TestCase):
             'security_service_update_support': True,
             'status': 'active'
         }
+        self.share = db_utils.create_share()
+        self.share_replica_id = self.share.instance.id
 
     def _get_context(self, role):
         return getattr(self, '%s_context' % role)
@@ -123,6 +125,10 @@ class ShareReplicasApiTest(test.TestCase):
                 api_version.APIVersionRequest(CAST_RULES_READONLY_VERSION)
                 and admin):
             expected_replica['cast_rules_to_readonly'] = False
+
+        if (api_version.APIVersionRequest(microversion) >=
+                api_version.APIVersionRequest("2.89")):
+            expected_replica['metadata'] = {}
 
         return replica, expected_replica
 
@@ -486,7 +492,7 @@ class ShareReplicasApiTest(test.TestCase):
             share_network)
 
     @ddt.data((True, PRE_GRADUATION_VERSION), (False, GRADUATION_VERSION),
-              (False, "2.72"))
+              (False, "2.72"), (False, "2.89"))
     @ddt.unpack
     def test_create(self, is_admin, microversion):
         fake_replica, expected_replica = self._get_fake_replica(
@@ -503,6 +509,9 @@ class ShareReplicasApiTest(test.TestCase):
             share_network = {'id': 'FAKE_NETID'}
         else:
             share_network = db_utils.create_share_network()
+
+        if self.is_microversion_ge(microversion, '2.89'):
+            body["share_replica"].update({"metadata": {"foo": "bar"}})
 
         self.mock_object(share_replicas.db, 'share_get',
                          mock.Mock(return_value=fake_replica))
@@ -975,3 +984,82 @@ class ShareReplicasApiTest(test.TestCase):
         else:
             self.assertEqual(202, resp.status_int)
             self.assertTrue(share_api_call.called)
+
+    def test_index_metadata(self):
+        req = fakes.HTTPRequest.blank('/share-replicas/', version="2.89")
+        mock_index = self.mock_object(
+            self.controller, '_index_metadata',
+            mock.Mock(return_value='fake_metadata'))
+
+        result = self.controller.index_metadata(req, self.share_replica_id)
+
+        self.assertEqual('fake_metadata', result)
+        mock_index.assert_called_once_with(req, self.share_replica_id)
+
+    def test_create_metadata(self):
+        req = fakes.HTTPRequest.blank('/share-replicas/', version="2.89")
+        mock_index = self.mock_object(
+            self.controller, '_create_metadata',
+            mock.Mock(return_value={'metadata': 'fake_metadata'}))
+
+        body = 'fake_metadata_body'
+        result = self.controller.create_metadata(req, self.share_replica_id,
+                                                 body)
+
+        self.assertEqual('fake_metadata', result['metadata'])
+        mock_index.assert_called_once_with(req, self.share_replica_id, body)
+
+    def test_update_all_metadata(self):
+        req = fakes.HTTPRequest.blank('/share-replicas/', version="2.89")
+
+        mock_index = self.mock_object(
+            self.controller, '_update_all_metadata',
+            mock.Mock(return_value={'metadata': 'fake_metadata'}))
+
+        body = 'fake_metadata_body'
+        result = self.controller.update_all_metadata(
+            req, self.share_replica_id, body)
+
+        self.assertEqual('fake_metadata', result['metadata'])
+        mock_index.assert_called_once_with(req, self.share_replica_id, body)
+
+    def test_update_metadata_item(self):
+        req = fakes.HTTPRequest.blank('/share-replicas/', version="2.89")
+        mock_index = self.mock_object(
+            self.controller, '_update_metadata_item',
+            mock.Mock(return_value={'metadata': 'fake_metadata'}))
+
+        body = 'fake_metadata_body'
+        key = 'fake_key'
+        result = self.controller.update_metadata_item(
+            req, self.share_replica_id, body, key)
+
+        self.assertEqual('fake_metadata', result['metadata'])
+        mock_index.assert_called_once_with(req, self.share_replica_id,
+                                           body, key)
+
+    def test_show_metadata(self):
+        req = fakes.HTTPRequest.blank('/share-replicas/', version="2.89")
+        mock_index = self.mock_object(
+            self.controller, '_show_metadata',
+            mock.Mock(return_value='fake_metadata'))
+
+        key = 'fake_key'
+        result = self.controller.show_metadata(
+            req, self.share_replica_id, key)
+
+        self.assertEqual('fake_metadata', result)
+        mock_index.assert_called_once_with(req, self.share_replica_id, key)
+
+    def test_delete_metadata(self):
+        req = fakes.HTTPRequest.blank('/share-replicas/', version="2.89")
+        mock_index = self.mock_object(
+            self.controller, '_delete_metadata',
+            mock.Mock(return_value='fake_metadata'))
+
+        key = 'fake_key'
+        result = self.controller.delete_metadata(
+            req, self.share_replica_id, key)
+
+        self.assertEqual('fake_metadata', result)
+        mock_index.assert_called_once_with(req, self.share_replica_id, key)

--- a/manila/tests/db/migrations/alembic/migrations_data_checks.py
+++ b/manila/tests/db/migrations/alembic/migrations_data_checks.py
@@ -3451,3 +3451,86 @@ class ServiceDisabledReason(BaseMigrationChecks):
         service_table = utils.load_table('services', conn)
         for s in conn.execute(service_table.select()):
             self.test_case.assertFalse(hasattr(s, 'disabled_reason'))
+
+
+@map_to_migration('004e506e922e')
+class AddShareReplicaMetadata(BaseMigrationChecks):
+    share_instance_id = uuidutils.generate_uuid()
+    new_table_name = 'share_instance_metadata'
+
+    def setup_upgrade_data(self, engine):
+        # Setup Availability Zone
+        availability_zone_table = utils.load_table('availability_zones',
+                                                   engine)
+        engine.execute(availability_zone_table.insert().values(
+            {'id': 'fake', 'name': 'fake',
+             'created_at': datetime.datetime.utcnow(),
+             'updated_at': datetime.datetime.utcnow()}
+        ))
+        # Setup Share
+        share_data = {
+            'id': uuidutils.generate_uuid(),
+            'share_proto': "NFS",
+            'size': 1,
+            'snapshot_id': None,
+            'user_id': 'fake',
+            'project_id': 'fake'
+        }
+        share_table = utils.load_table('shares', engine)
+        engine.execute(share_table.insert().values(share_data))
+        # Setup Share Instance
+        share_instance_data = {
+            'id': self.share_instance_id,
+            'deleted': 'False',
+            'host': 'fake',
+            'share_id': share_data['id'],
+            'status': 'available',
+            'access_rules_status': 'active',
+            'cast_rules_to_readonly': False,
+        }
+        share_instance_table = utils.load_table('share_instances', engine)
+        engine.execute(share_instance_table.insert().values(
+            share_instance_data))
+        # Setup Share Replica
+        share_replica_data = {
+            'id': uuidutils.generate_uuid(),
+            'status': 'available',
+            'host': 'fake',
+            'share_id': share_data['id'],
+            'replica_state': 'in_sync',
+            'availability_zone_id': 'fake',
+            'cast_rules_to_readonly': True
+        }
+        engine.execute(share_instance_table.insert().values(
+            share_replica_data))
+
+    def check_upgrade(self, engine, data):
+        data = {
+            'id': 1,
+            'key': 't' * 255,
+            'value': 'v' * 1023,
+            'share_instance_id': self.share_instance_id,
+            'deleted': 'False',
+        }
+
+        new_table = utils.load_table(self.new_table_name, engine)
+        engine.execute(new_table.insert().values(data))
+
+        item = engine.execute(
+            new_table.select().where(new_table.c.id ==
+                                     data['id'])).mappings().first()
+        self.test_case.assertTrue(hasattr(item, 'id'))
+        self.test_case.assertEqual(data['id'], item['id'])
+        self.test_case.assertTrue(hasattr(item, 'key'))
+        self.test_case.assertEqual(data['key'], item['key'])
+        self.test_case.assertTrue(hasattr(item, 'value'))
+        self.test_case.assertEqual(data['value'], item['value'])
+        self.test_case.assertTrue(hasattr(item, 'share_instance_id'))
+        self.test_case.assertEqual(self.share_instance_id,
+                                   item['share_instance_id'])
+        self.test_case.assertTrue(hasattr(item, 'deleted'))
+        self.test_case.assertEqual('False', item['deleted'])
+
+    def check_downgrade(self, engine):
+        self.test_case.assertRaises(sa_exc.NoSuchTableError, utils.load_table,
+                                    self.new_table_name, engine)

--- a/manila/tests/db/sqlalchemy/test_api.py
+++ b/manila/tests/db/sqlalchemy/test_api.py
@@ -1319,6 +1319,68 @@ class ShareDatabaseAPITestCase(test.TestCase):
             should_be, db_api.share_metadata_get(
                 self.ctxt, share_id=share_1['id']))
 
+    def test_share_instance_metadata_get(self):
+        metadata = {'a': 'b', 'c': 'd'}
+
+        share = db_utils.create_share(size=1)
+        replica = db_utils.create_share_replica(
+            share_id=share['id'])
+        db_api.share_replica_metadata_update(
+            self.ctxt, share_instance_id=replica['id'],
+            metadata=metadata, delete=False)
+        self.assertEqual(
+            metadata, db_api.share_replica_metadata_get(
+                self.ctxt, share_instance_id=replica['id']))
+
+    def test_share_replica_metadata_get_item(self):
+        metadata = {'a': 'b', 'c': 'd'}
+        key = 'a'
+        shouldbe = {'a': 'b'}
+        share = db_utils.create_share(size=1)
+        replica = db_utils.create_share_replica(
+            share_id=share['id'])
+        db_api.share_replica_metadata_update(
+            self.ctxt, share_instance_id=replica['id'],
+            metadata=metadata, delete=False)
+        self.assertEqual(
+            shouldbe, db_api.share_replica_metadata_get_item(
+                self.ctxt, share_replica_id=replica['id'],
+                key=key))
+
+    def test_share_replica_metadata_update(self):
+        metadata1 = {'a': '1', 'c': '2'}
+        metadata2 = {'a': '3', 'd': '5'}
+        should_be = {'a': '3', 'c': '2', 'd': '5'}
+        share = db_utils.create_share(size=1)
+        replica = db_utils.create_share_replica(
+            share_id=share['id'])
+        db_api.share_replica_metadata_update(
+            self.ctxt, share_instance_id=replica['id'],
+            metadata=metadata1, delete=False)
+        db_api.share_replica_metadata_update(
+            self.ctxt, share_instance_id=replica['id'],
+            metadata=metadata2, delete=False)
+        self.assertEqual(
+            should_be, db_api.share_replica_metadata_get(
+                self.ctxt, share_instance_id=replica['id']))
+
+    def test_share_replica_metadata_delete(self):
+        key = 'a'
+        metadata = {'a': '1', 'c': '2'}
+        should_be = {'c': '2'}
+        share = db_utils.create_share(size=1)
+        replica = db_utils.create_share_replica(
+            share_id=share['id'])
+        db_api.share_replica_metadata_update(
+            self.ctxt, share_instance_id=replica['id'],
+            metadata=metadata, delete=False)
+        db_api.share_replica_metadata_delete(
+            self.ctxt, share_instance_id=replica['id'],
+            key=key)
+        self.assertEqual(
+            should_be, db_api.share_replica_metadata_get(
+                self.ctxt, share_instance_id=replica['id']))
+
 
 @ddt.ddt
 class ShareGroupDatabaseAPITestCase(test.TestCase):

--- a/manila/tests/share/test_api.py
+++ b/manila/tests/share/test_api.py
@@ -1283,6 +1283,7 @@ class ShareAPITestCase(test.TestCase):
                 'mount_point_name': None,
                 'encryption_key_ref': None,
                 'qos_type_id': None,
+                'metadata': None
             }
         )
         db_api.share_type_get.assert_called_once_with(
@@ -1320,6 +1321,7 @@ class ShareAPITestCase(test.TestCase):
                 'mount_point_name': 'fake_mp',
                 'encryption_key_ref': None,
                 'qos_type_id': None,
+                'metadata': None
             }
         )
 
@@ -4690,7 +4692,8 @@ class ShareAPITestCase(test.TestCase):
              availability_zones=expected_azs,
              az_request_multiple_subnet_support_map={},
              cast_rules_to_readonly=cast_rules_to_readonly,
-             qos_type_id=None))
+             qos_type_id=None,
+             share_instance_metadata=None))
         db_api.share_replica_update.assert_called_once()
         mock_snapshot_get_all_call.assert_called_once()
         mock_sched_rpcapi_call.assert_called_once()
@@ -4832,7 +4835,8 @@ class ShareAPITestCase(test.TestCase):
              availability_zones=expected_azs,
              az_request_multiple_subnet_support_map=az_id,
              cast_rules_to_readonly=cast_rules_to_readonly,
-             qos_type_id=None))
+             qos_type_id=None,
+             share_instance_metadata=None))
 
     def test_delete_last_active_replica(self):
         fake_replica = fakes.fake_replica(
@@ -5072,7 +5076,8 @@ class ShareAPITestCase(test.TestCase):
                                  availability_zones=expected_azs,
                                  az_request_multiple_subnet_support_map={},
                                  cast_rules_to_readonly=False,
-                                 qos_type_id=None))
+                                 qos_type_id=None,
+                                 share_instance_metadata=None))
 
     def test_migration_complete(self):
 

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -1450,8 +1450,11 @@ class ShareManagerTestCase(test.TestCase):
         fake_access_rules = [{'id': '1'}, {'id': '2'}, {'id': '3'}]
         replica = fake_replica()
         replica_2 = fake_replica(id='fake2')
+        replica_metadata = {'fake_key': 'fake_value'}
         self.mock_object(db, 'share_replica_get',
                          mock.Mock(return_value=replica))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
         self.mock_object(db, 'share_instance_access_copy',
                          mock.Mock(return_value=fake_access_rules))
         self.mock_object(db, 'share_replicas_get_available_active_replica',
@@ -1511,6 +1514,9 @@ class ShareManagerTestCase(test.TestCase):
                                access_rules_status=constants.STATUS_ACTIVE)
         replica_2 = fake_replica(id='fake2')
         fake_access_rules = [{'id': '1'}, {'id': '2'}]
+        replica_metadata = {'fake_key': 'fake_value'}
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
         self.mock_object(db, 'share_replicas_get_available_active_replica',
                          mock.Mock(return_value=replica_2))
         self.mock_object(db, 'share_replicas_get_all_by_share',
@@ -1566,12 +1572,15 @@ class ShareManagerTestCase(test.TestCase):
             replica_state=constants.REPLICA_STATE_OUT_OF_SYNC,
             access_rules_status=None)
         replica_2 = fake_replica(id='fake2')
+        replica_metadata = {'fake_key': 'fake_value'}
         self.mock_object(db, 'share_replicas_get_all_by_share',
                          mock.Mock(return_value=[replica, replica_2]))
         self.share_manager.availability_zone = 'fake_az'
         fake_access_rules = [{'id': '1'}, {'id': '2'}, {'id': '3'}]
         self.mock_object(db, 'share_replica_get',
                          mock.Mock(return_value=replica))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
         self.mock_object(db, 'share_instance_access_copy',
                          mock.Mock(return_value=fake_access_rules))
         self.mock_object(db, 'share_replicas_get_available_active_replica',
@@ -1633,6 +1642,7 @@ class ShareManagerTestCase(test.TestCase):
             replica_state=constants.REPLICA_STATE_IN_SYNC,
             access_rules_status='active')
         replica_2 = fake_replica(id='fake2')
+        replica_metadata = {'fake_key': 'fake_value'}
         snapshots = ([fakes.fake_snapshot(create_instance=True)]
                      if has_snapshots else [])
         snapshot_instances = [
@@ -1642,6 +1652,8 @@ class ShareManagerTestCase(test.TestCase):
         fake_access_rules = [{'id': '1'}, {'id': '2'}, {'id': '3'}]
         self.mock_object(db, 'share_replica_get',
                          mock.Mock(return_value=replica))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
         self.mock_object(db, 'share_instance_access_copy',
                          mock.Mock(return_value=fake_access_rules))
         self.mock_object(db, 'share_replicas_get_available_active_replica',
@@ -1905,11 +1917,14 @@ class ShareManagerTestCase(test.TestCase):
     def test_promote_share_replica_no_active_replica(self):
         replica = fake_replica()
         replica_list = [replica]
+        replica_metadata = {'fake_key': 'fake_value'}
         self.mock_object(db, 'share_replica_get',
                          mock.Mock(return_value=replica))
         self.mock_object(self.share_manager, '_get_share_server')
         self.mock_object(db, 'share_replicas_get_available_active_replica',
                          mock.Mock(return_value=replica_list))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
         mock_info_log = self.mock_object(manager.LOG, 'info')
         mock_driver_call = self.mock_object(self.share_manager.driver,
                                             'promote_replica')
@@ -1930,6 +1945,7 @@ class ShareManagerTestCase(test.TestCase):
             id='current_active_replica',
             replica_state=constants.REPLICA_STATE_ACTIVE)
         replica_list = [replica, active_replica]
+        replica_metadata = {'fake_key': 'fake_value'}
         self.mock_object(db, 'share_access_get_all_for_share',
                          mock.Mock(return_value=[]))
         self.mock_object(db, 'share_replica_get',
@@ -1937,6 +1953,8 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(self.share_manager, '_get_share_server')
         self.mock_object(db, 'share_replicas_get_all_by_share',
                          mock.Mock(return_value=replica_list))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
         self.mock_object(self.share_manager.driver, 'promote_replica',
                          mock.Mock(side_effect=exception.ManilaException))
         mock_info_log = self.mock_object(manager.LOG, 'info')
@@ -1971,6 +1989,7 @@ class ShareManagerTestCase(test.TestCase):
         active_replica = fake_replica(
             id='current_active_replica',
             replica_state=constants.REPLICA_STATE_ACTIVE)
+        replica_metadata = {'fake_key': 'fake_value'}
         snapshots_instances = [
             fakes.fake_snapshot(create_instance=True,
                                 share_id=replica['share_id'],
@@ -1991,6 +2010,8 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(
             db, 'share_snapshot_instance_get_all_with_filters',
             mock.Mock(return_value=snapshots_instances))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
         self.mock_object(
             self.share_manager.driver, 'promote_replica',
             mock.Mock(return_value=retval))
@@ -2032,6 +2053,7 @@ class ShareManagerTestCase(test.TestCase):
             replica, active_replica, fake_replica(id=3),
             fake_replica(id='one_more_replica'),
         ]
+        replica_metadata = {'fake_key': 'fake_value'}
         updated_replica_list = [
             {
                 'id': replica['id'],
@@ -2065,6 +2087,8 @@ class ShareManagerTestCase(test.TestCase):
                          mock.Mock(return_value=replica_list))
         mock_snap_instance_update = self.mock_object(
             db, 'share_snapshot_instance_update')
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
         self.mock_object(
             self.share_manager.driver, 'promote_replica',
             mock.Mock(return_value=updated_replica_list))
@@ -2144,6 +2168,8 @@ class ShareManagerTestCase(test.TestCase):
                          mock.Mock(side_effect=exception.ManilaException))
         mock_db_update_call = self.mock_object(
             self.share_manager.db, 'share_replica_update')
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=None))
 
         self.share_manager._share_replica_update(
             self.context, replica['id'], share_id=replica['share_id'])
@@ -2203,6 +2229,8 @@ class ShareManagerTestCase(test.TestCase):
         self.share_manager.host = replica['host']
         self.mock_object(self.share_manager.driver, 'update_replica_state',
                          mock.Mock(side_effect=exception.ManilaException))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=None))
         mock_db_update_call = self.mock_object(
             self.share_manager.db, 'share_replica_update')
 
@@ -2285,6 +2313,8 @@ class ShareManagerTestCase(test.TestCase):
         self.mock_object(db, 'share_server_get',
                          mock.Mock(return_value=fakes.fake_share_server_get()))
         self.mock_object(db, 'share_metadata_get', mock.Mock(return_value=[]))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=None))
         mock_db_update_calls = []
         self.mock_object(self.share_manager.db, 'share_replica_get',
                          mock.Mock(return_value=replica))

--- a/releasenotes/notes/add_share_replica_metadata-519898d0cf144afa.yaml
+++ b/releasenotes/notes/add_share_replica_metadata-519898d0cf144afa.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds share replica metadata capabilities inlcuding, create,
+    update all, update single, show, and delete metadata.


### PR DESCRIPTION
This change adds metadata controller for share replica resource. Bumps microversion to 2.89.

Partially-implements: bp metadata-for-share-resources
Change-Id: I456b65a420522c39d7d6c8d1655728113077e81f

(cherry picked from commit a4f509e3261e9ef7ab73892c8d59758eaa840542)