### PR TITLE
NetApp: remove DigiCert Global Root CA from default certificate list

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -62,7 +62,6 @@ client_cmode_opts = [
             "/etc/ssl/certs/SAP_Global_Sub_CA_02.pem",
             "/etc/ssl/certs/SAP_Global_Sub_CA_04.pem",
             "/etc/ssl/certs/SAP_Global_Sub_CA_05.pem",
-            "/etc/ssl/certs/DigiCert_Global_Root_CA.pem",
             "/etc/ssl/certs/DigiCert_Global_Root_G2.pem",
             ],
         help="Path to the x509 certificate used for secure ldap "


### PR DESCRIPTION
it was removed from base image
https://launchpad.net/ubuntu/+source/ca-certificates/20260601~24.04.1
it is expired and distrusted
https://knowledge.digicert.com/general-information/digicert-root-and-intermediate-ca-certificate-updates-2023
Signed-off-by: Maurice Escher <maurice.escher@sap.com>

Change-Id: If259c279fb9d0b27188a1ba167e88bf0d2fbeee9
