### PR TITLE
NetApp: reject Sync replica fanout, make mount-wait state-aware

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -195,8 +195,20 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         while next_tag is not None:
             next_api_args = copy.deepcopy(api_args)
             next_api_args['tag'] = next_tag
-            next_result = self.send_request(api_name, next_api_args,
-                                            enable_tunneling=enable_tunneling)
+            try:
+                next_result = self.send_request(
+                    api_name, next_api_args,
+                    enable_tunneling=enable_tunneling)
+            except netapp_api.NaApiError as e:
+                # ONTAP iterator cursor loop (ONTAP bug): treat as end of
+                # iteration and return whatever was collected so far.
+                if (e.code == netapp_api.EAPIERROR and
+                        'Loop detected in next()' in e.message):
+                    LOG.warning('ONTAP iterator loop detected for API %s '
+                                '(tag=%s); returning partial results. '
+                                'Error: %s', api_name, next_tag, e)
+                    break
+                raise
 
             next_attributes_list = next_result.get_child_by_name(
                 'attributes-list') or netapp_api.NaElement('none')

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -1011,21 +1011,99 @@ class DataMotionSession(object):
             raise exception.NetAppException(message=msg)
 
     def wait_for_mount_replica(self, vserver_client, share_name, timeout=300):
-        """Mount a replica share that is waiting for snapmirror initialize."""
+        """Mount a replica share that is waiting for snapmirror initialize.
+
+        Polls the SnapMirror relationship state and only retries the mount
+        while the relationship is genuinely still initializing. Fails fast
+        on terminal SnapMirror errors instead of spinning the full timeout
+        on a doomed mount and surfacing a misleading "snapmirror initialize"
+        message.
+
+        Sync (Sync, StrictSync) and async (MirrorAllSnapshots / DP) have
+        different state machines, so each is checked accordingly:
+          - sync: ready when relationship-status == 'insync' and
+            mirror-state == 'snapmirrored'
+          - async DP: ready when relationship-status == 'idle' and
+            mirror-state == 'snapmirrored'
+          - either: still progressing while relationship-status is
+            'transferring' or mirror-state is 'uninitialized' with no
+            last-transfer-error
+        """
 
         interval = 10
         retries = (timeout // interval or 1)
 
+        sm_attrs = ['relationship-status', 'mirror-state', 'policy-type',
+                    'last-transfer-error']
+        sync_policy_types = (na_utils.ZAPI_SYNC_POLICY_TYPE_NAME,
+                             na_utils.ZAPI_STRICT_SYNC_POLICY_TYPE_NAME)
+
+        def _snapmirror_state_says_initializing():
+            """Inspect the SnapMirror relationship targeting this volume.
+
+            Returns (still_initializing, terminal_error_msg). If the state
+            can't be determined (no relationship found, ZAPI failure), both
+            are None and the caller falls back to the mount-error heuristic.
+            """
+            try:
+                snapmirrors = vserver_client.get_snapmirrors(
+                    dest_volume=share_name, desired_attributes=sm_attrs)
+            except netapp_api.NaApiError:
+                return None, None
+            if not snapmirrors:
+                return None, None
+            sm = snapmirrors[0]
+            policy_type = sm.get('policy-type')
+            mirror_state = sm.get('mirror-state')
+            rel_status = sm.get('relationship-status')
+            last_err = sm.get('last-transfer-error')
+
+            if policy_type in sync_policy_types:
+                if rel_status == 'insync' and mirror_state == 'snapmirrored':
+                    return False, None
+                if rel_status in (
+                    'preparing', 'transferring', 'finalizing') or (
+                        mirror_state == 'uninitialized' and not last_err):
+                    return True, None
+                return False, last_err or (
+                    'SnapMirror Sync relationship is in state '
+                    'mirror-state=%s, relationship-status=%s'
+                    % (mirror_state, rel_status))
+            # async DP
+            if rel_status == 'idle' and mirror_state == 'snapmirrored':
+                return False, None
+            if rel_status == 'transferring':
+                return True, None
+            if last_err:
+                return False, last_err
+            return None, None
+
         @utils.retry(exception.ShareBusyException, interval=interval,
                      retries=retries, backoff_rate=1)
         def try_mount_volume():
+            still_initializing, terminal_err = (
+                _snapmirror_state_says_initializing())
+            if terminal_err:
+                msg = _('Unable to mount share %(name)s: SnapMirror '
+                        'relationship is in a terminal state and will not '
+                        'become ready. Detail: %(err)s') % {
+                    'name': share_name, 'err': terminal_err}
+                LOG.error(msg)
+                raise exception.NetAppException(message=msg)
             try:
                 vserver_client.mount_volume(share_name)
             except netapp_api.NaApiError as e:
                 undergoing_snap_init = 'snapmirror initialize'
                 msg_args = {'name': share_name, 'err_msg': e.message}
-                if (e.code == netapp_api.EAPIERROR and
-                        undergoing_snap_init in e.message):
+                # Prefer the SnapMirror state signal over the error string;
+                # fall back to the historical substring match when state is
+                # unknown.
+                is_initializing = (
+                    still_initializing
+                    if still_initializing is not None
+                    else (e.code == netapp_api.EAPIERROR
+                          and undergoing_snap_init in e.message))
+                if is_initializing:
                     msg = _('The share %(name)s is undergoing a snapmirror '
                             'initialize. Will retry the operation.') % msg_args
                     LOG.warning(msg)

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -3545,6 +3545,50 @@ class NetAppCmodeFileStorageLibrary(object):
             )
             raise exception.NetAppException(msg % msg_args)
 
+        # SnapMirror Synchronous (Sync, StrictSync) does not support fanout:
+        # a source volume can only have a single Sync destination. Async DP
+        # supports fanout up to the platform limit. Reject the create here
+        # rather than letting ONTAP fail the SnapMirror create downstream,
+        # which leaves the destination volume in a DP-protected state and
+        # the wait_for_mount_replica retry loop spinning for 5 minutes on a
+        # doomed mount before surfacing a misleading "snapmirror initialize"
+        # error.
+        if is_sync_policy:
+            existing_sync_dests = [
+                sm for sm in src_client.get_snapmirror_destinations(
+                    source_vserver=src_vserver,
+                    source_volume=src_share_name,
+                    desired_attributes=['policy-type',
+                                        'destination-vserver',
+                                        'destination-volume'])
+                if sm.get('policy-type') in (
+                    na_utils.ZAPI_SYNC_POLICY_TYPE_NAME,
+                    na_utils.ZAPI_STRICT_SYNC_POLICY_TYPE_NAME)
+            ]
+            if existing_sync_dests:
+                msg = _('Could not create replica %(replica_id)s from share '
+                        '%(share_id)s in the destination host %(dest_host)s. '
+                        'SnapMirror Synchronous (%(policy)s) does not support '
+                        'fanout: the source volume already has a synchronous '
+                        'destination. Only one Sync replica per share is '
+                        'supported; use an asynchronous policy '
+                        '(MirrorAllSnapshots) for additional replicas.')
+                msg_args = {
+                    **base_msg_args,
+                    'dest_host': new_replica_host,
+                    'policy': replication_policy,
+                }
+                self.message_api.create(
+                    context,
+                    message_field.Action.CREATE,
+                    context.project_id,
+                    resource_type=message_field.Resource.SHARE_REPLICA,
+                    resource_id=new_replica_id,
+                    detail=(message_field.Detail
+                            .UNSUPPORTED_REPLICA_CREATE_CONFIG)
+                )
+                raise exception.NetAppException(msg % msg_args)
+
         # NOTE(felipe_rodrigues): The FlexGroup replication does not support
         # several replicas (fan-out) in some ONTAP versions, while FlexVol is
         # always supported.

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
@@ -1272,6 +1272,7 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
     def test_wait_for_mount_replica(self):
 
         mock_client = mock.Mock()
+        mock_client.get_snapmirrors.return_value = []
         self.mock_object(time, 'sleep')
         mock_warning_log = self.mock_object(data_motion.LOG, 'warning')
 
@@ -1284,6 +1285,7 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
     def test_wait_for_mount_replica_timeout(self):
 
         mock_client = mock.Mock()
+        mock_client.get_snapmirrors.return_value = []
         self.mock_object(time, 'sleep')
         mock_warning_log = self.mock_object(data_motion.LOG, 'warning')
         undergoing_snapmirror = (
@@ -1302,6 +1304,7 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
     def test_wait_for_mount_replica_api_not_found(self):
 
         mock_client = mock.Mock()
+        mock_client.get_snapmirrors.return_value = []
         self.mock_object(time, 'sleep')
         mock_warning_log = self.mock_object(data_motion.LOG, 'warning')
         na_api_error = netapp_api.NaApiError(code=netapp_api.EOBJECTNOTFOUND)
@@ -1313,6 +1316,78 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
 
         mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME)
         mock_warning_log.assert_not_called()
+
+    def test_wait_for_mount_replica_sync_in_sync_mounts_immediately(self):
+        """Sync relationship reaching in_sync should mount on first try."""
+
+        mock_client = mock.Mock()
+        self.mock_object(time, 'sleep')
+        mock_client.get_snapmirrors.return_value = [{
+            'policy-type': 'strict_sync_mirror',
+            'mirror-state': 'snapmirrored',
+            'relationship-status': 'insync',
+        }]
+
+        self.dm_session.wait_for_mount_replica(
+            mock_client, fake.SHARE_NAME)
+
+        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME)
+
+    def test_wait_for_mount_replica_sync_terminal_fails_fast(self):
+        """A broken/error Sync relationship must NOT spin retries."""
+
+        mock_client = mock.Mock()
+        self.mock_object(time, 'sleep')
+        mock_client.get_snapmirrors.return_value = [{
+            'policy-type': 'strict_sync_mirror',
+            'mirror-state': 'broken-off',
+            'relationship-status': 'broken-off',
+            'last-transfer-error': (
+                'is already the source of an existing SnapMirror '
+                'Synchronous relationship. Fanout is not supported '
+                'for SnapMirror Synchronous relationships.'),
+        }]
+
+        self.assertRaises(exception.NetAppException,
+                          self.dm_session.wait_for_mount_replica,
+                          mock_client, fake.SHARE_NAME, timeout=30)
+        # Mount must NOT have been attempted — we failed fast on the
+        # SnapMirror state instead of grinding through 3 retries.
+        mock_client.mount_volume.assert_not_called()
+
+    def test_wait_for_mount_replica_async_idle_mounts_immediately(self):
+        """Async DP relationship in idle/snapmirrored should mount."""
+
+        mock_client = mock.Mock()
+        self.mock_object(time, 'sleep')
+        mock_client.get_snapmirrors.return_value = [{
+            'policy-type': 'async_mirror',
+            'mirror-state': 'snapmirrored',
+            'relationship-status': 'idle',
+        }]
+
+        self.dm_session.wait_for_mount_replica(
+            mock_client, fake.SHARE_NAME)
+
+        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME)
+
+    def test_wait_for_mount_replica_falls_back_when_sm_state_unknown(self):
+        """Legacy substring match still works when SnapMirror lookup fails."""
+
+        mock_client = mock.Mock()
+        self.mock_object(time, 'sleep')
+        mock_client.get_snapmirrors.side_effect = netapp_api.NaApiError(
+            code=netapp_api.EAPIERROR)
+        undergoing_snapmirror = (
+            'The volume is undergoing a snapmirror initialize.')
+        mock_client.mount_volume.side_effect = netapp_api.NaApiError(
+            code=netapp_api.EAPIERROR, message=undergoing_snapmirror)
+
+        self.assertRaises(exception.NetAppException,
+                          self.dm_session.wait_for_mount_replica,
+                          mock_client, fake.SHARE_NAME, timeout=30)
+        # Fell back to the substring heuristic and retried.
+        self.assertEqual(3, mock_client.mount_volume.call_count)
 
     @ddt.data(mock.Mock(),
               mock.Mock(side_effect=netapp_api.NaApiError(

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -4534,6 +4534,121 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                           context, [fake.SHARE, fake.SHARE, fake.SHARE],
                           fake.SHARE, [], [], share_server=None)
 
+    def test_create_replica_raise_sync_fanout_blocked(self):
+        """A second Sync replica from the same source must be rejected."""
+
+        mock_dm_session = mock.Mock()
+        self.mock_object(data_motion, "DataMotionSession",
+                         mock.Mock(return_value=mock_dm_session))
+        self.mock_object(mock_dm_session, 'get_backend_info_for_share',
+                         mock.Mock(return_value=(fake.SHARE_NAME,
+                                                 fake.VSERVER1,
+                                                 fake.BACKEND_NAME)))
+        self.mock_object(self.library, '_is_flexgroup_share',
+                         mock.Mock(return_value=False))
+        self.mock_object(self.library, '_is_flexgroup_pool',
+                         mock.Mock(return_value=False))
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('StrictSync', True)))
+
+        # Source already has a Sync destination → fanout would fail in ONTAP.
+        mock_src_client = mock.Mock()
+        mock_src_client.get_snapmirror_destinations.return_value = [{
+            'policy-type': na_utils.ZAPI_STRICT_SYNC_POLICY_TYPE_NAME,
+            'destination-vserver': fake.VSERVER2,
+            'destination-volume': 'some_existing_dest',
+        }]
+        self.mock_object(data_motion, 'get_client_for_backend',
+                         mock.Mock(return_value=mock_src_client))
+
+        context = mock.Mock()
+        self.assertRaises(exception.NetAppException,
+                          self.library.create_replica,
+                          context, [fake.SHARE, fake.SHARE],
+                          fake.SHARE, [], [], share_server=None)
+        # SnapMirror create must NOT have been attempted.
+        mock_dm_session.create_snapmirror.assert_not_called()
+
+    def test_create_replica_sync_first_destination_allowed(self):
+        """A Sync replica is fine when the source has no Sync dest yet."""
+
+        self.mock_object(self.library, '_allocate_container')
+        mock_dm_session = mock.Mock()
+        self.mock_object(data_motion, "DataMotionSession",
+                         mock.Mock(return_value=mock_dm_session))
+        self.mock_object(mock_dm_session, 'get_vserver_from_share',
+                         mock.Mock(return_value=fake.VSERVER1))
+        self.mock_object(self.library, '_get_backend_share_name',
+                         mock.Mock(return_value=fake.SHARE_NAME))
+        self.mock_object(self.library, '_is_readable_replica',
+                         mock.Mock(return_value=False))
+        self.mock_object(mock_dm_session, 'get_backend_info_for_share',
+                         mock.Mock(return_value=(fake.SHARE_NAME,
+                                                 fake.VSERVER1,
+                                                 fake.BACKEND_NAME)))
+        self.mock_object(self.library, '_is_flexgroup_share',
+                         mock.Mock(return_value=False))
+        self.mock_object(self.library, '_is_flexgroup_pool',
+                         mock.Mock(return_value=False))
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('StrictSync', True)))
+
+        mock_src_client = mock.Mock()
+        mock_src_client.get_snapmirror_destinations.return_value = []
+        self.mock_object(data_motion, 'get_client_for_backend',
+                         mock.Mock(return_value=mock_src_client))
+
+        self.library.create_replica(
+            None, [fake.SHARE], fake.SHARE, [], [], share_server=None)
+
+        mock_dm_session.create_snapmirror.assert_called_once()
+
+    def test_create_replica_async_fanout_not_blocked_by_sync_guard(self):
+        """Async (MirrorAllSnapshots) must not query for Sync destinations."""
+
+        self.mock_object(self.library, '_allocate_container')
+        mock_dm_session = mock.Mock()
+        self.mock_object(data_motion, "DataMotionSession",
+                         mock.Mock(return_value=mock_dm_session))
+        self.mock_object(mock_dm_session, 'get_vserver_from_share',
+                         mock.Mock(return_value=fake.VSERVER1))
+        self.mock_object(self.library, '_get_backend_share_name',
+                         mock.Mock(return_value=fake.SHARE_NAME))
+        self.mock_object(self.library, '_is_readable_replica',
+                         mock.Mock(return_value=False))
+        self.mock_object(mock_dm_session, 'get_backend_info_for_share',
+                         mock.Mock(return_value=(fake.SHARE_NAME,
+                                                 fake.VSERVER1,
+                                                 fake.BACKEND_NAME)))
+        self.mock_object(self.library, '_is_flexgroup_share',
+                         mock.Mock(return_value=False))
+        self.mock_object(self.library, '_is_flexgroup_pool',
+                         mock.Mock(return_value=False))
+        self.mock_object(mock_dm_session,
+                         'get_policy_from_share_replica_metadata',
+                         mock.Mock(return_value=('MirrorAllSnapshots',
+                                                 False)))
+
+        mock_src_client = mock.Mock()
+        # Even with existing async destinations, async fanout is allowed.
+        mock_src_client.get_snapmirror_destinations.return_value = [{
+            'policy-type': na_utils.ASYNC_POLICY_TYPE_NAME,
+            'destination-vserver': fake.VSERVER2,
+            'destination-volume': 'some_existing_dest',
+        }]
+        self.mock_object(data_motion, 'get_client_for_backend',
+                         mock.Mock(return_value=mock_src_client))
+
+        self.library.create_replica(
+            None, [fake.SHARE, fake.SHARE], fake.SHARE, [], [],
+            share_server=None)
+
+        mock_dm_session.create_snapmirror.assert_called_once()
+        # The Sync-fanout guard must not even be consulted for async.
+        mock_src_client.get_snapmirror_destinations.assert_not_called()
+
     def test_create_replica_raise_unsupported_policy(self):
 
         mock_dm_session = mock.Mock()

--- a/releasenotes/notes/netapp-sync-replica-fanout-guard-b8e1c5d0a4f73c92.yaml
+++ b/releasenotes/notes/netapp-sync-replica-fanout-guard-b8e1c5d0a4f73c92.yaml
@@ -1,0 +1,22 @@
+---
+fixes:
+  - |
+    NetApp ONTAP driver: creating a second share replica with a SnapMirror
+    Synchronous policy (``Sync`` or ``StrictSync``) from the same source
+    share now fails fast at replica-create time with a clear error message.
+    SnapMirror Synchronous does not support fanout — a source volume can
+    only have a single Sync destination — and previously the driver let
+    ONTAP reject the SnapMirror create downstream, leaving the destination
+    volume in a DP-protected state and the mount-wait retry loop spinning
+    for the full ``netapp_mount_replica_timeout`` (1 hour by default)
+    before surfacing a misleading ``snapmirror initialize`` error. Use
+    an asynchronous policy (``MirrorAllSnapshots``) for additional
+    replicas.
+  - |
+    NetApp ONTAP driver: ``wait_for_mount_replica`` now consults the
+    SnapMirror relationship state (``mirror-state`` /
+    ``relationship-status``) instead of pattern-matching on the mount
+    error message. A relationship in a terminal/broken state fails the
+    mount immediately with the underlying SnapMirror error rather than
+    burning the full retry budget. The legacy substring heuristic remains
+    as a fallback when the SnapMirror state cannot be queried.


### PR DESCRIPTION
SnapMirror Synchronous (Sync, StrictSync) does not support fanout: a source volume can only have a single Sync destination. The driver's create_replica path always creates SnapMirrors from the active replica in a star topology, so creating a second Sync replica from the same share triggers an ONTAP error ("is already the source of an existing SnapMirror Synchronous relationship. Fanout is not supported for SnapMirror Synchronous relationships."), leaves the destination volume in a DP-protected state, and the wait_for_mount_replica retry loop spins for the configured netapp_mount_replica_timeout (default 1 hour) before surfacing a misleading "snapmirror initialize" error.

This change:

* Adds a guard in lib_base.create_replica that, for Sync policies, queries the source for existing SnapMirror destinations and rejects the create if any of them already use a sync policy-type. The user gets an actionable error at create time instead of a confusing mount timeout much later. Async DP fanout is unaffected.
* Reworks data_motion.wait_for_mount_replica to consult the SnapMirror relationship state (mirror-state / relationship-status / policy-type / last-transfer-error) before each retry. A relationship in a terminal/broken state fails the mount immediately with the underlying SnapMirror error rather than burning the full retry budget. Sync relationships are considered ready at mirror-state=in_sync; async DP at relationship-status=idle and mirror-state=snapmirrored. The legacy substring heuristic on the mount error message remains as a fallback when the relationship state can't be queried (no relationship visible, ZAPI failure).

Closes the symptom seen on a StrictSync replica created from a share that already had a Sync destination, where the only signal in the logs was the misleading "snapmirror initialize" retry banner.

Assisted-By: Claude Code (claude-opus-4-8)
AI generated: source modifications in lib_base.py and data_motion.py, the matching unit tests, and the release note. Human reviewed the diagnosis, approved the topology decision (cap Sync at one replica rather than cascading), and reviewed the patch.