### PR TITLE
scheduler: elevate context for service lookup in host_state_map

### DIFF
--- a/manila/scheduler/host_manager.py
+++ b/manila/scheduler/host_manager.py
@@ -653,8 +653,14 @@ class HostManager(object):
     def _update_host_state_map(self, context, consider_disabled=False):
         # Get resource usage across the available share nodes:
         topic = CONF.share_topic
+        # NOTE: service_get_all_by_topic is decorated with
+        # @require_admin_context. The scheduler also serves the cached pool
+        # listing to non-admin callers (e.g. reaching via
+        # /scheduler-stats/pools/detail), so we elevate the context just for
+        # the internal services lookup to avoid an AdminRequired the first
+        # time the cache is populated after a scheduler restart.
         share_services = db.service_get_all_by_topic(
-            context,
+            context.elevated(),
             topic,
             consider_disabled=consider_disabled,
         )

--- a/manila/tests/scheduler/test_host_manager.py
+++ b/manila/tests/scheduler/test_host_manager.py
@@ -168,8 +168,13 @@ class HostManagerTestCase(test.TestCase):
                 share_node = fakes.SHARE_SERVICES_WITH_POOLS[i]
                 host = share_node['host']
                 self.assertEqual(share_node, host_state_map[host].service)
+            # The DB lookup must run against an elevated (admin) context so
+            # non-admin callers (e.g. via /scheduler-stats) don't trip
+            # require_admin_context when the cache is cold.
+            call_ctx = db.service_get_all_by_topic.call_args[0][0]
+            self.assertTrue(call_ctx.is_admin)
             db.service_get_all_by_topic.assert_called_once_with(
-                fake_context, topic, consider_disabled=False)
+                call_ctx, topic, consider_disabled=False)
 
     def test_get_pools_no_pools(self):
         fake_context = context.RequestContext('user', 'project')

--- a/manila/tests/scheduler/weighers/test_capacity.py
+++ b/manila/tests/scheduler/weighers/test_capacity.py
@@ -53,8 +53,13 @@ class CapacityWeigherTestCase(test.TestCase):
         fakes.mock_host_manager_db_calls(_mock_service_get_all_by_topic,
                                          disabled=disabled)
         host_states = self.host_manager.get_all_host_states_share(ctxt)
+        # host_manager elevates the context for the admin-only DB lookup,
+        # which produces a fresh copy — match on type/admin rather than
+        # object identity.
         _mock_service_get_all_by_topic.assert_called_once_with(
-            ctxt, CONF.share_topic, consider_disabled=False)
+            mock.ANY, CONF.share_topic, consider_disabled=False)
+        call_ctx = _mock_service_get_all_by_topic.call_args[0][0]
+        self.assertTrue(call_ctx.is_admin)
         return host_states
 
     # NOTE(xyang): If thin_provisioning = True and

--- a/manila/tests/scheduler/weighers/test_netapp_aiq.py
+++ b/manila/tests/scheduler/weighers/test_netapp_aiq.py
@@ -261,8 +261,13 @@ class NetAppAIQWeigherTestCase(test.TestCase):
         fakes.mock_host_manager_db_calls(_mock_service_get_all_by_topic,
                                          disabled=disabled)
         host_states = self.host_manager.get_all_host_states_share(ctxt)
+        # host_manager elevates the context for the admin-only DB lookup,
+        # which produces a fresh copy — match on type/admin rather than
+        # object identity.
         _mock_service_get_all_by_topic.assert_called_once_with(
-            ctxt, CONF.share_topic, consider_disabled=False)
+            mock.ANY, CONF.share_topic, consider_disabled=False)
+        call_ctx = _mock_service_get_all_by_topic.call_args[0][0]
+        self.assertTrue(call_ctx.is_admin)
         return host_states
 
     def test_weigh_objects_netapp_only(self):

--- a/manila/tests/scheduler/weighers/test_pool.py
+++ b/manila/tests/scheduler/weighers/test_pool.py
@@ -79,8 +79,13 @@ class PoolWeigherTestCase(test.TestCase):
     def _get_all_hosts(self):
         ctxt = context.get_admin_context()
         host_states = self.host_manager.get_all_host_states_share(ctxt)
+        # host_manager elevates the context for the admin-only DB lookup,
+        # which produces a fresh copy — match on type/admin rather than
+        # object identity.
         db_api.IMPL.service_get_all_by_topic.assert_called_once_with(
-            ctxt, CONF.share_topic, consider_disabled=False)
+            mock.ANY, CONF.share_topic, consider_disabled=False)
+        call_ctx = db_api.IMPL.service_get_all_by_topic.call_args[0][0]
+        self.assertTrue(call_ctx.is_admin)
         return host_states
 
     def test_no_server_pool_mapping(self):


### PR DESCRIPTION
`_update_host_state_map` calls `db.service_get_all_by_topic`, which is
decorated with `@require_admin_context`. The scheduler exposes the
cached pool listing to non-admin callers (
`/scheduler-stats/pools/detail` is the policy-permitted path here), so
passing the caller's context through to that DB lookup raises
AdminRequired whenever the in-memory `host_state_map` is empty — most
visibly right after a scheduler restart, before manila-share
capability updates have repopulated the cache. Once warm, subsequent
requests hit the cache and the symptom disappears.

Elevate the context for just the internal services lookup, matching
how the other scheduler drivers already handle their admin-only DB
reads.

Change-Id: I2f8a3f4af99d99656931c8874ba01e4e741c8795
Signed-off-by: Maurice Escher <maurice.escher@sap.com>
Assisted-By: Claude (claude-opus-4-8)
