### PR TITLE
netapp: reuse TLS session, reconnect on failure

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/api.py
+++ b/manila/share/drivers/netapp/dataontap/client/api.py
@@ -373,11 +373,18 @@ class ZapiClient(BaseClient):
             else:
                 response = self._session.post(
                     self._get_url(), data=request_d)
+            # Reset refresh flag after successful request
+            self._refresh_conn = False
         except requests.HTTPError as e:
             raise NaApiError(e.errno, e.strerror)
         except requests.URLRequired as e:
             raise exception.StorageCommunicationException(str(e))
         except Exception as e:
+            if not self._refresh_conn:
+                # Connection may have timed out; rebuild and retry once.
+                self._refresh_conn = True
+                return self.invoke_elem(na_element,
+                                        enable_tunneling=enable_tunneling)
             raise NaApiError(message=e)
 
         response_xml = response.text
@@ -564,11 +571,17 @@ class RestClient(BaseClient):
                     url, data=data, timeout=self._timeout)
             else:
                 response = request_method(url, data=data)
+            # Reset refresh flag after successful request
+            self._refresh_conn = False
         except requests.HTTPError as e:
             raise NaApiError(e.errno, e.strerror)
         except requests.URLRequired as e:
             raise exception.StorageCommunicationException(str(e))
         except Exception as e:
+            if not self._refresh_conn:
+                # Connection may have timed out; rebuild and retry once.
+                self._refresh_conn = True
+                return self.invoke_elem(na_element, api_args=api_args)
             raise NaApiError(message=e)
 
         response = (

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -5877,6 +5877,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         mock_backend_config.netapp_mount_replica_timeout = 30
         self.mock_object(data_motion, 'get_backend_configuration',
                          mock.Mock(return_value=mock_backend_config))
+        self.mock_object(self.library, '_get_api_client_for_backend',
+                         mock.Mock(return_value=mock_client))
 
         replica = self.library._safe_change_replica_source(
             mock_dm_session, self.fake_replica, self.fake_replica_2,


### PR DESCRIPTION
_refresh_conn was never reset to False after successful POST, causing
every invoke_elem() call to create a new requests.Session() with a full
TCP+TLS handshake (3-4 RTTs) instead of reusing the existing connection
(1 RTT).

Confirmed via py-spy on qa-de-1 (5 concurrent share creations, 60s
flame graph): ssl_wrap_socket dropped from 45% to 33% of samples after
fix.

Change-Id: Ia93bc21aaf3244e71ea6d6e3cdb5863aec727b2d
Co-authored-by: Maurice Escher <maurice.escher@sap.com>
