### PR TITLE
netapp: skip efficiency settings on data-protection volumes

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -2676,14 +2676,18 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
         self.send_request('volume-create', api_args)
 
-        efficiency_policy = options.get('efficiency_policy', None)
-        self.update_volume_efficiency_attributes(
-            volume_name, dedup_enabled, compression_enabled,
-            cross_dedup_disabled=cross_dedup_disabled,
-            efficiency_policy=efficiency_policy
-        )
-
         if volume_type != 'dp':
+            # Efficiency settings are meaningless on a data-protection volume:
+            # SnapMirror replicates the source's already-efficient blocks and
+            # ignores destination-side dedup/compression configuration. The
+            # active replica (or promotion) will apply these settings.
+            efficiency_policy = options.get('efficiency_policy', None)
+            self.update_volume_efficiency_attributes(
+                volume_name, dedup_enabled, compression_enabled,
+                cross_dedup_disabled=cross_dedup_disabled,
+                efficiency_policy=efficiency_policy
+            )
+
             if options.get('max_files_multiplier') is not None:
                 max_files_multiplier = options.pop('max_files_multiplier')
                 max_files = na_utils.calculate_max_files(size_gb,

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -1029,14 +1029,19 @@ class NetAppRestClient(object):
             adaptive_qos_policy_group=adaptive_qos_policy_group,
             mount_point_name=mount_point_name, snaplock_type=snaplock_type,
             **options)
-        efficiency_policy = options.get('efficiency_policy', None)
-        self.update_volume_efficiency_attributes(
-            volume_name, dedup_enabled, compression_enabled,
-            efficiency_policy=efficiency_policy
-        )
+        if volume_type != 'dp':
+            # Efficiency settings are meaningless on a data-protection volume:
+            # SnapMirror replicates the source's already-efficient blocks and
+            # ignores destination-side dedup/compression configuration. The
+            # active replica (or promotion) will apply these settings.
+            efficiency_policy = options.get('efficiency_policy', None)
+            self.update_volume_efficiency_attributes(
+                volume_name, dedup_enabled, compression_enabled,
+                efficiency_policy=efficiency_policy
+            )
 
-        if max_files is not None:
-            self.set_volume_max_files(volume_name, max_files)
+            if max_files is not None:
+                self.set_volume_max_files(volume_name, max_files)
 
         if snaplock_type is not None:
             self.set_snaplock_attributes(volume_name, **options)

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -1422,13 +1422,21 @@ class NetAppCmodeFileStorageLibrary(object):
         timeout = self.configuration.netapp_flexgroup_volume_online_timeout
         self.wait_for_flexgroup_deployment(vserver_client, job_info['jobid'],
                                            timeout)
-        efficiency_policy = provisioning_options.get('efficiency_policy', None)
-
-        vserver_client.update_volume_efficiency_attributes(
-            share_name, dedup_enabled, compression_enabled, is_flexgroup=True,
-            efficiency_policy=efficiency_policy)
 
         if not replica:
+            # Efficiency settings (dedup, compression, efficiency policy) are
+            # write-time properties or local background scanners. On a
+            # data-protection (replica) volume, blocks are written by
+            # SnapMirror from the source, which already carries the source's
+            # efficiency state. Configuring these locally is a no-op at best
+            # and an async-job failure at worst (especially for FlexGroup).
+            # Promotion to active will (re)apply the desired settings.
+            efficiency_policy = provisioning_options.get(
+                'efficiency_policy', None)
+            vserver_client.update_volume_efficiency_attributes(
+                share_name, dedup_enabled, compression_enabled,
+                is_flexgroup=True, efficiency_policy=efficiency_policy)
+
             if provisioning_options.get('max_files_multiplier') is not None:
                 max_files_multiplier = provisioning_options.pop(
                     'max_files_multiplier')


### PR DESCRIPTION
Replica destination volumes ('dp' type) are written entirely by SnapMirror from the source, which already carries the source's deduplication and compression state. Configuring efficiency settings (dedup, compression, efficiency policy) on the destination is a no-op at best — and an async-job failure at worst on FlexGroup volumes, which is what bug 2143199 (commit 38fab0a12) papered over with a wait shim instead of skipping the call.

The 'volume_type' (and equivalent 'replica') flag is already plumbed end-to-end from create_replica() through _allocate_container() into the client create_volume calls; this change uses it to gate three call sites:

  - lib_base._create_flexgroup_share: gate the efficiency call inside the existing 'if not replica' block.
  - client_cmode.create_volume (ZAPI FlexVol): gate the efficiency call under the existing 'if volume_type != "dp"' block.
  - client_cmode_rest.create_volume (REST FlexVol): add the same 'if volume_type != "dp"' gate (also picks up the missing set_volume_max_files guard on the REST path).

promote_share_replica() already (re)applies the metadata-driven efficiency configuration when a replica becomes active, so the desired settings are never lost — just deferred to the moment the volume becomes writable.

_wait_for_efficiency_job is left in place; it remains useful for other callers of enable_dedupe_async (share create, svm migrate, promote).
