### PR TITLE
NetApp: pass share metadata to driver on replica promotion

### DIFF
--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -3415,37 +3415,18 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
         """Update dedupe & compression attributes to match desired values."""
         efficiency_status = self.get_volume_efficiency_status(volume_name)
 
-        # SCI Keep deduplication metadata from filling up the volume
+        # cDOT compression requires dedup to be enabled. When cross-volume
+        # dedup is disabled (inline-only policy), both dedup and compression
+        # must be on -- ONTAP rejects the policy otherwise.
         if cross_dedup_disabled:
-            if not efficiency_status['dedupe']:
-                self.enable_dedup(volume_name)
-            if not efficiency_status['compression']:
-                self.enable_compression(volume_name)
-            self.set_sis_config(
-                volume_name, {
-                    'policy-name': 'inline-only',
-                    'enable-cross-volume-background-dedupe': 'false',
-                    'enable-cross-volume-inline-dedupe': 'false',
-                    'enable-data-compaction': 'true',
-                })
-            return
-
-        # Reset policy to default if it was previously set to inline-only
-        current_policy = efficiency_status.get('policy')
-        LOG.debug('Current deduplication policy for volume %s is %s.',
-                  volume_name, current_policy)
-        if current_policy == 'inline-only':
-            LOG.debug('Resetting deduplication policy for volume %s to auto.',
-                      volume_name)
-            self.set_sis_config(
-                volume_name, {
-                    'policy-name': 'auto',
-                    'enable-cross-volume-background-dedupe': 'true',
-                    'enable-cross-volume-inline-dedupe': 'true',
-                    'enable-data-compaction': 'true',
-                })
-
-        # cDOT compression requires dedup to be enabled
+            if not dedup_enabled or not compression_enabled:
+                LOG.warning(
+                    'cross_dedup_disabled requested on volume %s but '
+                    'dedup_enabled=%s / compression_enabled=%s; forcing both '
+                    'on because the inline-only policy requires them.',
+                    volume_name, dedup_enabled, compression_enabled)
+            dedup_enabled = True
+            compression_enabled = True
         dedup_enabled = dedup_enabled or compression_enabled
 
         # enable/disable dedup if needed
@@ -3472,7 +3453,77 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
             else:
                 self.disable_compression(volume_name)
 
-        if is_flexgroup:
+        # Decide on the target policy:
+        #   cross_dedup_disabled=True     -> inline-only + cross-vol dedup off
+        #                                    (SCI: keep dedup metadata from
+        #                                    filling up the volume)
+        #   otherwise, when the current policy is inline-only or absent
+        #   (e.g. a SnapMirror destination promoted RW without SIS
+        #   reconfiguration), reset it: use the caller's efficiency_policy
+        #   if provided, else 'auto'. Enable cross-vol dedup iff dedup is on.
+        current_policy = efficiency_status.get('policy')
+        LOG.debug('Current deduplication policy for volume %s is %s.',
+                  volume_name, current_policy)
+        if cross_dedup_disabled:
+            # inline-only implies inline dedup is on, but policy-name and
+            # enable-inline-dedupe are independent SIS flags -- set both.
+            self.set_sis_config(
+                volume_name, {
+                    'policy-name': 'inline-only',
+                    'enable-inline-dedupe': 'true',
+                    'enable-cross-volume-background-dedupe': 'false',
+                    'enable-cross-volume-inline-dedupe': 'false',
+                    'enable-data-compaction': 'true',
+                })
+        elif (current_policy in (None, 'inline-only')
+              or efficiency_status.get('cross_dedup_disabled')):
+            target_policy = efficiency_policy or 'auto'
+            LOG.debug('Resetting deduplication policy for volume %s to %s.',
+                      volume_name, target_policy)
+            # ONTAP validates cross-volume-dedup against the *current*
+            # inline-dedup flag, and setting policy-name alone doesn't
+            # atomically flip inline-dedup on (they're independent SIS
+            # config fields). Enable inline-dedup and set the target policy
+            # in the first call; flip the cross-volume flags in a second
+            # call once inline-dedup is on. Best-effort: some volumes
+            # (paused SIS, mid-scan, etc.) can't be reconciled this way --
+            # log and move on rather than fail the whole caller. If step 2
+            # fails while step 1 succeeds, the next ensure/update run will
+            # come back through this branch (policy is now auto, but
+            # cross-vol flags still mismatched) and retry step 2.
+            try:
+                inline_dedupe = 'true' if dedup_enabled else 'false'
+                self.set_sis_config(
+                    volume_name, {
+                        'policy-name': target_policy,
+                        'enable-inline-dedupe': inline_dedupe,
+                        'enable-data-compaction': 'true',
+                    })
+                cross_vol_dedupe = 'true' if dedup_enabled else 'false'
+                self.set_sis_config(
+                    volume_name, {
+                        'enable-cross-volume-background-dedupe':
+                            cross_vol_dedupe,
+                        'enable-cross-volume-inline-dedupe': cross_vol_dedupe,
+                    })
+            except netapp_api.NaApiError as e:
+                # "Operation was stopped" (error 40043) is ONTAP's way of
+                # reporting that a related SIS scan was stopped as a side
+                # effect of the config change -- the config change itself
+                # was applied. Treat it as informational; the next ensure/
+                # update run will find the volume in the intended state.
+                if (e.code == netapp_api.OPERATION_ALREADY_ENABLED
+                        and 'Operation was stopped' in e.message):
+                    LOG.debug(
+                        'set_sis_config for volume %s reported "Operation '
+                        'was stopped"; treating as informational.',
+                        volume_name)
+                    return
+                LOG.warning(
+                    'Could not reset deduplication policy for volume %s to '
+                    '%s (current policy %s): %s',
+                    volume_name, target_policy, current_policy, e)
+        elif is_flexgroup:
             self.apply_volume_efficiency_policy_async(
                 volume_name, efficiency_policy=efficiency_policy)
         else:

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -1164,11 +1164,13 @@ class NetAppRestClient(object):
             'efficiency.volume_path': f'/vol/{volume_name}',
             'fields': 'efficiency.state,'
                       'efficiency.compression,'
-                      'efficiency.policy'
+                      'efficiency.policy,'
+                      'efficiency.cross_volume_dedupe'
         }
         dedupe = False
         compression = False
         policy = None
+        cross_dedup_disabled = False
         try:
             response = self.send_request('/storage/volumes', 'get',
                                          query=query)
@@ -1177,6 +1179,8 @@ class NetAppRestClient(object):
                 dedupe = (efficiency['state'] == 'enabled')
                 compression = (efficiency['compression'] != 'none')
                 policy = efficiency.get('policy', {}).get('name')
+                cross_dedup_disabled = (
+                    efficiency.get('cross_volume_dedupe') == 'none')
         except netapp_api.api.NaApiError:
             msg = _('Failed to get volume efficiency status for %s.')
             LOG.error(msg, volume_name)
@@ -1185,6 +1189,7 @@ class NetAppRestClient(object):
             'dedupe': dedupe,
             'compression': compression,
             'policy': policy,
+            'cross_dedup_disabled': cross_dedup_disabled,
         }
 
     @na_utils.trace
@@ -1226,44 +1231,20 @@ class NetAppRestClient(object):
 
         efficiency_status = self.get_volume_efficiency_status(volume_name)
 
-        # SCI Keep deduplication metadata from filling up the volume
+        # cDOT compression requires dedup to be enabled. When cross-volume
+        # dedup is disabled (inline-only policy), both dedup and compression
+        # must be on -- ONTAP rejects the policy otherwise.
         if cross_dedup_disabled:
-            volume = self._get_volume_by_args(vol_name=volume_name)
-            uuid = volume['uuid']
-
-            # Enable dedup and compression if not already enabled
-            if not efficiency_status['dedupe']:
-                self.enable_dedupe_async(volume_name)
-            if not efficiency_status['compression']:
-                self.enable_compression_async(volume_name)
-
-            # Set efficiency policy to inline-only & disable cross-volume dedup
-            body = {
-                'efficiency': {
-                    'policy': {'name': 'inline-only'},
-                    'cross_volume_dedupe': 'none',
-                    'compaction': 'inline'
-                }
-            }
-            self.send_request(f'/storage/volumes/{uuid}', 'patch', body=body)
-            return
-
-        # Reset policy to default if it was previously set to inline-only
-        current_policy = efficiency_status.get('policy')
-        if current_policy == 'inline-only':
-            volume = self._get_volume_by_args(vol_name=volume_name)
-            uuid = volume['uuid']
-            body = {
-                'efficiency': {
-                    'policy': {'name': 'auto'},
-                    'cross_volume_dedupe': 'both',
-                    'compaction': 'inline'
-                }
-            }
-            self.send_request(f'/storage/volumes/{uuid}', 'patch', body=body)
-
-        # cDOT compression requires dedup to be enabled
+            if not dedup_enabled or not compression_enabled:
+                LOG.warning(
+                    'cross_dedup_disabled requested on volume %s but '
+                    'dedup_enabled=%s / compression_enabled=%s; forcing both '
+                    'on because the inline-only policy requires them.',
+                    volume_name, dedup_enabled, compression_enabled)
+            dedup_enabled = True
+            compression_enabled = True
         dedup_enabled = dedup_enabled or compression_enabled
+
         # enable/disable compression if needed
         if compression_enabled and not efficiency_status['compression']:
             self.enable_compression_async(volume_name)
@@ -1275,8 +1256,78 @@ class NetAppRestClient(object):
         elif not dedup_enabled and efficiency_status['dedupe']:
             self.disable_dedupe_async(volume_name)
 
-        self.apply_volume_efficiency_policy(
-            volume_name, efficiency_policy=efficiency_policy)
+        # Decide on the target policy:
+        #   cross_dedup_disabled=True     -> inline-only + cross-vol dedup off
+        #                                    (SCI: keep dedup metadata from
+        #                                    filling up the volume)
+        #   otherwise, when the current policy is inline-only or absent
+        #   (e.g. a SnapMirror destination promoted RW without SIS
+        #   reconfiguration), reset it: use the caller's efficiency_policy
+        #   if provided, else 'auto'. Enable cross-vol dedup iff dedup is on.
+        current_policy = efficiency_status.get('policy')
+        if cross_dedup_disabled:
+            volume = self._get_volume_by_args(vol_name=volume_name)
+            uuid = volume['uuid']
+            # inline-only implies inline dedup is on, but efficiency.policy
+            # and efficiency.dedupe are independent -- set dedupe='inline'
+            # so the volume actually has inline dedup enabled.
+            body = {
+                'efficiency': {
+                    'policy': {'name': 'inline-only'},
+                    'dedupe': 'inline',
+                    'cross_volume_dedupe': 'none',
+                    'compaction': 'inline'
+                }
+            }
+            self.send_request(f'/storage/volumes/{uuid}', 'patch', body=body)
+        elif (current_policy in (None, 'inline-only')
+              or efficiency_status.get('cross_dedup_disabled')):
+            target_policy = efficiency_policy or 'auto'
+            volume = self._get_volume_by_args(vol_name=volume_name)
+            uuid = volume['uuid']
+            # ONTAP validates cross_volume_dedupe against the *current*
+            # inline-dedup state, and setting the policy alone doesn't
+            # atomically flip inline-dedup on. Set efficiency.dedupe='both'
+            # (turns inline-dedupe on) with the target policy first, then
+            # flip cross_volume_dedupe in a second PATCH. Best-effort: some
+            # volumes (paused SIS, mid-scan, etc.) can't be reconciled this
+            # way -- log and move on rather than fail the whole caller. If
+            # step 2 fails while step 1 succeeds, the next ensure/update
+            # run will come back through this branch (policy is now auto,
+            # but cross-vol flags still mismatched) and retry step 2.
+            try:
+                dedupe_value = 'both' if dedup_enabled else 'none'
+                self.send_request(
+                    f'/storage/volumes/{uuid}', 'patch',
+                    body={'efficiency': {
+                        'policy': {'name': target_policy},
+                        'dedupe': dedupe_value,
+                        'compaction': 'inline'}})
+                self.send_request(
+                    f'/storage/volumes/{uuid}', 'patch',
+                    body={'efficiency': {
+                        'cross_volume_dedupe':
+                            'both' if dedup_enabled else 'none'}})
+            except netapp_api.api.NaApiError as e:
+                # "Operation was stopped" (error 40043) is ONTAP's way of
+                # reporting that a related SIS scan was stopped as a side
+                # effect of the config change -- the config change itself
+                # was applied. Treat it as informational; the next ensure/
+                # update run will find the volume in the intended state.
+                if (e.code == netapp_api.api.OPERATION_ALREADY_ENABLED
+                        and 'Operation was stopped' in e.message):
+                    LOG.debug(
+                        'Efficiency PATCH for volume %s reported "Operation '
+                        'was stopped"; treating as informational.',
+                        volume_name)
+                    return
+                LOG.warning(
+                    'Could not reset deduplication policy for volume %s to '
+                    '%s (current policy %s): %s',
+                    volume_name, target_policy, current_policy, e)
+        else:
+            self.apply_volume_efficiency_policy(
+                volume_name, efficiency_policy=efficiency_policy)
 
     @na_utils.trace
     def enable_dedupe_async(self, volume_name):
@@ -2922,7 +2973,8 @@ class NetAppRestClient(object):
                       compression_enabled=False, max_files=None,
                       qos_policy_group=None, hide_snapdir=None,
                       autosize_attributes=None, comment=None,
-                      adaptive_qos_policy_group=None, **options):
+                      adaptive_qos_policy_group=None,
+                      cross_dedup_disabled=False, **options):
         """Update backend volume for a share as necessary.
 
         :param aggregate_name: either a list or a string. List for aggregate
@@ -2996,6 +3048,7 @@ class NetAppRestClient(object):
         # Efficiency options must be handled separately
         self.update_volume_efficiency_attributes(
             volume_name, dedup_enabled, compression_enabled,
+            cross_dedup_disabled=cross_dedup_disabled,
             is_flexgroup=is_flexgroup, efficiency_policy=efficiency_policy
         )
         if self._is_snaplock_enabled_volume(volume_name):

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -3972,19 +3972,18 @@ class NetAppCmodeFileStorageLibrary(object):
         else:
             LOG.exception(logical_space_error_msg)
 
-        # SCI: Check metadata to determine if cross-volume dedup should be
-        # disabled on the promoted replica. All replicas of the same share
-        # share the same metadata.
-        metadata = new_active_replica.get('metadata', {})
-        if metadata.get('cross_volume_dedupe') == 'false':
-            try:
-                new_active_vserver_cli.update_volume_efficiency_attributes(
-                    new_active_replica_name, True, True,
-                    cross_dedup_disabled=True)
-            except Exception as e:
-                LOG.exception(
-                    f"Could not disable cross_volume_dedupe on the promoted "
-                    f"replica. {e}")
+        # SCI: Apply cross_volume_dedupe metadata to the promoted replica.
+        # All replicas of the same share share the same metadata; when the
+        # metadata is missing or not 'false', reset the policy to auto so
+        # a stale inline-only setting from the old source doesn't linger.
+        effi_opts = self._get_cross_volume_dedupe_options(new_active_replica)
+        try:
+            new_active_vserver_cli.update_volume_efficiency_attributes(
+                new_active_replica_name, True, True, **effi_opts)
+        except Exception as e:
+            LOG.exception(
+                f"Could not apply cross_volume_dedupe to the promoted "
+                f"replica. {e}")
 
         return new_replica_list
 
@@ -4915,6 +4914,10 @@ class NetAppCmodeFileStorageLibrary(object):
         snap_attributes = self._get_provisioning_options_for_snap_attributes(
             vserver_client, new_share_volume_name)
         provisioning_options.update(snap_attributes)
+
+        # SCI: Apply cross_volume_dedupe metadata to the destination volume.
+        provisioning_options.update(
+            self._get_cross_volume_dedupe_options(destination_share))
 
         destination_aggregate = share_utils.extract_host(
             destination_share['host'], level='pool')

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -2103,6 +2103,23 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                     # Update share attributes according with share extra specs.
                     self._update_share_attributes_after_server_migration(
                         instance, src_client, dest_aggregate, dest_client)
+                else:
+                    # SCI: SVM Migrate copies the volume as-is (including
+                    # dedup and compression state); only reconcile
+                    # cross_volume_dedupe so the policy follows the share
+                    # metadata instead of the source SVM's historical state.
+                    # Go through the efficiency-only helper (not
+                    # modify_volume) to avoid touching unrelated attributes
+                    # like space-guarantee, which ONTAP rejects on volumes
+                    # with compacted data. Pass the current dedup/
+                    # compression status so those aren't touched either.
+                    current = dest_client.get_volume_efficiency_status(
+                        share_name)
+                    dest_client.update_volume_efficiency_attributes(
+                        share_name,
+                        current.get('dedupe', False),
+                        current.get('compression', False),
+                        **self._get_cross_volume_dedupe_options(instance))
 
             except Exception:
                 msg_args = {
@@ -2332,6 +2349,9 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         # have the opportunity to add the snapshot policy after a successful
         # migration.
         provisioning_options.pop('snapshot_policy', None)
+        # SCI: Apply cross_volume_dedupe metadata to the destination volume.
+        provisioning_options.update(
+            self._get_cross_volume_dedupe_options(src_share_instance))
 
         # Modify volume to match extra specs
         dest_client.modify_volume(dest_aggregate, volume_name,

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -2037,6 +2037,16 @@ class ShareManager(manager.SchedulerDependentManager):
             self._get_migrating_snapshots(context, src_share_instance,
                                           dest_share_instance))
 
+        # SCI: attach share metadata to the share instances so the driver
+        # can act on share-level metadata (e.g. cross_volume_dedupe) when
+        # reconciling the destination volume.
+        share_metadata_list = share_ref.get('share_metadata', [])
+        share_metadata = {
+            m['key']: m['value'] for m in share_metadata_list
+        } if share_metadata_list else {}
+        src_share_instance['metadata'] = share_metadata
+        dest_share_instance['metadata'] = share_metadata
+
         data_updates = self.driver.migration_complete(
             context, src_share_instance, dest_share_instance,
             src_snap_instances, snapshot_mappings, share_server,
@@ -3093,14 +3103,26 @@ class ShareManager(manager.SchedulerDependentManager):
         replica_list = [self._get_share_instance_dict(context, r)
                         for r in replica_list]
 
+        # SCI: Merge share metadata into each replica dict so the driver
+        # can act on share-level metadata (e.g. cross_volume_dedupe) during
+        # promotion. Share metadata wins over replica-specific metadata.
+        share = self.db.share_get(context, share_replica['share_id'])
+        share_metadata_list = share.get('share_metadata', [])
+        share_metadata = {
+            m['key']: m['value'] for m in share_metadata_list
+        } if share_metadata_list else {}
+
         for r in replica_list:
-            r['metadata'] = self.db.share_replica_metadata_get(
+            replica_metadata = self.db.share_replica_metadata_get(
                 context, r["id"]) or {}
+            r['metadata'] = {**replica_metadata, **share_metadata}
 
         share_replica = self._get_share_instance_dict(context, share_replica)
-        share_replica['metadata'] = (
-            self.db.share_replica_metadata_get(
-                context, share_replica_id) or {})
+        share_replica['metadata'] = {
+            **(self.db.share_replica_metadata_get(
+                context, share_replica_id) or {}),
+            **share_metadata,
+        }
 
         try:
             updated_replica_list = (

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -4355,7 +4355,8 @@ class NetAppClientCmodeTestCase(test.TestCase):
             self.client,
             'get_volume_efficiency_status',
             mock.Mock(return_value={'dedupe': existing_dedupe,
-                                    'compression': existing_compression}))
+                                    'compression': existing_compression,
+                                    'policy': 'auto'}))
         mock_enable_compression = self.mock_object(self.client,
                                                    'enable_compression')
         mock_enable_compression_async = self.mock_object(

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -1144,13 +1144,15 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
             'efficiency.volume_path': '/vol/%s' % fake.VOLUME_NAMES[0],
             'fields': 'efficiency.state,'
                       'efficiency.compression,'
-                      'efficiency.policy'
+                      'efficiency.policy,'
+                      'efficiency.cross_volume_dedupe'
         }
 
         expected_result = {
             'dedupe': True,
             'compression': True,
-            'policy': None
+            'policy': None,
+            'cross_dedup_disabled': False,
         }
 
         self.mock_object(self.client, 'send_request',
@@ -2632,6 +2634,7 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
             '/storage/volumes/' + volume['uuid'], 'patch', body=body)
         mock_update_volume_efficiency_attributes.assert_called_once_with(
             fake.SHARE_NAME, False, False,
+            cross_dedup_disabled=False,
             is_flexgroup=is_flexgroup, efficiency_policy=None
         )
 
@@ -2689,6 +2692,7 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
             '/storage/volumes/' + volume['uuid'], 'patch', body=body)
         mock_update_volume_efficiency_attributes.assert_called_once_with(
             fake.SHARE_NAME, True, False,
+            cross_dedup_disabled=False,
             is_flexgroup=False,
             efficiency_policy=fake.VOLUME_EFFICIENCY_POLICY_NAME
         )
@@ -3191,7 +3195,8 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
     def test_update_volume_efficiency_attributes(self, status):
         response = {
             'dedupe': not status,
-            'compression': not status
+            'compression': not status,
+            'policy': 'auto',
         }
         self.mock_object(self.client, 'get_volume_efficiency_status',
                          mock.Mock(return_value=response))

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -3816,6 +3816,9 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
         mock_modify_volume = self.mock_object(self.mock_dest_client,
                                               'modify_volume')
         fake_provisioning_opts.pop('snapshot_policy', None)
+        # SCI: cross_volume_dedupe metadata is applied on the destination.
+        # fake.SHARE_INSTANCE has no metadata key -> cross_dedup_disabled=False
+        fake_provisioning_opts['cross_dedup_disabled'] = False
 
         self.library._update_share_attributes_after_server_migration(
             fake.SHARE_INSTANCE, self.mock_src_client, fake_aggregate,

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -1957,6 +1957,8 @@ class ShareManagerTestCase(test.TestCase):
                          mock.Mock(return_value=replica_list))
         self.mock_object(db, 'share_replica_metadata_get',
                          mock.Mock(return_value=replica_metadata))
+        self.mock_object(db, 'share_get',
+                         mock.Mock(return_value={'share_metadata': []}))
         self.mock_object(self.share_manager.driver, 'promote_replica',
                          mock.Mock(side_effect=exception.ManilaException))
         mock_info_log = self.mock_object(manager.LOG, 'info')
@@ -2014,6 +2016,8 @@ class ShareManagerTestCase(test.TestCase):
             mock.Mock(return_value=snapshots_instances))
         self.mock_object(db, 'share_replica_metadata_get',
                          mock.Mock(return_value=replica_metadata))
+        self.mock_object(db, 'share_get',
+                         mock.Mock(return_value={'share_metadata': []}))
         self.mock_object(
             self.share_manager.driver, 'promote_replica',
             mock.Mock(return_value=retval))
@@ -2091,6 +2095,8 @@ class ShareManagerTestCase(test.TestCase):
             db, 'share_snapshot_instance_update')
         self.mock_object(db, 'share_replica_metadata_get',
                          mock.Mock(return_value=replica_metadata))
+        self.mock_object(db, 'share_get',
+                         mock.Mock(return_value={'share_metadata': []}))
         self.mock_object(
             self.share_manager.driver, 'promote_replica',
             mock.Mock(return_value=updated_replica_list))
@@ -2130,6 +2136,59 @@ class ShareManagerTestCase(test.TestCase):
         ])
         self.assertTrue(mock_info_log.called)
         self.assertFalse(mock_snap_instance_update.called)
+
+    def test_promote_share_replica_share_metadata_wins(self):
+        # Share metadata must win over replica metadata when both define
+        # the same key, so driver-side helpers (e.g. cross_volume_dedupe)
+        # see the share-level value.
+        replica = fake_replica()
+        active_replica = fake_replica(
+            id='current_active_replica',
+            replica_state=constants.REPLICA_STATE_ACTIVE)
+        replica_list = [replica, active_replica]
+        replica_metadata = {
+            'shared_key': 'replica_value',
+            'replica_only': 'r',
+        }
+        share_metadata_rows = [
+            {'key': 'shared_key', 'value': 'share_value'},
+            {'key': 'share_only', 'value': 's'},
+            {'key': 'cross_volume_dedupe', 'value': 'false'},
+        ]
+        self.mock_object(db, 'share_access_get_all_for_share',
+                         mock.Mock(return_value=[]))
+        self.mock_object(db, 'share_replica_get',
+                         mock.Mock(return_value=replica))
+        self.mock_object(self.share_manager, '_get_share_server')
+        self.mock_object(db, 'share_replicas_get_all_by_share',
+                         mock.Mock(return_value=replica_list))
+        self.mock_object(db, 'share_replica_metadata_get',
+                         mock.Mock(return_value=replica_metadata))
+        self.mock_object(
+            db, 'share_get',
+            mock.Mock(return_value={'share_metadata': share_metadata_rows}))
+        self.mock_object(
+            db, 'share_snapshot_instance_get_all_with_filters',
+            mock.Mock(return_value=[]))
+        self.mock_object(db, 'export_locations_update')
+        self.mock_object(db, 'share_replica_update')
+        mock_driver_call = self.mock_object(
+            self.share_manager.driver, 'promote_replica',
+            mock.Mock(return_value=[]))
+
+        self.share_manager.promote_share_replica(self.context, replica)
+
+        _, replica_list_arg, share_replica_arg, _ = (
+            mock_driver_call.call_args.args[:4])
+        expected_metadata = {
+            'shared_key': 'share_value',
+            'replica_only': 'r',
+            'share_only': 's',
+            'cross_volume_dedupe': 'false',
+        }
+        for r in replica_list_arg:
+            self.assertEqual(expected_metadata, r['metadata'])
+        self.assertEqual(expected_metadata, share_replica_arg['metadata'])
 
     @ddt.data('openstack1@watson#_pool0', 'openstack1@newton#_pool0')
     def test_periodic_share_replica_update(self, host):


### PR DESCRIPTION
PR #321 made share metadata the authoritative source for the
cross_volume_dedupe driver setting, but the share manager only
attaches *replica* metadata to the dicts handed to the driver via
promote_replica(). The share-level metadata never reached the
driver, so a share with cross_volume_dedupe=false saw its policy
stay at auto after a replica promotion instead of being switched
to inline-only.

Look up the parent share's metadata once and merge it into each
replica dict (and into the share_replica passed as the promotion
target). Share metadata wins over replica-specific metadata for
overlapping keys.

The driver code at promote_replica already reads
new_active_replica.get('metadata').get('cross_volume_dedupe') so
no driver change is required.

Change-Id: Ic624884d7387bbdfa84aec7c74b32164debb9f02
Assisted-By: Claude (Anthropic, claude-opus-4-8)
Signed-off-by: Maurice Escher <maurice.escher@sap.com>
