### PR TITLE
NetApp: set real ifgroup MAC on Neutron ports for consistency

### DIFF
--- a/manila/exception.py
+++ b/manila/exception.py
@@ -763,6 +763,10 @@ class IPAddressInUse(InUse):
     message = _("IP address %(ip)s is already used.")
 
 
+class MacAddressInUse(InUse):
+    message = _("MAC address %(mac)s is already in use.")
+
+
 class ShareGroupTypeInUse(ManilaException):
     message = _("Share group Type %(type_id)s deletion is not allowed "
                 "with groups present with the type.")

--- a/manila/network/neutron/api.py
+++ b/manila/network/neutron/api.py
@@ -72,6 +72,10 @@ class PortBindingAlreadyExistsClient(neutron_client_exc.Conflict):
     pass
 
 
+class MacAddressInUseClient(neutron_client_exc.Conflict):
+    pass
+
+
 # We need to monkey-patch neutronclient.common.exceptions module, to make
 # neutron client to raise error specific exceptions. E.g. exception
 # PortBindingAlreadyExistsClient is raised for Neutron API error
@@ -79,6 +83,7 @@ class PortBindingAlreadyExistsClient(neutron_client_exc.Conflict):
 # Conflict will be raised.
 neutron_client_exc.PortBindingAlreadyExistsClient = \
     PortBindingAlreadyExistsClient
+neutron_client_exc.MacAddressInUseClient = MacAddressInUseClient
 
 
 def list_opts():
@@ -197,6 +202,8 @@ class API(object):
         except neutron_client_exc.NeutronClientException as e:
             LOG.warning('Neutron error creating port on network %s',
                         network_id)
+            if e.status_code == 409 and 'mac' in str(e.message).lower():
+                raise exception.MacAddressInUse(mac=e.message)
             if e.status_code == 409:
                 raise exception.PortLimitExceeded()
             raise exception.NetworkException(code=e.status_code,

--- a/manila/network/neutron/neutron_network_plugin.py
+++ b/manila/network/neutron/neutron_network_plugin.py
@@ -165,6 +165,7 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
 
         allocation_count = kwargs.get('count', 1)
         device_owner = kwargs.get('device_owner', 'share')
+        mac_address = kwargs.get('mac_address')
 
         ports = []
         for current_count in range(0, allocation_count):
@@ -175,7 +176,8 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
                                   share_network_subnet,
                                   device_owner,
                                   current_count,
-                                  is_external_network=is_external_network),
+                                  is_external_network=is_external_network,
+                                  mac_address=mac_address),
             )
 
         return ports
@@ -348,8 +350,8 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
 
     def _get_port_create_args(self, share_server, share_network_subnet,
                               device_owner, count=0,
-                              is_external_network=False):
-        return {
+                              is_external_network=False, mac_address=None):
+        args = {
             "network_id": share_network_subnet['neutron_net_id'],
             "subnet_id": share_network_subnet['neutron_subnet_id'],
             "device_owner": 'manila:' + device_owner,
@@ -360,16 +362,32 @@ class NeutronNetworkPlugin(network.NetworkBaseAPI):
             # neutron creates merely assist in IPAM.
             "admin_state_up": not is_external_network,
         }
+        if mac_address:
+            args["mac_address"] = mac_address
+        return args
 
     def _create_port(self, context, share_server, share_network,
                      share_network_subnet, device_owner, count=0,
-                     is_external_network=False):
+                     is_external_network=False, mac_address=None):
         create_args = self._get_port_create_args(
             share_server, share_network_subnet, device_owner, count,
-            is_external_network=is_external_network)
+            is_external_network=is_external_network,
+            mac_address=mac_address)
 
-        port = self.neutron_api.create_port(
-            share_network['project_id'], **create_args)
+        try:
+            port = self.neutron_api.create_port(
+                share_network['project_id'], **create_args)
+        except exception.MacAddressInUse:
+            LOG.warning('MAC %s already in use on network %s; retrying '
+                        'without MAC (overflow port — real wire MAC recorded '
+                        'in port description).',
+                        mac_address,
+                        share_network_subnet['neutron_net_id'])
+            create_args.pop('mac_address', None)
+            create_args['description'] = (
+                'NetApp LIF; effective wire MAC=%s' % mac_address)
+            port = self.neutron_api.create_port(
+                share_network['project_id'], **create_args)
 
         if is_external_network:
             msg = (
@@ -639,11 +657,12 @@ class NeutronBindNetworkPlugin(NeutronNetworkPlugin):
 
     def _get_port_create_args(self, share_server, share_network_subnet,
                               device_owner, count=0,
-                              is_external_network=False):
+                              is_external_network=False, mac_address=None):
         arguments = super(
             NeutronBindNetworkPlugin, self)._get_port_create_args(
             share_server, share_network_subnet, device_owner, count,
-            is_external_network=is_external_network
+            is_external_network=is_external_network,
+            mac_address=mac_address
         )
         arguments['host_id'] = self.config.neutron_host_id
         arguments['binding:vnic_type'] = self.config.neutron_vnic_type

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -757,6 +757,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                     'node': None,
                     'operational-speed': None,
                     'ifgrp-port': None,
+                    'mac-address': None,
                 },
             },
         }
@@ -775,6 +776,7 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
                 'node': port_info.get_child_content('node'),
                 'port': port_info.get_child_content('port'),
                 'speed': port_info.get_child_content('operational-speed'),
+                'mac-address': port_info.get_child_content('mac-address'),
             }
             ports.append(port)
 

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -5141,7 +5141,7 @@ class NetAppRestClient(object):
             'state': 'up',
             'type': 'physical',
             'broadcast_domain.name': 'Default',
-            'fields': 'node.name,speed,name'
+            'fields': 'node.name,speed,name,mac_address'
         }
 
         result = self.send_request('/network/ethernet/ports', 'get',
@@ -5174,6 +5174,7 @@ class NetAppRestClient(object):
                         'node': port_info['node']['name'],
                         'port': port_info['name'],
                         'speed': port_info['speed'],
+                        'mac-address': port_info.get('mac_address'),
                     }
                     ports.append(port)
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/drv_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/drv_multi_svm.py
@@ -139,6 +139,17 @@ class NetAppCmodeMultiSvmShareDriver(driver.ShareDriver):
     def get_network_allocations_number(self):
         return self.library.get_network_allocations_number()
 
+    def allocate_network(self, context, share_server, share_network,
+                         share_network_subnet, **kwargs):
+        """Allocate network, injecting the ifgroup MAC for the first port."""
+
+        mac = self.library.get_node_mac_for_network_allocation()
+        if mac:
+            kwargs.setdefault('mac_address', mac)
+        return super().allocate_network(
+            context, share_server, share_network, share_network_subnet,
+            **kwargs)
+
     def get_admin_network_allocations_number(self):
         return self.library.get_admin_network_allocations_number(
             self.admin_network_api)

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/drv_single_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/drv_single_svm.py
@@ -123,6 +123,12 @@ class NetAppCmodeSingleSvmShareDriver(driver.ShareDriver):
     def get_network_allocations_number(self):
         return self.library.get_network_allocations_number()
 
+    def allocate_network(self, context, share_server, share_network,
+                         share_network_subnet, **kwargs):
+        return super().allocate_network(
+            context, share_server, share_network, share_network_subnet,
+            **kwargs)
+
     def get_admin_network_allocations_number(self):
         return self.library.get_admin_network_allocations_number()
 

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_multi_svm.py
@@ -29,6 +29,8 @@ from oslo_utils import units
 from oslo_utils import uuidutils
 
 from manila.common import constants
+from manila import context as manila_context
+from manila import db
 from manila import exception
 from manila.i18n import _
 from manila.message import message_field
@@ -534,6 +536,25 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                              node_name, lif_name, network_allocation,
                              lif_home_port=lif_home_port)
 
+            # Sync the real LIF MAC (inherited from the node's physical port)
+            self._sync_lif_mac_to_db(node_name, network_allocation)
+
+    @na_utils.trace
+    def _sync_lif_mac_to_db(self, node_name, network_allocation):
+        """Update network_allocations.mac_address with the LIF's real MAC."""
+
+        node_mac = self._get_node_data_port_mac(node_name)
+        if not node_mac:
+            LOG.warning('Could not retrieve MAC for node %s; leaving '
+                        'network_allocation %s untouched.',
+                        node_name, network_allocation['id'])
+            return
+        admin_ctx = manila_context.get_admin_context()
+        db.network_allocation_update(
+            admin_ctx, network_allocation['id'], {'mac_address': node_mac})
+        LOG.info('Synced LIF MAC for node %s: allocation %s updated to %s.',
+                 node_name, network_allocation['id'], node_mac)
+
     @na_utils.trace
     def _create_vserver_admin_lif(self, vserver_name, vserver_client,
                                   network_info, ipspace_name,
@@ -557,6 +578,8 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
         self._create_lif(vserver_client, vserver_name, ipspace_name,
                          node_name, lif_name, network_allocation,
                          lif_home_port=home_port)
+
+        self._sync_lif_mac_to_db(node_name, network_allocation)
 
     @na_utils.trace
     def _create_vserver_routes(self, vserver_client, network_info):
@@ -583,6 +606,17 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
                 _('Could not find eligible network ports on node %s on which '
                   'to create Vserver LIFs.') % node)
         return matched_port_names[0]
+
+    @na_utils.trace
+    def _get_node_data_port_mac(self, node):
+        """Return MAC address of the data port selected for LIF creation."""
+
+        pattern = self.configuration.netapp_port_name_search_pattern
+        ports = self._client.get_node_data_ports(node)
+        matched = [p for p in ports if re.match(pattern, p.get('port', ''))]
+        if matched:
+            return matched[0].get('mac-address')
+        return None
 
     def _get_lif_name(self, node_name, network_allocation):
         """Get LIF name based on template from manila.conf file."""
@@ -646,6 +680,15 @@ class NetAppCmodeMultiSVMFileStorageLibrary(
     def get_network_allocations_number(self):
         """Get number of network interfaces to be created."""
         return len(self._client.list_cluster_nodes())
+
+    @na_utils.trace
+    def get_node_mac_for_network_allocation(self):
+        """Return the ifgroup MAC of the first cluster node."""
+
+        nodes = self._client.list_cluster_nodes()
+        if nodes:
+            return self._get_node_data_port_mac(nodes[0])
+        return None
 
     @na_utils.trace
     def get_admin_network_allocations_number(self, admin_network_api):

--- a/manila/tests/network/neutron/test_neutron_api.py
+++ b/manila/tests/network/neutron/test_neutron_api.py
@@ -276,6 +276,36 @@ class NeutronApiTest(test.TestCase):
         self.assertTrue(clientv20.Client.called)
         self.assertTrue(self.neutron_api.client.create_port.called)
 
+    @mock.patch.object(neutron_api.LOG, 'warning', mock.Mock())
+    def test_create_port_exception_status_409_mac_in_use(self):
+        self.mock_object(
+            self.neutron_api.client, 'create_port',
+            mock.Mock(side_effect=neutron_client_exc.NeutronClientException(
+                status_code=409,
+                message='The mac address fa:16:3e:xx is in use.')))
+        port_args = {'tenant_id': 'test tenant', 'network_id': 'test net'}
+
+        self.assertRaises(exception.MacAddressInUse,
+                          self.neutron_api.create_port,
+                          **port_args)
+
+        self.assertTrue(neutron_api.LOG.warning.called)
+
+    @mock.patch.object(neutron_api.LOG, 'warning', mock.Mock())
+    def test_create_port_exception_status_409_quota_not_mac(self):
+        self.mock_object(
+            self.neutron_api.client, 'create_port',
+            mock.Mock(side_effect=neutron_client_exc.NeutronClientException(
+                status_code=409,
+                message='Quota exceeded for resources: [\'port\']')))
+        port_args = {'tenant_id': 'test tenant', 'network_id': 'test net'}
+
+        self.assertRaises(exception.PortLimitExceeded,
+                          self.neutron_api.create_port,
+                          **port_args)
+
+        self.assertTrue(neutron_api.LOG.warning.called)
+
     def test_delete_port(self):
         # Set up test data
         self.mock_object(self.neutron_api.client, 'delete_port')

--- a/manila/tests/network/neutron/test_neutron_plugin.py
+++ b/manila/tests/network/neutron/test_neutron_plugin.py
@@ -416,6 +416,77 @@ class NeutronNetworkPluginTest(test.TestCase):
         save_subnet_data.stop()
         create_port.stop()
 
+    @mock.patch.object(db_api, 'network_allocation_create',
+                       mock.Mock(return_values=fake_network_allocation))
+    @mock.patch.object(db_api, 'share_network_get',
+                       mock.Mock(return_value=fake_share_network))
+    @mock.patch.object(db_api, 'share_server_get',
+                       mock.Mock(return_value=fake_share_server))
+    def test_allocate_network_with_mac_address(self):
+        fake_mac = 'd2:39:ea:ac:06:9c'
+        has_provider_nw_ext = mock.patch.object(
+            self.plugin, '_has_provider_network_extension').start()
+        has_provider_nw_ext.return_value = True
+        mock.patch.object(self.plugin, '_save_neutron_network_data').start()
+        mock.patch.object(self.plugin, '_save_neutron_subnet_data').start()
+
+        with mock.patch.object(self.plugin.neutron_api, 'create_port',
+                               mock.Mock(return_value=fake_neutron_port)):
+            self.plugin.allocate_network(
+                self.fake_context,
+                fake_share_server,
+                fake_share_network,
+                fake_share_network_subnet,
+                mac_address=fake_mac)
+
+            self.plugin.neutron_api.create_port.assert_called_once_with(
+                fake_share_network['project_id'],
+                network_id=fake_share_network_subnet['neutron_net_id'],
+                subnet_id=fake_share_network_subnet['neutron_subnet_id'],
+                device_owner='manila:share',
+                device_id=fake_share_network['id'],
+                name=fake_share_network['id'] + '_0',
+                admin_state_up=False,
+                mac_address=fake_mac,
+            )
+
+    @mock.patch.object(db_api, 'network_allocation_create',
+                       mock.Mock(return_values=fake_network_allocation))
+    @mock.patch.object(db_api, 'share_network_get',
+                       mock.Mock(return_value=fake_share_network))
+    @mock.patch.object(db_api, 'share_server_get',
+                       mock.Mock(return_value=fake_share_server))
+    @mock.patch.object(plugin.LOG, 'warning', mock.Mock())
+    def test_allocate_network_mac_in_use_retries_without_mac(self):
+        fake_mac = 'd2:39:ea:ac:06:9c'
+        has_provider_nw_ext = mock.patch.object(
+            self.plugin, '_has_provider_network_extension').start()
+        has_provider_nw_ext.return_value = True
+        mock.patch.object(self.plugin, '_save_neutron_network_data').start()
+        mock.patch.object(self.plugin, '_save_neutron_subnet_data').start()
+
+        create_port = mock.patch.object(
+            self.plugin.neutron_api, 'create_port',
+            mock.Mock(side_effect=[
+                exception.MacAddressInUse(mac=fake_mac),
+                fake_neutron_port,
+            ])).start()
+
+        self.plugin.allocate_network(
+            self.fake_context,
+            fake_share_server,
+            fake_share_network,
+            fake_share_network_subnet,
+            mac_address=fake_mac)
+
+        self.assertEqual(2, create_port.call_count)
+        _, second_kwargs = create_port.call_args
+
+        self.assertNotIn('mac_address', second_kwargs)
+        self.assertIn('description', second_kwargs)
+        self.assertIn(fake_mac, second_kwargs['description'])
+        plugin.LOG.warning.assert_called()
+
     def _setup_manage_network_allocations(self):
 
         allocations = ['192.168.0.11', '192.168.0.12', 'fd12::2000']

--- a/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/fakes.py
@@ -833,10 +833,14 @@ NET_PORT_GET_ITER_RESPONSE = etree.XML("""
 """ % {'node_name': NODE_NAME})
 
 SPEED_SORTED_PORTS = (
-    {'node': NODE_NAME, 'port': 'e0d', 'speed': '10000'},
-    {'node': NODE_NAME, 'port': 'e0c', 'speed': '1000'},
-    {'node': NODE_NAME, 'port': 'e0b', 'speed': '100'},
-    {'node': NODE_NAME, 'port': 'e0a', 'speed': '10'},
+    {'node': NODE_NAME, 'port': 'e0d', 'speed': '10000',
+     'mac-address': '00:0c:29:fc:04:f7'},
+    {'node': NODE_NAME, 'port': 'e0c', 'speed': '1000',
+     'mac-address': '00:0c:29:fc:04:ed'},
+    {'node': NODE_NAME, 'port': 'e0b', 'speed': '100',
+     'mac-address': '00:0c:29:fc:04:e3'},
+    {'node': NODE_NAME, 'port': 'e0a', 'speed': '10',
+     'mac-address': '00:0c:29:fc:04:d9'},
 )
 PORT_NAMES = ('e0a', 'e0b', 'e0c', 'e0d')
 SPEED_SORTED_PORT_NAMES = ('e0d', 'e0c', 'e0b', 'e0a')
@@ -4613,15 +4617,21 @@ FAKE_PEER_GET_RESPONSE = {
 }
 
 REST_SPEED_SORTED_PORTS = [
-    {'node': NODE_NAME, 'port': 'e0d', 'speed': 10000},
-    {'node': NODE_NAME, 'port': 'e0c', 'speed': 1000},
-    {'node': NODE_NAME, 'port': 'e0b', 'speed': 100},
+    {'node': NODE_NAME, 'port': 'e0d', 'speed': 10000,
+     'mac-address': 'aa:bb:cc:dd:ee:04'},
+    {'node': NODE_NAME, 'port': 'e0c', 'speed': 1000,
+     'mac-address': 'aa:bb:cc:dd:ee:03'},
+    {'node': NODE_NAME, 'port': 'e0b', 'speed': 100,
+     'mac-address': 'aa:bb:cc:dd:ee:02'},
 ]
 
 REST_SPEED_NOT_SORTED_PORTS = [
-    {'node': NODE_NAME, 'port': 'e0b', 'speed': 100},
-    {'node': NODE_NAME, 'port': 'e0c', 'speed': 1000},
-    {'node': NODE_NAME, 'port': 'e0d', 'speed': 10000},
+    {'node': NODE_NAME, 'port': 'e0b', 'speed': 100,
+     'mac-address': 'aa:bb:cc:dd:ee:02'},
+    {'node': NODE_NAME, 'port': 'e0c', 'speed': 1000,
+     'mac-address': 'aa:bb:cc:dd:ee:03'},
+    {'node': NODE_NAME, 'port': 'e0d', 'speed': 10000,
+     'mac-address': 'aa:bb:cc:dd:ee:04'},
 ]
 
 REST_ETHERNET_PORTS = {
@@ -4641,6 +4651,7 @@ REST_ETHERNET_PORTS = {
             },
             "state": "up",
             "speed": 10,
+            "mac_address": "aa:bb:cc:dd:ee:01",
         },
         {
             "uuid": "fake_uuid2",
@@ -4657,6 +4668,7 @@ REST_ETHERNET_PORTS = {
             },
             "state": "up",
             "speed": 100,
+            "mac_address": "aa:bb:cc:dd:ee:02",
         },
         {
             "uuid": "fake_uuid3",
@@ -4673,6 +4685,7 @@ REST_ETHERNET_PORTS = {
             },
             "state": "up",
             "speed": 1000,
+            "mac_address": "aa:bb:cc:dd:ee:03",
         },
         {
             "uuid": "fake_uuid4",
@@ -4689,13 +4702,9 @@ REST_ETHERNET_PORTS = {
             },
             "state": "up",
             "speed": 10000,
+            "mac_address": "aa:bb:cc:dd:ee:04",
         }
     ],
-}
-
-SVM_ITEM_SIMPLE_RESPONSE_REST = {
-    "uuid": "fake_uuid",
-    "name": VSERVER_NAME,
 }
 
 FAKE_GET_BROADCAST_DOMAIN = {

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode.py
@@ -1077,6 +1077,7 @@ class NetAppClientCmodeTestCase(test.TestCase):
                     'node': None,
                     'operational-speed': None,
                     'ifgrp-port': None,
+                    'mac-address': None,
                 },
             },
         }

--- a/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/manila/tests/share/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -5178,7 +5178,7 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
             'state': 'up',
             'type': 'physical',
             'broadcast_domain.name': 'Default',
-            'fields': 'node.name,speed,name'
+            'fields': 'node.name,speed,name,mac_address'
         }
 
         query_interfaces = {

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_multi_svm.py
@@ -28,6 +28,7 @@ from manila import context
 from manila import exception
 from manila.share.drivers.netapp.dataontap.client import api as netapp_api
 from manila.share.drivers.netapp.dataontap.cluster_mode import data_motion
+from manila.share.drivers.netapp.dataontap.cluster_mode import drv_multi_svm
 from manila.share.drivers.netapp.dataontap.cluster_mode import lib_base
 from manila.share.drivers.netapp.dataontap.cluster_mode import lib_multi_svm
 from manila.share.drivers.netapp import utils as na_utils
@@ -1037,6 +1038,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          '_get_lif_name',
                          mock.Mock(side_effect=['fake_lif1', 'fake_lif2']))
         self.mock_object(self.library, '_create_lif')
+        self.mock_object(self.library, '_sync_lif_mac_to_db')
 
         self.library._create_vserver_lifs(fake.VSERVER1,
                                           'fake_vserver_client',
@@ -1062,6 +1064,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          '_get_lif_name',
                          mock.Mock(side_effect=['fake_lif1', 'fake_lif2']))
         self.mock_object(self.library, '_create_lif')
+        self.mock_object(self.library, '_sync_lif_mac_to_db')
 
         lif_home_ports = {
             fake.CLUSTER_NODES[0]: 'fake_port1',
@@ -1093,6 +1096,7 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                          '_get_lif_name',
                          mock.Mock(return_value='fake_admin_lif'))
         self.mock_object(self.library, '_create_lif')
+        self.mock_object(self.library, '_sync_lif_mac_to_db')
 
         self.library._create_vserver_admin_lif(fake.VSERVER1,
                                                'fake_vserver_client',
@@ -1124,6 +1128,116 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
                                                fake.IPSPACE)
 
         self.assertFalse(self.library._create_lif.called)
+
+    def test_create_vserver_lifs_syncs_mac(self):
+        self.mock_object(self.library._client,
+                         'list_cluster_nodes',
+                         mock.Mock(return_value=fake.CLUSTER_NODES))
+        self.mock_object(self.library,
+                         '_get_lif_name',
+                         mock.Mock(side_effect=['fake_lif1', 'fake_lif2']))
+        self.mock_object(self.library, '_create_lif')
+        self.mock_object(self.library, '_sync_lif_mac_to_db')
+
+        self.library._create_vserver_lifs(fake.VSERVER1,
+                                          'fake_vserver_client',
+                                          fake.NETWORK_INFO,
+                                          fake.IPSPACE)
+
+        self.library._sync_lif_mac_to_db.assert_has_calls([
+            mock.call(fake.CLUSTER_NODES[0],
+                      fake.NETWORK_INFO['network_allocations'][0]),
+            mock.call(fake.CLUSTER_NODES[1],
+                      fake.NETWORK_INFO['network_allocations'][1])])
+
+    def test_create_vserver_admin_lif_syncs_mac(self):
+        self.mock_object(self.library._client,
+                         'list_cluster_nodes',
+                         mock.Mock(return_value=fake.CLUSTER_NODES))
+        self.mock_object(self.library,
+                         '_get_lif_name',
+                         mock.Mock(return_value='fake_admin_lif'))
+        self.mock_object(self.library, '_create_lif')
+        self.mock_object(self.library, '_sync_lif_mac_to_db')
+
+        self.library._create_vserver_admin_lif(fake.VSERVER1,
+                                               'fake_vserver_client',
+                                               fake.NETWORK_INFO,
+                                               fake.IPSPACE)
+
+        self.library._sync_lif_mac_to_db.assert_called_once_with(
+            fake.CLUSTER_NODES[0],
+            fake.NETWORK_INFO['admin_network_allocations'][0])
+
+    def test_sync_lif_mac_to_db(self):
+        fake_mac = 'd2:39:ea:ac:06:9c'
+        fake_allocation = fake.NETWORK_INFO['network_allocations'][0]
+        self.mock_object(self.library,
+                         '_get_node_data_port_mac',
+                         mock.Mock(return_value=fake_mac))
+        self.mock_object(context,
+                         'get_admin_context',
+                         mock.Mock(return_value='fake_admin_context'))
+        mock_db_update = self.mock_object(lib_multi_svm.db,
+                                          'network_allocation_update')
+
+        self.library._sync_lif_mac_to_db(
+            fake.CLUSTER_NODES[0], fake_allocation)
+
+        self.library._get_node_data_port_mac.assert_called_once_with(
+            fake.CLUSTER_NODES[0])
+        mock_db_update.assert_called_once_with(
+            'fake_admin_context', fake_allocation['id'],
+            {'mac_address': fake_mac})
+
+    def test_sync_lif_mac_to_db_no_mac(self):
+        fake_allocation = fake.NETWORK_INFO['network_allocations'][0]
+        self.mock_object(self.library,
+                         '_get_node_data_port_mac',
+                         mock.Mock(return_value=None))
+        mock_db_update = self.mock_object(lib_multi_svm.db,
+                                          'network_allocation_update')
+
+        self.library._sync_lif_mac_to_db(
+            fake.CLUSTER_NODES[0], fake_allocation)
+
+        mock_db_update.assert_not_called()
+
+    def test_get_node_mac_for_network_allocation(self):
+        fake_mac = 'd2:39:ea:ac:06:9c'
+        self.mock_object(self.library._client,
+                         'list_cluster_nodes',
+                         mock.Mock(return_value=fake.CLUSTER_NODES))
+        self.mock_object(self.library,
+                         '_get_node_data_port_mac',
+                         mock.Mock(return_value=fake_mac))
+
+        result = self.library.get_node_mac_for_network_allocation()
+
+        self.assertEqual(fake_mac, result)
+        self.library._get_node_data_port_mac.assert_called_once_with(
+            fake.CLUSTER_NODES[0])
+
+    def test_get_node_mac_for_network_allocation_no_nodes(self):
+        self.mock_object(self.library._client,
+                         'list_cluster_nodes',
+                         mock.Mock(return_value=[]))
+
+        result = self.library.get_node_mac_for_network_allocation()
+
+        self.assertIsNone(result)
+
+    def test_get_node_mac_for_network_allocation_no_mac(self):
+        self.mock_object(self.library._client,
+                         'list_cluster_nodes',
+                         mock.Mock(return_value=fake.CLUSTER_NODES))
+        self.mock_object(self.library,
+                         '_get_node_data_port_mac',
+                         mock.Mock(return_value=None))
+
+        result = self.library.get_node_mac_for_network_allocation()
+
+        self.assertIsNone(result)
 
     @ddt.data(
         fake.get_network_info(fake.USER_NETWORK_ALLOCATIONS,
@@ -4370,3 +4484,75 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.library._check_data_lif_count_limit_reached_for_ha_pair,
             self.client,
         )
+
+
+class NetAppMultiSvmDriverAllocateNetworkTestCase(test.TestCase):
+
+    def setUp(self):
+        super(NetAppMultiSvmDriverAllocateNetworkTestCase, self).setUp()
+        self.mock_object(drv_multi_svm.NetAppCmodeMultiSvmShareDriver,
+                         '__init__',
+                         mock.Mock(return_value=None))
+        self.driver = drv_multi_svm.NetAppCmodeMultiSvmShareDriver()
+        self.driver.library = mock.Mock()
+        self.driver.network_api = mock.Mock()
+        self.fake_context = 'fake_context'
+        self.fake_share_server = {'id': 'fake-ss-id'}
+        self.fake_share_network = {'project_id': 'fake-project'}
+        self.fake_share_network_subnet = {'neutron_net_id': 'fake-net'}
+
+    def test_allocate_network_injects_mac_from_library(self):
+        fake_mac = 'd2:39:ea:ac:06:9c'
+        mock_get_mac = (
+            self.driver.library.get_node_mac_for_network_allocation)
+        mock_get_mac.return_value = fake_mac
+        super_mock = self.mock_object(
+            drv_multi_svm.driver.ShareDriver, 'allocate_network')
+
+        self.driver.allocate_network(
+            self.fake_context,
+            self.fake_share_server,
+            self.fake_share_network,
+            self.fake_share_network_subnet)
+
+        super_mock.assert_called_once_with(
+            self.fake_context,
+            self.fake_share_server,
+            self.fake_share_network,
+            self.fake_share_network_subnet,
+            mac_address=fake_mac)
+
+    def test_allocate_network_no_mac_does_not_inject(self):
+        mock_get_mac = (
+            self.driver.library.get_node_mac_for_network_allocation)
+        mock_get_mac.return_value = None
+        super_mock = self.mock_object(
+            drv_multi_svm.driver.ShareDriver, 'allocate_network')
+
+        self.driver.allocate_network(
+            self.fake_context,
+            self.fake_share_server,
+            self.fake_share_network,
+            self.fake_share_network_subnet)
+
+        _, call_kwargs = super_mock.call_args
+        self.assertNotIn('mac_address', call_kwargs)
+
+    def test_allocate_network_does_not_overwrite_caller_mac(self):
+        caller_mac = 'aa:bb:cc:dd:ee:ff'
+        lib_mac = 'd2:39:ea:ac:06:9c'
+        mock_get_mac = (
+            self.driver.library.get_node_mac_for_network_allocation)
+        mock_get_mac.return_value = lib_mac
+        super_mock = self.mock_object(
+            drv_multi_svm.driver.ShareDriver, 'allocate_network')
+
+        self.driver.allocate_network(
+            self.fake_context,
+            self.fake_share_server,
+            self.fake_share_network,
+            self.fake_share_network_subnet,
+            mac_address=caller_mac)
+
+        _, call_kwargs = super_mock.call_args
+        self.assertEqual(caller_mac, call_kwargs['mac_address'])


### PR DESCRIPTION
NetApp LIFs do not have their own MAC - they inherit from the underlying ifgroup. Manila creates a Neutron port per share server, but never set the MAC, leaving it as a random Neutron-generated value that does not match what appears on the wire. This caused MAC mismatch warnings in hammer net check.

Approach:
- On allocate_network, fetch the real ifgroup MAC of the first cluster node and pass it to the Neutron port create call
- On MacAddressInUse (409), retry the create without the MAC
- Sync the real per-node LIF MACs into Manila's network_allocations DB after LIF creation, so Manila's own view is always correct regardless of what ended up on the Neutron port

Neutron enforces UniqueConstraint(network_id, mac_address) in our fork, so the overflow case (2nd+ share server on the same network+filer) always falls back to the description path - this is expected and matches the plan.

Limitations from Neutron fork:
SAP's Neutron makes MAC uniqueness *global* (deployment-wide) on port create, motivated by Cisco IOS XE dropping frames on MAC collision regardless of VRF. This means the very first port for a given filer succeeds anywhere in the deployment, but every subsequent share server on that filer - across any network, any project - hits 409 and falls through to the fallback path.

Change-Id: I17464f0d3300e86f26172242f12453397972bf4a
Signed-off-by: Nikita Skakun nikita.skakun@sap.com