### PR TITLE
NetApp: fix replica promote failing for shares with mount_point_name

### DIFF
--- a/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/data_motion.py
@@ -1010,7 +1010,8 @@ class DataMotionSession(object):
                     "Retries exhausted. Aborting") % source_vserver
             raise exception.NetAppException(message=msg)
 
-    def wait_for_mount_replica(self, vserver_client, share_name, timeout=300):
+    def wait_for_mount_replica(self, vserver_client, share_name, timeout=300,
+                               mount_point_name=None):
         """Mount a replica share that is waiting for snapmirror initialize.
 
         Polls the SnapMirror relationship state and only retries the mount
@@ -1078,6 +1079,10 @@ class DataMotionSession(object):
                 return False, last_err
             return None, None
 
+        junction_path = ('/%s' % mount_point_name
+                         if mount_point_name
+                         else None)
+
         @utils.retry(exception.ShareBusyException, interval=interval,
                      retries=retries, backoff_rate=1)
         def try_mount_volume():
@@ -1091,7 +1096,7 @@ class DataMotionSession(object):
                 LOG.error(msg)
                 raise exception.NetAppException(message=msg)
             try:
-                vserver_client.mount_volume(share_name)
+                vserver_client.mount_volume(share_name, junction_path)
             except netapp_api.NaApiError as e:
                 undergoing_snap_init = 'snapmirror initialize'
                 msg_args = {'name': share_name, 'err_msg': e.message}

--- a/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
+++ b/manila/share/drivers/netapp/dataontap/cluster_mode/lib_base.py
@@ -4307,9 +4307,11 @@ class NetAppCmodeFileStorageLibrary(object):
             try:
                 replica_config = data_motion.get_backend_configuration(
                     replica_backend)
+                mount_point_name = replica.get('mount_point_name')
                 dm_session.wait_for_mount_replica(
                     replica_client, replica_volume_name,
-                    timeout=replica_config.netapp_mount_replica_timeout)
+                    timeout=replica_config.netapp_mount_replica_timeout,
+                    mount_point_name=mount_point_name)
             except netapp_api.NaApiError:
                 replica['status'] = constants.STATUS_ERROR
                 replica['replica_state'] = constants.STATUS_ERROR

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -5940,6 +5940,7 @@ class ShareManager(manager.SchedulerDependentManager):
                 'source_share_group_snapshot_member_id'),
             'availability_zone': share_instance.get('availability_zone'),
             'qos_type_id': share_instance.get('qos_type_id'),
+            'mount_point_name': share_instance.get('mount_point_name'),
         }
         # share type is nullable
         if share_instance_ref.get('share_type'):

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_data_motion.py
@@ -1279,7 +1279,7 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
         self.dm_session.wait_for_mount_replica(
             mock_client, fake.SHARE_NAME)
 
-        mock_client.mount_volume.ssert_called_once_with(fake.SHARE_NAME)
+        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME, None)
         self.assertEqual(0, mock_warning_log.call_count)
 
     def test_wait_for_mount_replica_timeout(self):
@@ -1314,7 +1314,7 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
                           self.dm_session.wait_for_mount_replica,
                           mock_client, fake.SHARE_NAME, timeout=30)
 
-        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME)
+        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME, None)
         mock_warning_log.assert_not_called()
 
     def test_wait_for_mount_replica_sync_in_sync_mounts_immediately(self):
@@ -1331,7 +1331,7 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
         self.dm_session.wait_for_mount_replica(
             mock_client, fake.SHARE_NAME)
 
-        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME)
+        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME, None)
 
     def test_wait_for_mount_replica_sync_terminal_fails_fast(self):
         """A broken/error Sync relationship must NOT spin retries."""
@@ -1369,7 +1369,7 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
         self.dm_session.wait_for_mount_replica(
             mock_client, fake.SHARE_NAME)
 
-        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME)
+        mock_client.mount_volume.assert_called_once_with(fake.SHARE_NAME, None)
 
     def test_wait_for_mount_replica_falls_back_when_sm_state_unknown(self):
         """Legacy substring match still works when SnapMirror lookup fails."""
@@ -1388,6 +1388,19 @@ class NetAppCDOTDataMotionSessionTestCase(test.TestCase):
                           mock_client, fake.SHARE_NAME, timeout=30)
         # Fell back to the substring heuristic and retried.
         self.assertEqual(3, mock_client.mount_volume.call_count)
+
+    def test_wait_for_mount_replica_custom_mount_point_name(self):
+
+        mock_client = mock.Mock()
+        mock_client.get_snapmirrors.return_value = []
+        self.mock_object(time, 'sleep')
+
+        self.dm_session.wait_for_mount_replica(
+            mock_client, fake.SHARE_NAME,
+            mount_point_name='my-custom-mount')
+
+        mock_client.mount_volume.assert_called_once_with(
+            fake.SHARE_NAME, '/my-custom-mount')
 
     @ddt.data(mock.Mock(),
               mock.Mock(side_effect=netapp_api.NaApiError(

--- a/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
+++ b/manila/tests/share/drivers/netapp/dataontap/cluster_mode/test_lib_base.py
@@ -5902,7 +5902,8 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.assertEqual('fake_export_location',
                              replica['export_locations'])
             mock_dm_session.wait_for_mount_replica.assert_called_once_with(
-                mock_client, fake.SHARE_NAME, timeout=30)
+                mock_client, fake.SHARE_NAME, timeout=30,
+                mount_point_name=fake.MOUNT_POINT_NAME)
             protocol_helper.update_access.assert_called_once_with(
                 self.fake_replica, fake.SHARE_NAME, [fake.SHARE_ACCESS],
                 replica=True)
@@ -5955,7 +5956,49 @@ class NetAppFileStorageLibraryTestCase(test.TestCase):
             self.assertEqual('fake_export_location',
                              replica['export_locations'])
             mock_dm_session.wait_for_mount_replica.assert_called_once_with(
-                mock_client, fake.SHARE_NAME, timeout=30)
+                mock_client, fake.SHARE_NAME, timeout=30,
+                mount_point_name=fake.MOUNT_POINT_NAME)
+
+    def test_safe_change_replica_source_custom_mount_point_name(self):
+        fake_replica_3 = copy.deepcopy(self.fake_replica_2)
+        fake_replica_3['id'] = fake.SHARE_ID3
+        fake_replica_3['replica_state'] = constants.REPLICA_STATE_OUT_OF_SYNC
+        # Set a custom mount point name on the replica being recovered.
+        self.fake_replica['mount_point_name'] = 'my-custom-mount'
+
+        protocol_helper = mock.Mock()
+        self.mock_object(self.library, '_get_helper',
+                         mock.Mock(return_value=protocol_helper))
+        self.mock_object(self.library, '_create_export',
+                         mock.Mock(return_value='fake_export_location'))
+        self.mock_object(self.library, '_unmount_orig_active_replica')
+        self.mock_object(self.library, '_handle_qos_on_replication_change')
+
+        mock_dm_session = mock.Mock()
+        mock_dm_session.change_snapmirror_source.return_value = False
+        mock_dm_session.wait_for_mount_replica.return_value = None
+        self.mock_object(mock_dm_session, 'get_backend_info_for_share',
+                         mock.Mock(return_value=(fake.SHARE_NAME,
+                                                 fake.VSERVER1,
+                                                 fake.BACKEND_NAME)))
+        mock_client = mock.Mock()
+        self.mock_object(data_motion, 'get_client_for_backend',
+                         mock.Mock(return_value=mock_client))
+        mock_backend_config = fake.get_config_cmode()
+        mock_backend_config.netapp_mount_replica_timeout = 30
+        self.mock_object(data_motion, 'get_backend_configuration',
+                         mock.Mock(return_value=mock_backend_config))
+        self.mock_object(self.library, '_get_api_client_for_backend',
+                         mock.Mock(return_value=mock_client))
+
+        self.library._safe_change_replica_source(
+            mock_dm_session, self.fake_replica, self.fake_replica_2,
+            fake_replica_3, [self.fake_replica, self.fake_replica_2,
+                             fake_replica_3], False, [fake.SHARE_ACCESS])
+
+        mock_dm_session.wait_for_mount_replica.assert_called_once_with(
+            mock_client, fake.SHARE_NAME, timeout=30,
+            mount_point_name='my-custom-mount')
 
     @ddt.data({'fail_create_export': False, 'fail_mount': True},
               {'fail_create_export': True, 'fail_mount': False})

--- a/manila/tests/share/test_manager.py
+++ b/manila/tests/share/test_manager.py
@@ -1000,6 +1000,7 @@ class ShareManagerTestCase(test.TestCase):
                 'source_share_group_snapshot_member_id'),
             'availability_zone': share_instance.get('availability_zone'),
             'export_locations': share_instance.get('export_locations') or [],
+            'mount_point_name': share_instance.get('mount_point_name'),
             'qos_type_id': share_instance.get('qos_type_id'),
             'metadata': share_instance.get('metadata') if isinstance(
                 share_instance.get('metadata'), dict) else {},


### PR DESCRIPTION
Promoting a readable replica of a share with a custom mount_point_name caused the old active replica to enter error state. The driver was not providing custom mount point name and thus mount operation was failed.

Closes-Bug: #2156862
Change-Id: I19126f7c6da03e686a6759ea3e6fa8b24322888f