### PR TITLE
[Gazpacho] Sync dev/2026.1-m3 → qa/2026.1-m3 - batch 1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @Carthaca @chuan137 @kpawar-sap @sumitarora2786 @crenduchinta88 @skook1
+/.github/CODEOWNERS @Carthaca @chuan137

--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,0 +1,15 @@
+raven
+paste
+pyreloader
+pytz
+
+crc<7.0.0 # until https://github.com/schlitzered/pyredis/issues/10 has been fixed
+
+git+https://github.com/sapcc/manila-extensions.git@master#egg=manila-extensions
+git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
+git+https://github.com/sapcc/openstack-audit-middleware.git@master#egg=audit-middleware
+git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
+git+https://github.com/sapcc/python-agentliveness.git#egg=agentliveness
+
+# needs for osprofiler
+# jaeger-client # but the wheel for thrift does not build

--- a/manila/scheduler/manager.py
+++ b/manila/scheduler/manager.py
@@ -92,8 +92,18 @@ class SchedulerManager(manager.Manager):
 
     def init_host_with_rpc(self, service_id=None):
         self.service_id = service_id
+        try:
+            open('/etc/manila/probe', 'a')
+        except Exception as e:
+            LOG.error("Probe not created: %(e)s", {'e': str(e)})
         ctxt = context.get_admin_context()
         self.request_service_capabilities(ctxt)
+        # init done, mark service ready
+        try:
+            with open('/etc/manila/probe', 'w+') as f:
+                f.write('ready\n')
+        except Exception as e:
+            LOG.error("Probe not written: %(e)s", {'e': str(e)})
 
     def get_host_list(self, context):
         """Get a list of hosts from the HostManager."""

--- a/manila/share/drivers/netapp/dataontap/client/client_cmode.py
+++ b/manila/share/drivers/netapp/dataontap/client/client_cmode.py
@@ -1029,8 +1029,10 @@ class NetAppCmodeClient(client_base.NetAppBaseClient):
 
         # Port already in desired ipspace and broadcast domain.
         if (port_info['ipspace'] == ipspace
-                and port_info['broadcast-domain'] == domain):
-            self._modify_broadcast_domain(domain, ipspace, mtu)
+            and (port_info['broadcast-domain'] == domain
+                 or port_info['broadcast-domain'] == 'OpenStack')):
+            self._modify_broadcast_domain(
+                port_info['broadcast-domain'], ipspace, mtu)
             return
 
         # If in another broadcast domain, remove port from it.

--- a/manila/share/manager.py
+++ b/manila/share/manager.py
@@ -25,6 +25,7 @@ import functools
 import hashlib
 import json
 from operator import xor
+import os
 
 from keystoneauth1 import loading as ks_loading
 from oslo_config import cfg
@@ -377,6 +378,12 @@ class ShareManager(manager.SchedulerDependentManager):
         """Initialization for a standalone service."""
 
         self.service_id = service_id
+        # mark service alive by creating a probe
+        try:
+            open('/etc/manila/probe', 'a')
+        except Exception as e:
+            LOG.error("Probe not created: %(e)s", {'e': str(e)})
+
         ctxt = context.get_admin_context()
         driver_host_pair = "{}@{}".format(
             self.driver.__class__.__name__,
@@ -396,6 +403,13 @@ class ShareManager(manager.SchedulerDependentManager):
             except Exception:
                 LOG.exception("Error encountered during initialization of "
                               "driver %s", driver_host_pair)
+                # init failed, mark service dead by removing the probe
+                try:
+                    os.remove('/etc/manila/probe')
+                except Exception as e:
+                    LOG.error("Not removed: %(e)s", {'e': str(e)})
+                # we don't want to continue since we failed
+                # to initialize the driver correctly.
                 raise
             else:
                 self.driver.initialized = True
@@ -413,6 +427,12 @@ class ShareManager(manager.SchedulerDependentManager):
                  "@%(host)s'",
                  {"driver": self.driver.__class__.__name__,
                   "host": self.host})
+        # init done, mark service ready
+        try:
+            with open('/etc/manila/probe', 'w+') as f:
+                f.write('ready\n')
+        except Exception as e:
+            LOG.error("Probe not written: %(e)s", {'e': str(e)})
 
     def is_service_ready(self):
         """Return if Manager is ready to accept requests.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 minversion = 3.18.0
 envlist = py3,pep8
+requires = virtualenv<=20.36
 # Automatic envs (pyXX) will only use the python version appropriate to that
 # env and ignore basepython inherited from [testenv] if we set
 # ignore_basepython_conflict.


### PR DESCRIPTION
Tracking PR: `dev/2026.1-m3` → `qa/2026.1-m3`

This is a long-running PR that accretes commits as SAP cherry-picks land on
`dev/2026.1-m3`. It is **not merged and re-opened** — new commits are simply pushed
to `dev/2026.1-m3` and this PR updates automatically.

---

## Promotion pipeline

```
dev/2026.1-m3  ──[gate: unit tests]──►  qa/2026.1-m3  ──[gate: Tempest]──►  stable/2026.1-m3
```

**Gate to merge this PR:** unit tests and lint must pass:

```bash
cd ci && bash run.sh -p py3 run      # unit tests
cd ci && bash run.sh -p pep8 run     # lint
```

Once merged, a separate promotion PR (`qa/2026.1-m3` → `stable/2026.1-m3`) will be
raised. That PR's gate is Tempest passing against a QA environment.

---

**Commits included** (oldest first, accreting as picks land):
1. `8a86f237f` pin tox virtenv — chore/CI
2. `69fb06321` file after successful share + scheduler service init
3. `e30353c34` ccloud: leave existing ports in OpenStack broadcast domain