### PR TITLE
Fix access-delete 404 for orphaned share access rules

### DIFF
--- a/manila/db/api.py
+++ b/manila/db/api.py
@@ -658,6 +658,11 @@ def share_instance_access_delete(context, mapping_id):
     return IMPL.share_instance_access_delete(context, mapping_id)
 
 
+def share_access_delete(context, access_id):
+    """Delete an orphaned share access rule and its metadata."""
+    return IMPL.share_access_delete(context, access_id)
+
+
 def share_access_metadata_update(context, access_id, metadata):
     """Update metadata of share access rule."""
     return IMPL.share_access_metadata_update(context, access_id, metadata)

--- a/manila/db/sqlalchemy/api.py
+++ b/manila/db/sqlalchemy/api.py
@@ -3461,15 +3461,21 @@ def _check_for_existing_access(context, resource, resource_id, access_type,
     if resource == 'share':
         query_method = _share_access_get_query
         access_to_field = models.ShareAccessMapping.access_to
+        instance_mappings_filter = (
+            models.ShareAccessMapping.instance_mappings.any())
     else:
         query_method = _share_snapshot_access_get_query
         access_to_field = models.ShareSnapshotAccessMapping.access_to
+        instance_mappings_filter = None
 
     if access_type == 'ip':
-        rules = query_method(
+        query = query_method(
             context,
             {'%s_id' % resource: resource_id, 'access_type': access_type}
-        ).filter(access_to_field.startswith(access_to.split('/')[0])).all()
+        ).filter(access_to_field.startswith(access_to.split('/')[0]))
+        if instance_mappings_filter is not None:
+            query = query.filter(instance_mappings_filter)
+        rules = query.all()
 
         matching_rules = [
             rule for rule in rules if
@@ -3478,14 +3484,17 @@ def _check_for_existing_access(context, resource, resource_id, access_type,
         ]
         return len(matching_rules) > 0
 
-    return query_method(
+    query = query_method(
         context,
         {
             '%s_id' % resource: resource_id,
             'access_type': access_type,
             'access_to': access_to
         }
-    ).count() > 0
+    )
+    if instance_mappings_filter is not None:
+        query = query.filter(instance_mappings_filter)
+    return query.count() > 0
 
 
 @require_context
@@ -3545,6 +3554,22 @@ def share_instance_access_delete(context, mapping_id):
         context.session.query(models.ShareAccessMapping).filter_by(
             id=mapping['access_id']
         ).soft_delete()
+
+
+@require_context
+@context_manager.writer
+def share_access_delete(context, access_id):
+    """Delete an orphaned share access rule (no instance mappings) directly.
+
+    Mirrors the cascade-cleanup at the bottom of share_instance_access_delete()
+    for the case where zero instance mappings exist from the start.
+    """
+    context.session.query(models.ShareAccessRulesMetadata).filter_by(
+        access_id=access_id
+    ).soft_delete()
+    context.session.query(models.ShareAccessMapping).filter_by(
+        id=access_id
+    ).soft_delete()
 
 
 @require_context

--- a/manila/share/api.py
+++ b/manila/share/api.py
@@ -2739,18 +2739,38 @@ class API(base.Base):
                     "host or is in an invalid state.")
             raise exception.InvalidShare(message=msg)
 
+        any_instance_had_mapping = False
         for share_instance in share.instances:
-            self.deny_access_to_instance(ctx, share_instance, access)
+            had_mapping = self.deny_access_to_instance(
+                ctx, share_instance, access)
+            any_instance_had_mapping = any_instance_had_mapping or had_mapping
+
+        if not any_instance_had_mapping:
+            # The rule has no instance mappings (orphaned ShareAccessMapping).
+            # The normal cleanup path via update_access_rules /
+            # share_instance_access_delete will never run, so delete directly.
+            LOG.warning("Access rule %s has no instance mappings; "
+                        "deleting orphaned record directly.", access['id'])
+            self.db.share_access_delete(ctx, access['id'])
 
     def deny_access_to_instance(self, context, share_instance, access):
         self._conditionally_transition_share_instance_access_rules_status(
             context, share_instance)
         updates = {'state': constants.ACCESS_STATE_QUEUED_TO_DENY}
-        self.access_helper.get_and_update_share_instance_access_rule(
-            context, access['id'], updates=updates,
-            share_instance_id=share_instance['id'])
+        try:
+            self.access_helper.get_and_update_share_instance_access_rule(
+                context, access['id'], updates=updates,
+                share_instance_id=share_instance['id'])
+        except exception.NotFound:
+            # No ShareInstanceAccessMapping exists for this instance — the
+            # rule was never applied here, nothing to deny.
+            LOG.debug("No instance mapping found for access rule %s on "
+                      "share instance %s; skipping.",
+                      access['id'], share_instance['id'])
+            return False
 
         self.share_rpcapi.update_access(context, share_instance)
+        return True
 
     def access_get_all(self, context, share, filters=None):
         """Returns all access rules for share."""

--- a/releasenotes/notes/fix-access-delete-404-orphaned-rules-f09da2088c390e29.yaml
+++ b/releasenotes/notes/fix-access-delete-404-orphaned-rules-f09da2088c390e29.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue where share access deletion request returned error for
+    orphaned share access rules i.e. rules visible via access show request
+    but absent from access list request. Such orphans can arise from a race
+    during replica add/remove or a share manager crash mid-sync.


### PR DESCRIPTION
When a ShareAccessMapping row exists with no associated ShareInstanceAccessMapping rows (an "orphaned" access rule), the user is stuck in an unrecoverable state:

  openstack share access show <id>       -> succeeds (state: None)
  openstack share access list <share-id> -> rule NOT shown
  openstack share access delete ...      -> 404 NotFound
  openstack share access allow (same IP) -> "already exists" error

In all cases share_access_get() finds the orphaned row (no instance- mapping filter), while share_access_get_all_for_share() does not (it filters on instance_mappings.any()), causing the inconsistency.

deny_access_to_instance() catches NotFound (no instance mapping for a share instance) and returns False rather than propagating a 404. deny_access() detects when every instance returned False and calls db.share_access_delete() directly to clean up the orphaned record, making 'access delete' succeed.

Change-Id: I19b2e1b7b44d7d1e5a3dfaf1a93efbae27af8df7

(cherry picked from commit e28392104686774afaae57bf4ed1a7d155d28c46)