### PR TITLE
scheduler: fix capacity filter/weigher for extend of snapshot-based s…

### DIFF
--- a/manila/scheduler/filters/capacity.py
+++ b/manila/scheduler/filters/capacity.py
@@ -44,10 +44,10 @@ class CapacityFilter(base_host.BaseHostFilter):
 
         free_space = host_state.free_capacity_gb
         total_space = host_state.total_capacity_gb
-        if filter_properties.get('snapshot_id'):
-            reserved = float(host_state.reserved_snapshot_percentage) / 100
-        elif filter_properties.get('is_share_extend'):
+        if filter_properties.get('is_share_extend'):
             reserved = float(host_state.reserved_share_extend_percentage) / 100
+        elif filter_properties.get('snapshot_id'):
+            reserved = float(host_state.reserved_snapshot_percentage) / 100
         else:
             reserved = float(host_state.reserved_percentage) / 100
 

--- a/manila/scheduler/weighers/capacity.py
+++ b/manila/scheduler/weighers/capacity.py
@@ -52,10 +52,10 @@ class CapacityWeigher(base_host.BaseHostWeigher):
 
     def _weigh_object(self, host_state, weight_properties):
         """Higher weighers win.  We want spreading to be the default."""
-        if weight_properties.get('snapshot_id'):
-            reserved = float(host_state.reserved_snapshot_percentage) / 100
-        elif weight_properties.get('is_share_extend'):
+        if weight_properties.get('is_share_extend'):
             reserved = float(host_state.reserved_share_extend_percentage) / 100
+        elif weight_properties.get('snapshot_id'):
+            reserved = float(host_state.reserved_snapshot_percentage) / 100
         else:
             reserved = float(host_state.reserved_percentage) / 100
 

--- a/manila/tests/scheduler/filters/test_capacity.py
+++ b/manila/tests/scheduler/filters/test_capacity.py
@@ -157,6 +157,35 @@ class HostFiltersTestCase(test.TestCase):
                                     'service': service})
         self.assertFalse(self.filter.host_passes(host, filter_properties))
 
+    @ddt.data(
+        {'free_capacity': 120, 'total_capacity': 200,
+         'reserved': 20, 'reserved_snapshot': 90,
+         'reserved_share_extend_percentage': 5})
+    @ddt.unpack
+    def test_capacity_filter_extend_snapshot_share_uses_extend_reserved(
+            self, free_capacity, total_capacity, reserved, reserved_snapshot,
+            reserved_share_extend_percentage):
+        # Regression test for bug #2050101: extending a share that was
+        # created from a snapshot must honour reserved_share_extend_percentage,
+        # not reserved_snapshot_percentage.
+        self._stub_service_is_up(True)
+        filter_properties = {'size': 100, 'is_share_extend': True,
+                             'snapshot_id': 1234}
+        service = {'disabled': False}
+        host = fakes.FakeHostState('host1',
+                                   {'total_capacity_gb': total_capacity,
+                                    'free_capacity_gb': free_capacity,
+                                    'reserved_percentage': reserved,
+                                    'reserved_snapshot_percentage':
+                                        reserved_snapshot,
+                                    'reserved_share_extend_percentage':
+                                        reserved_share_extend_percentage,
+                                    'updated_at': None,
+                                    'service': service})
+        # reserved_share_extend_percentage=5 allows the request;
+        # reserved_snapshot_percentage=90 would have rejected it.
+        self.assertTrue(self.filter.host_passes(host, filter_properties))
+
     def test_capacity_filter_passes_unknown(self):
         free = 'unknown'
         self._stub_service_is_up(True)

--- a/manila/tests/scheduler/weighers/test_capacity.py
+++ b/manila/tests/scheduler/weighers/test_capacity.py
@@ -175,6 +175,33 @@ class CapacityWeigherTestCase(test.TestCase):
         result = weigher._weigh_object(host_state, weight_properties)
         self.assertEqual(float('-inf'), result)
 
+    def test_extend_snapshot_share_uses_extend_reserved(self):
+        # Regression test for bug #2050101: extending a share created from a
+        # snapshot must use reserved_share_extend_percentage, not
+        # reserved_snapshot_percentage.
+        host_state = mock.Mock()
+        host_state.free_capacity_gb = 120
+        host_state.total_capacity_gb = 200
+        host_state.provisioned_capacity_gb = 80
+        host_state.max_over_subscription_ratio = 1.0
+        host_state.thin_provisioning = False
+        host_state.reserved_percentage = 0
+        host_state.reserved_snapshot_percentage = 90  # would starve if used
+        host_state.reserved_share_extend_percentage = 5
+
+        weigher = capacity.CapacityWeigher()
+        weight_properties = {'snapshot_id': 1234, 'is_share_extend': True,
+                             'share_type': {}}
+        result_extend = weigher._weigh_object(host_state, weight_properties)
+
+        # Weight with only extend reserved (correct)
+        weight_properties_extend_only = {'is_share_extend': True,
+                                         'share_type': {}}
+        result_extend_only = weigher._weigh_object(
+            host_state, weight_properties_extend_only)
+
+        self.assertEqual(result_extend_only, result_extend)
+
     @ddt.data(
         {'cap_thin': '<is> True',
          'cap_thin_key': 'capabilities:thin_provisioning',

--- a/releasenotes/notes/fix-capacity-filter-extend-snapshot-share-2050101.yaml
+++ b/releasenotes/notes/fix-capacity-filter-extend-snapshot-share-2050101.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue where extending a share originally created from a snapshot
+    incorrectly applied ``reserved_snapshot_percentage`` instead of
+    ``reserved_share_extend_percentage`` in the capacity filter and weigher.
+    `launchpad bug: #2050101 <https://bugs.launchpad.net/manila/+bug/2050101>`_


### PR DESCRIPTION
…hare

When extending a share that was originally created from a snapshot, filter_properties contains both 'is_share_extend' and 'snapshot_id'. The capacity filter and weigher checked 'snapshot_id' first, so they applied reserved_snapshot_percentage instead of
reserved_share_extend_percentage, causing valid extend operations to be rejected on hosts where reserved_snapshot_percentage was set high.

Closes-Bug: #2050101
Change-Id: I6e5f310ef72403966d18ee7f2d5ed7d2651f15cc
Assisted-By: Claude

(cherry picked from commit 54b39b443d3ddd12021512f2a3ecdfd89337c205)